### PR TITLE
Update library to Passcode Lock v1.3.0

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile 'com.android.support:support-vector-drawable:23.3.0'
     compile "com.google.android.gms:play-services-analytics:8.3.0"
     compile "com.google.android.gms:play-services-wearable:8.3.0"
-    compile "org.wordpress:passcodelock:1.0.0"
+    compile 'org.wordpress:passcodelock:1.3.0'
     compile 'com.automattic:tracks:1.1.0'
     compile 'com.loopj.android:android-async-http:1.4.9'
     compile 'com.commonsware.cwac:anddown:0.2.4'

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -124,7 +124,7 @@ public class NoteEditorActivity extends AppCompatActivity {
     @Override
     protected void onPause() {
         if (AppLockManager.getInstance().isAppLockFeatureEnabled()) {
-            AppLockManager.getInstance().getCurrentAppLock().setDisabledActivities(null);
+            AppLockManager.getInstance().getAppLock().setExemptActivities(null);
         }
 
         super.onPause();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -378,10 +378,10 @@ public class NotesActivity extends AppCompatActivity implements
                     // Disable the lock screen when sharing content and opening NoteEditorActivity
                     // Lock screen activities are enabled again in NoteEditorActivity.onPause()
                     if (AppLockManager.getInstance().isAppLockFeatureEnabled()) {
-                        AppLockManager.getInstance().getCurrentAppLock().setDisabledActivities(
+                        AppLockManager.getInstance().getAppLock().setExemptActivities(
                                 new String[]{"com.automattic.simplenote.NotesActivity",
                                 "com.automattic.simplenote.NoteEditorActivity"});
-                        AppLockManager.getInstance().getCurrentAppLock().setOneTimeTimeout(0);
+                        AppLockManager.getInstance().getAppLock().setOneTimeTimeout(0);
                     }
                 }
             }


### PR DESCRIPTION
### Fix

Update Passcode Lock library to [v1.3.0](https://github.com/wordpress-mobile/PasscodeLock-Android/releases/tag/1.3.0) as described in https://github.com/Automattic/simplenote-android/issues/368.
### Test
1. Open navigation drawer.
2. Tap **Settings** option.
3. Tap **Turn PIN lock on** option.
4. Enter four-digit PIN.
5. Enter same four-digit PIN.
6. Tap **Change PIN** option.
7. Enter incorrect four-digit PIN.
8. Notice screen shake.
9. Press **Home** navigation button.
10. Wait five seconds.
11. Open Simplenote app.
12. Enter incorrect four-digit PIN.
13. Notice screen shake.
