### PR TITLE
Fix Keyboard Typing Issue

### DIFF
--- a/Simplenote/src/main/res/layout/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_editor.xml
@@ -32,7 +32,6 @@
                     android:background="@null"
                     android:gravity="top"
 	                android:maxLength="999999999"
-                    android:lineSpacingExtra="4dp"
                     android:inputType="textMultiLine|textCapSentences|textAutoCorrect"
                     android:paddingBottom="@dimen/padding_small"
                     android:paddingTop="@dimen/padding_small"


### PR DESCRIPTION
Reverting 40ccb924f227a29f4b8d23bef8a2d486566c7a10 because of undesirable keyboard issues reported in #351.

I added in the `lineSpacingExtra` value so that it works again (whenever Google decides to fix it)

cc @0nko can you have a look?
