### PR TITLE
Yet another potential fix for #132. 

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.preference.PreferenceManager;
@@ -262,6 +263,13 @@ public class NotesActivity extends Activity implements
     }
 
     private void setTitleWithCustomFont(CharSequence title) {
+        // LG devices running 4.1 can't handle a custom font in the action bar title
+        if ((!TextUtils.isEmpty(Build.BRAND) && Build.BRAND.toLowerCase().contains("lge"))
+                && Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN) {
+            mActionBar.setTitle(title);
+            return;
+        }
+
         SpannableString s = new SpannableString(title);
         s.setSpan(new TypefaceSpan(this), 0, s.length(),
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);


### PR DESCRIPTION
Don’t set the ActionBar title with the custom font span if the device brand contains ‘lge’ and is running 4.1 or lower.
