### PR TITLE
Prevent lag in action bar when drawer is toggled

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -68,6 +68,12 @@ public class NotesActivity extends Activity implements
     private MenuItem mEmptyTrashMenuItem;
 
     // Menu drawer
+    public static final int DRAWER_STATE_CLOSED = 0x00;
+    public static final int DRAWER_STATE_OPEN = 0x01;
+    public static final int DRAWER_STATE_SLIDING_OPEN = 0x02;
+    public static final int DRAWER_STATE_SLIDING_CLOSED = 0x03;
+
+    private int mDrawerState = DRAWER_STATE_CLOSED;
     private DrawerLayout mDrawerLayout;
     private ListView mDrawerList;
     private ActionBarDrawerToggle mDrawerToggle;
@@ -150,13 +156,23 @@ public class NotesActivity extends Activity implements
                 R.string.close_drawer
         ) {
             public void onDrawerClosed(View view) {
-                setTitle(mActionBarTitle);
-                invalidateOptionsMenu();
+                mDrawerState = DRAWER_STATE_CLOSED;
             }
 
             public void onDrawerOpened(View drawerView) {
-                setTitleWithCustomFont(getString(R.string.app_name));
-                invalidateOptionsMenu();
+                mDrawerState = DRAWER_STATE_OPEN;
+            }
+
+            public void onDrawerSlide(View drawerView, float slideOffset) {
+                if (mDrawerState == DRAWER_STATE_CLOSED) {
+                    mDrawerState = DRAWER_STATE_SLIDING_OPEN;
+                    setTitleWithCustomFont(getString(R.string.app_name));
+                    invalidateOptionsMenu();
+                } else if (mDrawerState == DRAWER_STATE_OPEN) {
+                    mDrawerState = DRAWER_STATE_SLIDING_CLOSED;
+                    setTitle(mActionBarTitle);
+                    invalidateOptionsMenu();
+                }
             }
         };
         mDrawerLayout.setDrawerListener(mDrawerToggle);
@@ -447,7 +463,7 @@ public class NotesActivity extends Activity implements
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.notes_list, menu);
 
-        boolean drawerOpen = mDrawerLayout.isDrawerOpen(mDrawerList);
+        boolean drawerOpen = mDrawerState == DRAWER_STATE_SLIDING_OPEN || mDrawerState == DRAWER_STATE_OPEN;
 
         // restore the search query if on a landscape tablet
         String searchQuery = null;


### PR DESCRIPTION
Manually track the state of the drawer and adjust the Action Bar
accordingly instead of waiting until it finishes opening/closing.

Fixes #104 
Previously #177
