### PR TITLE
Material Design widgets for pre-Lollipop

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
@@ -1,17 +1,16 @@
 package com.automattic.simplenote;
 
-import android.content.Context;
+import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-import android.support.v4.app.Fragment;
-import android.content.DialogInterface;
 import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
+import android.support.v7.widget.SwitchCompat;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.ImageButton;
-import android.widget.Switch;
 import android.widget.TextView;
 
 import com.automattic.simplenote.models.Note;
@@ -29,8 +28,8 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
     private TextView mInfoWords;
     private TextView mInfoLinkUrl;
     private TextView mInfoLinkTitle;
-    private Switch mInfoPinSwitch;
-    private Switch mInfoMarkdownSwitch;
+    private SwitchCompat mInfoPinSwitch;
+    private SwitchCompat mInfoMarkdownSwitch;
     private ImageButton mCopyButton;
     private ImageButton mShareButton;
 
@@ -48,7 +47,7 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
         mInfoLinkUrl = (TextView)infoView.findViewById(R.id.info_public_link_url);
         mInfoLinkTitle = (TextView)infoView.findViewById(R.id.info_public_link_title);
 
-        mInfoPinSwitch = (Switch)infoView.findViewById(R.id.info_pin_switch);
+        mInfoPinSwitch = (SwitchCompat) infoView.findViewById(R.id.info_pin_switch);
         mInfoPinSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
@@ -56,7 +55,7 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
             }
         });
 
-        mInfoMarkdownSwitch = (Switch)infoView.findViewById(R.id.info_markdown_switch);
+        mInfoMarkdownSwitch = (SwitchCompat) infoView.findViewById(R.id.info_markdown_switch);
         mInfoMarkdownSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -297,6 +297,11 @@ public class NotesActivity extends AppCompatActivity implements
             public void onDrawerOpened(View drawerView) {
                 // noop
             }
+
+            @Override
+            public void onDrawerSlide(View drawerView, float slideOffset) {
+                super.onDrawerSlide(drawerView, 0f);
+            }
         };
 
         mDrawerLayout.addDrawerListener(mDrawerToggle);

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
@@ -1,6 +1,5 @@
 package com.automattic.simplenote;
 
-import android.app.AlertDialog;
 import android.app.ListFragment;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -8,6 +7,7 @@ import android.database.Cursor;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v7.app.AlertDialog;
 import android.text.Html;
 import android.view.ActionMode;
 import android.view.LayoutInflater;

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
+import android.support.v7.widget.AppCompatMultiAutoCompleteTextView;
 import android.text.Editable;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
@@ -16,12 +17,11 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
-import android.widget.MultiAutoCompleteTextView;
 import android.widget.TextView;
 
 import com.automattic.simplenote.R;
 
-public class TagsMultiAutoCompleteTextView extends MultiAutoCompleteTextView implements OnItemClickListener {
+public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTextView implements OnItemClickListener {
 
     private boolean mShouldMoveNewTagText;
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -1,13 +1,13 @@
 package com.automattic.simplenote.widgets;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatEditText;
 import android.util.AttributeSet;
-import android.widget.EditText;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class SimplenoteEditText extends EditText {
+public class SimplenoteEditText extends AppCompatEditText {
 
     public interface OnSelectionChangedListener {
         void onSelectionChanged(int selStart, int selEnd);

--- a/Simplenote/src/main/res/layout/bottom_sheet_info.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_info.xml
@@ -46,7 +46,7 @@
         android:layout_below="@id/info_words_text"
         android:background="@color/divider_grey" />
 
-    <Switch
+    <android.support.v7.widget.SwitchCompat
         android:id="@+id/info_pin_switch"
         android:layout_below="@+id/info_divider"
         android:layout_width="match_parent"
@@ -60,7 +60,7 @@
         android:paddingRight="@dimen/padding_large"
         android:text="@string/pin_to_top" />
 
-    <Switch
+    <android.support.v7.widget.SwitchCompat
         android:id="@+id/info_markdown_switch"
         android:layout_below="@+id/info_pin_switch"
         android:layout_width="match_parent"

--- a/Simplenote/src/main/res/layout/bottom_sheet_info.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_info.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    app:theme="@style/Theme.Simplestyle">
 
     <com.automattic.simplenote.widgets.RobotoRegularTextView
         android:id="@+id/info_modified_date_text"


### PR DESCRIPTION
Partial implementation of Material Design for pre-Lollipop devices as explained in #391. This doesn't touch settings screen.

Additional change is disabling of drawer toggle animation when drawer is slided since it gets hidden by drawer.