### PR TITLE
Remember active list when returning to Notes List

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -224,11 +224,13 @@ public class NotesActivity extends Activity implements
 
         updateNavigationDrawerItems();
 
-        // if the user is not authenticated revert to default drawer selection
+        // if the user is not authenticated and the tag doesn't exist revert to default drawer selection
         Simplenote currentApp = (Simplenote)getApplication();
         if (currentApp.getSimperium().getUser().getStatus() == User.Status.NOT_AUTHORIZED) {
-            mSelectedTag = null;
-            mDrawerList.setSelection(mTagsAdapter.DEFAULT_ITEM_POSITION);
+            if (-1 == mTagsAdapter.getPosition(mSelectedTag)) {
+                mSelectedTag = null;
+                mDrawerList.setSelection(mTagsAdapter.DEFAULT_ITEM_POSITION);
+            }
         }
 
         setSelectedTagActive();


### PR DESCRIPTION
This adds an additional check to the one added in #125 (and 0520b29) by only reverting to the default Drawer position if the selected Drawer entry doesn't exist.

This way, we can remember the selected Drawer position when a logged out user navigates away from and then back to the Notes List as well.

Fixes #180
