### PR TITLE
Fixes #148 

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -179,11 +179,8 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-		Simplenote application = (Simplenote) getActivity().getApplication();
-
 		mNotesAdapter = new NotesCursorAdapter(getActivity().getBaseContext(), null, 0);
 		setListAdapter(mNotesAdapter);
-
 	}
 
     @Override
@@ -472,15 +469,15 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
     public void setNoteSelected(String selectedNoteID) {
         // Loop through notes and set note selected if found
-        ObjectCursor<Note> cursor = (ObjectCursor<Note>)mNotesAdapter.getCursor();
-        if (cursor == null || cursor.getCount() == 0)
-            return;
-        for(int i=0; i < cursor.getCount(); i++) {
-            cursor.moveToPosition(i);
-            String noteKey = cursor.getSimperiumKey();
-            if (noteKey != null && noteKey.equals(selectedNoteID)) {
-                setActivatedPosition(i);
-                return;
+        ObjectCursor<Note> cursor = (ObjectCursor<Note>) mNotesAdapter.getCursor();
+        if (cursor != null) {
+            for (int i = 0; i < cursor.getCount(); i++) {
+                cursor.moveToPosition(i);
+                String noteKey = cursor.getSimperiumKey();
+                if (noteKey != null && noteKey.equals(selectedNoteID)) {
+                    setActivatedPosition(i);
+                    return;
+                }
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -52,7 +52,7 @@ public class NotesActivity extends Activity implements
         NoteListFragment.Callbacks, User.StatusChangeListener, Simperium.OnUserCreatedListener, UndoBarController.UndoListener,
         Bucket.Listener<Note> {
 
-    private boolean mIsLargeScreen, mIsLandscape;
+    private boolean mIsLargeScreen, mIsLandscape, mShouldSelectNewNote;
     private String mTabletSearchQuery;
     private UndoBarController mUndoBarController;
     private SearchView mSearchView;
@@ -195,7 +195,8 @@ public class NotesActivity extends Activity implements
                 note.setModificationDate(note.getCreationDate());
                 note.setContent(text);
                 note.save();
-                onNoteSelected(note.getSimperiumKey(), true, null);
+                setCurrentNote(note);
+                mShouldSelectNewNote = true;
                 mTracker.sendEvent("note", "create_note", "external_share", null);
             }
         }
@@ -222,6 +223,11 @@ public class NotesActivity extends Activity implements
 
         updateNavigationDrawerItems();
         setSelectedTagActive();
+
+        if (mCurrentNote != null && mShouldSelectNewNote) {
+            onNoteSelected(mCurrentNote.getSimperiumKey(), true, null);
+            mShouldSelectNewNote = false;
+        }
     }
 
     @Override


### PR DESCRIPTION
Wait until onResume() in NotesActivity to set a newly shared note as selected so that the NoteEditorFragment can finish its onCreateView() method. Fixes #148.

Also fixed issue where newly shared note would not be selected on a landscape tablet.
