### PR TITLE
Update Library to Passcode Lock v1.4.0

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile 'com.android.support:support-vector-drawable:24.2.1'
     compile "com.google.android.gms:play-services-analytics:9.6.1"
     compile "com.google.android.gms:play-services-wearable:9.6.1"
-    compile 'org.wordpress:passcodelock:1.3.0'
+    compile 'org.wordpress:passcodelock:1.4.0'
     compile 'com.automattic:tracks:1.1.0'
     compile 'com.loopj.android:android-async-http:1.4.9'
     compile 'com.commonsware.cwac:anddown:0.2.4'


### PR DESCRIPTION
### Fix
Update Passcode Lock library to [v1.4.0](https://github.com/wordpress-mobile/PasscodeLock-Android/releases/tag/1.4.0) as described in https://github.com/Automattic/simplenote-android/issues/397.