### PR TITLE
Add links when the note loads or saves instead of every time the text changes

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -555,8 +555,10 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         @Override
         protected void onPostExecute(Void nada) {
-            // Update links
-            SimplenoteLinkify.addLinks(mContentEditText, Linkify.ALL);
+            if (getActivity() != null && !getActivity().isFinishing()) {
+                // Update links
+                SimplenoteLinkify.addLinks(mContentEditText, Linkify.ALL);
+            }
         }
     }
 


### PR DESCRIPTION
Significantly increased editor performance when editing large notes. Fixes #189.
