### PR TITLE
Update List Margin and Normal Font Size

### DIFF
--- a/Simplenote/src/main/res/layout/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_editor.xml
@@ -38,7 +38,7 @@
                     android:scrollHorizontally="false"
                     android:textColor="?attr/noteEditorTextColor"
                     android:textColorLink="@color/simplenote_blue"
-                    android:textSize="14sp"
+                    android:textSize="16sp"
                     tools:context=".NoteEditorFragment" />
 
             </android.support.v4.widget.NestedScrollView>

--- a/Simplenote/src/main/res/layout/note_list_row.xml
+++ b/Simplenote/src/main/res/layout/note_list_row.xml
@@ -37,7 +37,7 @@
         android:lines="1"
         android:singleLine="true"
         android:textColor="?attr/noteTitleColor"
-        android:textSize="16sp"
+        android:textSize="18sp"
         tools:text="Three-line item" />
 
     <com.automattic.simplenote.widgets.RobotoRegularTextView
@@ -45,7 +45,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/note_title"
-        android:paddingTop="1dp"
         android:layout_marginLeft="@dimen/list_padding_left"
         android:layout_marginStart="@dimen/list_padding_left"
         android:layout_marginRight="@dimen/padding_large"
@@ -56,7 +55,7 @@
         android:ellipsize="end"
         android:maxLines="2"
         android:textColor="?attr/notePreviewColor"
-        android:textSize="14sp"
+        android:textSize="16sp"
         tools:text="The first few times he tried to climb up on\nthe smooth chest of drawers." />
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/values/arrays.xml
+++ b/Simplenote/src/main/res/values/arrays.xml
@@ -38,9 +38,9 @@
     </string-array>
 
     <string-array name="array_font_size_values" translatable="false">
-        <item>10</item>
         <item>12</item>
         <item>14</item>
+        <item>16</item>
         <item>18</item>
         <item>22</item>
     </string-array>

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -23,8 +23,8 @@
     <dimen name="nav_drawer_navigation_padding_top">0dp</dimen>
 
     <dimen name="note_list_item_padding_right">52dp</dimen>
-    <dimen name="note_list_item_padding_bottom">20dp</dimen>
-    <dimen name="note_list_item_padding_top">@dimen/padding_large</dimen>
+    <dimen name="note_list_item_padding_bottom">@dimen/padding_small</dimen>
+    <dimen name="note_list_item_padding_top">@dimen/padding_small</dimen>
     <dimen name="note_list_padding">@dimen/padding_small</dimen>
     <dimen name="list_padding_left">@dimen/padding_large</dimen>
 

--- a/Simplenote/src/main/res/xml/preferences.xml
+++ b/Simplenote/src/main/res/xml/preferences.xml
@@ -16,7 +16,7 @@
             android:summary="%s"
             android:title="@string/sort_order" />
         <ListPreference
-            android:defaultValue="14"
+            android:defaultValue="16"
             android:entries="@array/array_font_size"
             android:entryValues="@array/array_font_size_values"
             android:key="pref_key_font_size"


### PR DESCRIPTION
We received quite a bit of feedback about the margins and font size in the 1.5 update, and I agree that they should be tweaked.

This PR changes the list margin back to a 4dp at the top and bottom, and sets the default/normal font size to back to 16sp.

Before:
![screenshot_20160729-130048](https://cloud.githubusercontent.com/assets/789137/17262176/c5766f60-558e-11e6-9796-fb5f65d5935c.png)

After:
![screenshot_20160729-130629](https://cloud.githubusercontent.com/assets/789137/17262234/0eaa958a-558f-11e6-8860-1c5d2e7155b9.png)
