### PR TITLE
Fixes PIN Lock Bypass from Google Now

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -369,10 +369,8 @@ public class NotesActivity extends AppCompatActivity implements
                 note.setContent(text);
                 note.save();
                 setCurrentNote(note);
+                mShouldSelectNewNote = true;
 
-                if (!isVoiceShare) {
-                    mShouldSelectNewNote = true;
-                }
                 AnalyticsTracker.track(
                         AnalyticsTracker.Stat.LIST_NOTE_CREATED,
                         AnalyticsTracker.CATEGORY_NOTE,


### PR DESCRIPTION
Open the note even when sharing with Google Now, so that the notes list is still protected by the pin lock.

Fixes #338
