### PR TITLE
Make font size setting work in Markdown preview

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ContextUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ContextUtils.java
@@ -1,0 +1,46 @@
+package com.automattic.simplenote.utils;
+
+import android.content.Context;
+import android.support.annotation.RawRes;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class ContextUtils {
+    public static String readRawResourceFile(Context context, @RawRes int resId) {
+        InputStream stream = null;
+        BufferedReader reader = null;
+        StringBuilder builder = new StringBuilder();
+        String line;
+
+        try {
+            stream = context.getResources().openRawResource(resId);
+            reader = new BufferedReader(new InputStreamReader(stream));
+
+            while ((line = reader.readLine()) != null) {
+                builder.append(line);
+                builder.append('\n');
+            }
+
+            return builder.toString();
+        } catch (IOException ex) {
+            return null;
+        } finally {
+            try {
+                if (stream != null) {
+                    stream.close();
+                }
+            } catch (IOException ignored) {
+            }
+
+            try {
+                if (reader != null) {
+                    reader.close();
+                }
+            } catch (IOException ignored) {
+            }
+        }
+    }
+}

--- a/Simplenote/src/main/res/raw/font_size_style.css
+++ b/Simplenote/src/main/res/raw/font_size_style.css
@@ -1,0 +1,9 @@
+p,
+h4,
+ul li,
+ol li { font-size: ${P-SIZE}px; }
+h1 { font-size: ${H1-SIZE}px; }
+h2 { font-size: ${H2-SIZE}px; }
+h3 { font-size: ${H3-SIZE}px; }
+h5 { font-size: ${H5-SIZE}px; }
+h6 { font-size: ${H6-SIZE}px; }

--- a/Simplenote/src/main/res/raw/font_size_style.css
+++ b/Simplenote/src/main/res/raw/font_size_style.css
@@ -5,5 +5,6 @@ ol li { font-size: ${P-SIZE}px; }
 h1 { font-size: ${H1-SIZE}px; }
 h2 { font-size: ${H2-SIZE}px; }
 h3 { font-size: ${H3-SIZE}px; }
+pre,
 h5 { font-size: ${H5-SIZE}px; }
 h6 { font-size: ${H6-SIZE}px; }


### PR DESCRIPTION
This closes the #377 issue.

I implemented it by adding font size style rules to the HTML for the markdown preview.
The specified sizes for headers are chosen to stay as close to the original size as possible.

# Text for easy testing

```
# Header 1
## Header 2
### Header 3
#### Header 4
##### Header 5
###### Header 6

Paragraph text.

> Quote text.

Text attributes *italic*, **bold**, `monospace`.

Bullet list:

- One
- Two
- Three

Numbered list:

1. One
2. Two
3. Three

A [link](http://example.com).
```