### PR TITLE
Fill Viewport with Input Text Box in Edit Tab

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     wearApp project(':Wear')
 }
 
-version "1.5.1"
+version "1.5.2"
 
 android {
 
@@ -47,7 +47,7 @@ android {
     defaultConfig {
         applicationId "com.automattic.simplenote"
         versionName project.version
-        versionCode 53
+        versionCode 54
         minSdkVersion 15
         targetSdkVersion 24
 

--- a/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
@@ -25,7 +25,8 @@
             <android.support.v4.widget.NestedScrollView
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="1">
+                android:layout_weight="1"
+                android:fillViewport="true" >
 
                 <com.automattic.simplenote.widgets.SimplenoteEditText
                     android:id="@+id/note_content"

--- a/Simplenote/src/main/res/layout/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_editor.xml
@@ -23,7 +23,8 @@
             <android.support.v4.widget.NestedScrollView
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="1">
+                android:layout_weight="1"
+                android:fillViewport="true" >
 
                 <com.automattic.simplenote.widgets.SimplenoteEditText
                     android:id="@+id/note_content"


### PR DESCRIPTION
### Fix
The input field in the Edit tab only fills area with text.  If no text is added, you must tap the top of the input field just below the Edit tab in order to select the field and input text.  The green area show in the screenshot below represents the ***old*** selectable/tappable area.

![simplenote_layout_bounds](https://cloud.githubusercontent.com/assets/3827611/20679228/43093f2a-b557-11e6-969c-1eeb9b68f178.png)

This fix expands the input field to fill the viewport (i.e. screen) allowing you to tap anywhere in the input field to select it.  The green area show in the screenshot below represents the ***new*** selectable/tappable area.

![simplenote_layout_bounds_new](https://cloud.githubusercontent.com/assets/3827611/20679446/2e69a5ae-b558-11e6-90b8-34730c0e4ba3.png)

### Test
1. Create new note.
2. Select ***Tags*** field.
3. Tap anywhere in ***Edit*** tab field.
4. Notice input field is selected.