### PR TITLE
Converted AsyncTasks that were still using `execute()` to `executeOnExec...

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -119,7 +119,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     @Override
     public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
         if (getListView().getCheckedItemIds().length > 0 && item.getItemId() == R.id.menu_delete)
-            new trashNotesTask().execute();
+            new trashNotesTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         return false;
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -632,7 +632,7 @@ public class NotesActivity extends Activity implements
                 alert.setMessage(R.string.confirm_empty_trash);
                 alert.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int whichButton) {
-                        new emptyTrashTask().execute();
+                        new emptyTrashTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
                         mTracker.sendEvent("note", "trash_emptied", "overflow_menu", null);
                     }
                 });

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsListActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsListActivity.java
@@ -331,7 +331,7 @@ public class TagsListActivity extends ListActivity implements AdapterView.OnItem
 
         private void deleteTag(Tag tag) {
             tag.delete();
-            new removeTagFromNotesTask().execute(tag);
+            new removeTagFromNotesTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, tag);
             mTracker.sendEvent("tag", "deleted_tag", "list_trash_button", null);
         }
 


### PR DESCRIPTION
...utor()` with THREAD_POOL_EXECUTOR.

Fixes #213.
