### PR TITLE
Clear drawer selection if the user is logged out

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -222,6 +222,14 @@ public class NotesActivity extends Activity implements
         mTagsBucket.addListener(mTagsMenuUpdater);
 
         updateNavigationDrawerItems();
+
+        // if the user is not authenticated revert to default drawer selection
+        Simplenote currentApp = (Simplenote)getApplication();
+        if (currentApp.getSimperium().getUser().getStatus() == User.Status.NOT_AUTHORIZED) {
+            mSelectedTag = null;
+            mDrawerList.setSelection(mTagsAdapter.DEFAULT_ITEM_POSITION);
+        }
+
         setSelectedTagActive();
 
         if (mCurrentNote != null && mShouldSelectNewNote) {


### PR DESCRIPTION
Ideally we'd have a way to listen for logged out broadcasts, but this gets the trick done as well.

The only downside is if a user were to log out and then try to use the app in the logged out state, every time they come back to the list view it will clear the filter until they launch the app again.
