### PR TITLE
Remove unneeded tools directive from manifest

### DIFF
--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
         android:hardwareAccelerated="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.Simplestyle"
-        tools:replace="allowBackup">
+        android:theme="@style/Theme.Simplestyle">
     <activity
             android:name="com.automattic.simplenote.NotesActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"


### PR DESCRIPTION
Simperium manifest used to include the `android:backup` property but no longer does.

```
Warning: /Users/beaucollins/code/simplenote-android/Simplenote/src/main/AndroidManifest.xml:10:5 Warning:
    application@tools:allowBackup was tagged at AndroidManifest.xml:10 to replace other declarations but no other declaration present
/Users/beaucollins/code/simplenote-android/Simplenote/src/main/AndroidManifest.xml:10:5 Warning:
    application@tools:allowBackup was tagged at AndroidManifest.xml:10 to replace other declarations but no other declaration present
```
