### PR TITLE
Handle out of bounds offset indices

### DIFF
--- a/Simplenote/src/instrumentTest/java/com/automattic/simplenote/utils/MatchOffsetHighlighterTest.java
+++ b/Simplenote/src/instrumentTest/java/com/automattic/simplenote/utils/MatchOffsetHighlighterTest.java
@@ -95,8 +95,14 @@ public class MatchOffsetHighlighterTest extends TestCase {
 
     public void testOutOfBoundsOffset()
     throws Exception {
-        int offset = MatchOffsetHighlighter.getByteOffset("short", 3, 2);
+        // start plus length exceeds bounds
+        int offset = MatchOffsetHighlighter.getByteOffset("short", 3, 5);
         assertEquals(0, offset);
+
+        // start exceeds string bounds
+        offset = MatchOffsetHighlighter.getByteOffset("short", 10, 12);
+        assertEquals(0, offset);
+        
     }
 
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/MatchOffsetHighlighter.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/MatchOffsetHighlighter.java
@@ -162,15 +162,23 @@ public class MatchOffsetHighlighter implements Runnable {
         String substring = "";
         int length = source.length();
 
+        // starting index cannot be negative
+        if (start < 0) {
+            start = 0;
+        }
+
         if (start > length - 1) {
+            // if start is past the end of string
             return 0;
-        } else if (start + end > length - 1) {
+        } else if (end > length - 1) {
+            // end is past the end of the string, so cap at string's end
             substring = source.substring(start, length -1);
         } else {
+            // start and end are both valid indices
             substring = source.substring(start, end);
         }
         try {
-            return substring.length() - substring.getBytes(CHARSET).length;
+            return length - substring.getBytes(CHARSET).length;
         } catch (UnsupportedEncodingException e) {
             return 0;
         }


### PR DESCRIPTION
Protects the app from accessing the string with out of bounds indices until the problem can be solved more generically by Simperium/simperium-android#77
