### PR TITLE
Moved note load to onCreateView() to prevent 'losing' note content if us...

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -177,6 +177,18 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             mPlaceholderView.setVisibility(View.VISIBLE);
 
         mTagView.setAdapter(mAutocompleteAdapter);
+
+        // Load note if we were passed a note Id
+        Bundle arguments = getArguments();
+        if (arguments != null && arguments.containsKey(ARG_ITEM_ID)) {
+            String key = arguments.getString(ARG_ITEM_ID);
+            if (arguments.containsKey(ARG_MATCH_OFFSETS)) {
+                mMatchOffsets = arguments.getString(ARG_MATCH_OFFSETS);
+            }
+            new loadNoteTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, key);
+            setIsNewNote(getArguments().getBoolean(ARG_NEW_NOTE, false));
+        }
+
 		return rootView;
 	}
 
@@ -187,17 +199,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mNotesBucket.addListener(this);
 
         mTagView.setOnTagAddedListener(this);
-
-        Bundle arguments = getArguments();
-
-        if (arguments != null && arguments.containsKey(ARG_ITEM_ID)) {
-            String key = arguments.getString(ARG_ITEM_ID);
-            if (arguments.containsKey(ARG_MATCH_OFFSETS))
-                mMatchOffsets = arguments.getString(ARG_MATCH_OFFSETS);
-            new loadNoteTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, key);
-            setIsNewNote(getArguments().getBoolean(ARG_NEW_NOTE, false));
-        }
-
     }
 
     @Override
@@ -206,19 +207,23 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         // Hide soft keyboard if it is showing...
         if (getActivity() != null) {
             InputMethodManager inputMethodManager = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
-            if (inputMethodManager != null)
+            if (inputMethodManager != null) {
                 inputMethodManager.hideSoftInputFromWindow(mContentEditText.getWindowToken(), 0);
+            }
         }
+
         // Delete the note if it is new and has empty fields
-        if (mNote != null && mIsNewNote && noteIsEmpty())
+        if (mNote != null && mIsNewNote && noteIsEmpty()) {
             mNote.delete();
-        else
+        } else {
             saveNote();
+        }
 
         mTagView.setOnTagAddedListener(null);
 
-        if (mAutoSaveHandler != null)
+        if (mAutoSaveHandler != null) {
             mAutoSaveHandler.removeCallbacks(autoSaveRunnable);
+        }
 
         mHighlighter.stop();
 
@@ -497,10 +502,11 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         @Override
         protected Void doInBackground(String... args) {
+            if (getActivity() == null) {
+                return null;
+            }
 
             String noteID = args[0];
-            if (getActivity() == null)
-                return null;
             Simplenote application = (Simplenote) getActivity().getApplication();
             Bucket<Note> notesBucket = application.getNotesBucket();
             try {


### PR DESCRIPTION
...er leaves the note editor and returns before the object was saved to the db.

Fixes #188 
