### PR TITLE
Set NotesActivity to run as a single task

### DIFF
--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.automattic.simplenote"
     android:installLocation="auto">
 
@@ -12,9 +13,11 @@
         android:hardwareAccelerated="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.Simplestyle">
+        android:theme="@style/Theme.Simplestyle"
+        tools:replace="allowBackup">
         <activity
             android:name="com.automattic.simplenote.NotesActivity"
+            android:launchMode="singleTask"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/app_name"
             android:windowSoftInputMode="adjustResize|stateHidden">

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -182,28 +182,18 @@ public class NotesActivity extends Activity implements
             editor.commit();
         }
 
-        if (Intent.ACTION_SEND.equals(getIntent().getAction())) {
-            // Check share action
-            Intent intent = getIntent();
-            String subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
-            String text = intent.getStringExtra(Intent.EXTRA_TEXT);
-            if (text != null && !text.equals("")) {
-                if (subject != null && !subject.equals("")) {
-                    text = subject + "\n\n" + text;
-                }
-                Note note = mNotesBucket.newObject();
-                note.setCreationDate(Calendar.getInstance());
-                note.setModificationDate(note.getCreationDate());
-                note.setContent(text);
-                note.save();
-                setCurrentNote(note);
-                mShouldSelectNewNote = true;
-                mTracker.sendEvent("note", "create_note", "external_share", null);
-            }
-        }
+        checkForSharedContent(getIntent());
+
         currentApp.getSimperium().setOnUserCreatedListener(this);
         currentApp.getSimperium().setUserStatusChangeListener(this);
         setProgressBarIndeterminateVisibility(false);
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+
+        checkForSharedContent(intent);
     }
 
     @Override
@@ -256,6 +246,27 @@ public class NotesActivity extends Activity implements
     public void onStop() {
         super.onStop();
         EasyTracker.getInstance().activityStop(this);
+    }
+
+    public void checkForSharedContent(Intent intent) {
+        if (Intent.ACTION_SEND.equals(intent.getAction())) {
+            // Check share action
+            String subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
+            String text = intent.getStringExtra(Intent.EXTRA_TEXT);
+            if (text != null && !text.equals("")) {
+                if (subject != null && !subject.equals("")) {
+                    text = subject + "\n\n" + text;
+                }
+                Note note = mNotesBucket.newObject();
+                note.setCreationDate(Calendar.getInstance());
+                note.setModificationDate(note.getCreationDate());
+                note.setContent(text);
+                note.save();
+                setCurrentNote(note);
+                mShouldSelectNewNote = true;
+                mTracker.sendEvent("note", "create_note", "external_share", null);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Also moved sharing intent check to its own method, since we also need to check in `onNewIntent()` now.
