### PR TITLE
Use Simperium 0.4.11 from the shiny new maven central repo.

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -12,12 +12,11 @@ apply plugin: 'com.android.application'
 repositories {
     mavenCentral()
     maven { url "http://simperium.github.io/simplenote-android" }
-    maven { url "http://simperium.github.io/simperium-android" }
     maven { url "http://wordpress-mobile.github.io/Android-PasscodeLock"}
 }
 
 dependencies {
-    compile project(path: ":Simperium")
+    compile "com.simperium.android:simperium:0.4.11"
     compile "com.android.support:support-v4:20.+"
     compile "com.google:google-analytics:2.0-beta-4"
     compile "org.wordpress:android-passcodelock:0.0.5"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
 include ':Simplenote'
-include ':Simperium'


### PR DESCRIPTION
Removed reference to local simperium in `settings.gradle` as well as old github-based maven repo.
