### PR TITLE
Account for Font Size Setting in Markdown Preview

### DIFF
--- a/Simplenote/src/main/assets/dark.css
+++ b/Simplenote/src/main/assets/dark.css
@@ -53,3 +53,25 @@ pre code {
     color: #dbdee0;
     background: transparent;
 }
+p,
+h4,
+ul li,
+ol li {
+    font-size: ${P-SIZE}px;
+}
+h1 {
+    font-size: ${H1-SIZE}px;
+}
+h2 {
+    font-size: ${H2-SIZE}px;
+}
+h3 {
+    font-size: ${H3-SIZE}px;
+}
+pre,
+h5 {
+    font-size: ${H5-SIZE}px;
+}
+h6 {
+    font-size: ${H6-SIZE}px;
+}

--- a/Simplenote/src/main/assets/light.css
+++ b/Simplenote/src/main/assets/light.css
@@ -53,3 +53,25 @@ pre code {
     color: #6f7880;
     background: transparent;
 }
+p,
+h4,
+ul li,
+ol li {
+    font-size: ${P-SIZE}px;
+}
+h1 {
+    font-size: ${H1-SIZE}px;
+}
+h2 {
+    font-size: ${H2-SIZE}px;
+}
+h3 {
+    font-size: ${H3-SIZE}px;
+}
+pre,
+h5 {
+    font-size: ${H5-SIZE}px;
+}
+h6 {
+    font-size: ${H6-SIZE}px;
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ContextUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ContextUtils.java
@@ -1,0 +1,45 @@
+package com.automattic.simplenote.utils;
+
+import android.content.Context;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class ContextUtils {
+    public static String readCssFile(Context context, String css) {
+        InputStream stream = null;
+        BufferedReader reader = null;
+        StringBuilder builder = new StringBuilder();
+        String line;
+
+        try {
+            stream = context.getResources().getAssets().open(css);
+            reader = new BufferedReader(new InputStreamReader(stream));
+
+            while ((line = reader.readLine()) != null) {
+                builder.append(line);
+                builder.append('\n');
+            }
+
+            return builder.toString();
+        } catch (IOException ex) {
+            return null;
+        } finally {
+            try {
+                if (stream != null) {
+                    stream.close();
+                }
+            } catch (IOException ignored) {
+            }
+
+            try {
+                if (reader != null) {
+                    reader.close();
+                }
+            } catch (IOException ignored) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Fix
Add variables to the CSS files so that Markdown on the Preview tab will account for app font size setting as described in https://github.com/Automattic/simplenote-android/issues/377.

### Test
1. Create note with Markdown.
2. Compare size in **Edit** and **Preview** tabs.
3. Change font size in **Settings**.
4. Compare size in **Edit** and **Preview** tabs.

### Attribution
Thanks to @Tunous for this fix!  The majority of the changes were created from their pull request (https://github.com/Automattic/simplenote-android/pull/387).