### PR TITLE
Reduce size of pinned icon

### DIFF
--- a/Simplenote/src/main/res/layout/note_list_row.xml
+++ b/Simplenote/src/main/res/layout/note_list_row.xml
@@ -11,8 +11,8 @@
 
     <ToggleButton
         android:id="@+id/pin_button"
-        android:layout_width="26dp"
-        android:layout_height="26dp"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
         android:layout_marginRight="@dimen/padding_medium"
         android:layout_marginEnd="@dimen/padding_medium"
         android:focusable="false"


### PR DESCRIPTION
The pin icon was causing rows to be too large when in compact mode, this makes it a bit smaller so it fits well with both the compact and regular rows:

<img width="325" alt="screen shot 2016-07-29 at 1 40 28 pm" src="https://cloud.githubusercontent.com/assets/789137/17262844/a260358e-5592-11e6-8428-a29778e78abb.png">
