### PR TITLE
Editor: Add Back `lineSpacingExtra` for better line spacing

### DIFF
--- a/Simplenote/src/main/res/layout/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_editor.xml
@@ -31,6 +31,7 @@
                     android:layout_height="match_parent"
                     android:background="@null"
                     android:gravity="top"
+                    android:lineSpacingExtra="4dp"
 	                android:maxLength="999999999"
                     android:inputType="textMultiLine|textCapSentences|textAutoCorrect"
                     android:paddingBottom="@dimen/padding_small"


### PR DESCRIPTION
Looks like Goole finally fixed the `lineSpacingExtra` bug in 7.0 that they added in 5.0 :)

Before:
<img width="324" alt="screen shot 2016-08-29 at 4 12 43 pm" src="https://cloud.githubusercontent.com/assets/789137/18070592/bc50df1e-6e03-11e6-8cec-00a37e47bbef.png">

After:
<img width="323" alt="screen shot 2016-08-29 at 4 12 21 pm" src="https://cloud.githubusercontent.com/assets/789137/18070595/c2a4d712-6e03-11e6-8ba5-b6fd60cb84e4.png">

This makes the text in the editor more readable.

cc @0nko 