### PR TITLE
Fix Missing Empty Trash Button

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -69,7 +69,7 @@ public class NotesActivity extends AppCompatActivity implements
 
     public static String TAG_NOTE_LIST = "noteList";
     public static String TAG_NOTE_EDITOR = "noteEditor";
-    private int TRASH_SELECTED_ID = 2;
+    private int TRASH_SELECTED_ID = 1;
 
     private boolean mIsMarkdownEnabledGlobal;
     private boolean mIsShowingMarkdown;


### PR DESCRIPTION
TRASH_SELECTED_ID is now 1 since we removed the list header in the redesign.

Fixes #353
