### PR TITLE
Stop Buckets after App goes to Background

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/repo' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.0.0'
     }
 }
 

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -50,6 +50,8 @@ android {
         versionCode 57
         minSdkVersion 15
         targetSdkVersion 25
+        
+        vectorDrawables.useSupportLibrary = true
 
         buildConfigField "String", "SIMPERIUM_APP_ID", "\"${project.simperiumAppId}\""
         buildConfigField "String", "SIMPERIUM_APP_KEY", "\"${project.simperiumAppKey}\""

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     wearApp project(':Wear')
 }
 
-version "1.5.4"
+version "1.5.5"
 
 android {
 
@@ -47,7 +47,7 @@ android {
     defaultConfig {
         applicationId "com.automattic.simplenote"
         versionName project.version
-        versionCode 57
+        versionCode 58
         minSdkVersion 15
         targetSdkVersion 25
         

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/repo' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 
@@ -21,14 +21,14 @@ repositories {
 
 dependencies {
     compile "com.simperium.android:simperium:0.6.8"
-    compile "com.android.support:appcompat-v7:24.2.1"
-    compile 'com.android.support:design:24.2.1'
-    compile 'com.android.support:support-vector-drawable:24.2.1'
-    compile 'com.android.support:preference-v7:24.2.1'
-    compile 'com.android.support:preference-v14:24.2.1'
+    compile "com.android.support:appcompat-v7:25.0.1"
+    compile 'com.android.support:design:25.0.1'
+    compile 'com.android.support:support-vector-drawable:25.0.1'
+    compile 'com.android.support:preference-v7:25.0.1'
+    compile 'com.android.support:preference-v14:25.0.1'
     compile 'com.takisoft.fix:preference-v7:24.2.1.0'
-    compile "com.google.android.gms:play-services-analytics:9.6.1"
-    compile "com.google.android.gms:play-services-wearable:9.6.1"
+    compile "com.google.android.gms:play-services-analytics:10.0.1"
+    compile "com.google.android.gms:play-services-wearable:10.0.1"
     compile 'org.wordpress:passcodelock:1.5.1'
     compile 'com.automattic:tracks:1.1.0'
     compile 'com.loopj.android:android-async-http:1.4.9'

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -50,8 +50,6 @@ android {
         versionCode 58
         minSdkVersion 15
         targetSdkVersion 25
-        
-        vectorDrawables.useSupportLibrary = true
 
         buildConfigField "String", "SIMPERIUM_APP_ID", "\"${project.simperiumAppId}\""
         buildConfigField "String", "SIMPERIUM_APP_KEY", "\"${project.simperiumAppKey}\""

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/repo' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 
@@ -21,14 +21,14 @@ repositories {
 
 dependencies {
     compile "com.simperium.android:simperium:0.6.8"
-    compile "com.android.support:appcompat-v7:24.2.1"
-    compile 'com.android.support:design:24.2.1'
-    compile 'com.android.support:support-vector-drawable:24.2.1'
-    compile 'com.android.support:preference-v7:24.2.1'
-    compile 'com.android.support:preference-v14:24.2.1'
+    compile "com.android.support:appcompat-v7:25.0.1"
+    compile 'com.android.support:design:25.0.1'
+    compile 'com.android.support:support-vector-drawable:25.0.1'
+    compile 'com.android.support:preference-v7:25.0.1'
+    compile 'com.android.support:preference-v14:25.0.1'
     compile 'com.takisoft.fix:preference-v7:24.2.1.0'
-    compile "com.google.android.gms:play-services-analytics:9.6.1"
-    compile "com.google.android.gms:play-services-wearable:9.6.1"
+    compile "com.google.android.gms:play-services-analytics:10.0.1"
+    compile "com.google.android.gms:play-services-wearable:10.0.1"
     compile 'org.wordpress:passcodelock:1.5.1'
     compile 'com.automattic:tracks:1.1.0'
     compile 'com.loopj.android:android-async-http:1.4.9'
@@ -50,6 +50,8 @@ android {
         versionCode 58
         minSdkVersion 15
         targetSdkVersion 25
+
+        vectorDrawables.useSupportLibrary = true
 
         buildConfigField "String", "SIMPERIUM_APP_ID", "\"${project.simperiumAppId}\""
         buildConfigField "String", "SIMPERIUM_APP_KEY", "\"${project.simperiumAppKey}\""

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/repo' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.0.0'
     }
 }
 
@@ -21,14 +21,14 @@ repositories {
 
 dependencies {
     compile "com.simperium.android:simperium:0.6.8"
-    compile "com.android.support:appcompat-v7:25.0.1"
-    compile 'com.android.support:design:25.0.1'
-    compile 'com.android.support:support-vector-drawable:25.0.1'
-    compile 'com.android.support:preference-v7:25.0.1'
-    compile 'com.android.support:preference-v14:25.0.1'
+    compile "com.android.support:appcompat-v7:24.2.1"
+    compile 'com.android.support:design:24.2.1'
+    compile 'com.android.support:support-vector-drawable:24.2.1'
+    compile 'com.android.support:preference-v7:24.2.1'
+    compile 'com.android.support:preference-v14:24.2.1'
     compile 'com.takisoft.fix:preference-v7:24.2.1.0'
-    compile "com.google.android.gms:play-services-analytics:10.0.1"
-    compile "com.google.android.gms:play-services-wearable:10.0.1"
+    compile "com.google.android.gms:play-services-analytics:9.6.1"
+    compile "com.google.android.gms:play-services-wearable:9.6.1"
     compile 'org.wordpress:passcodelock:1.5.1'
     compile 'com.automattic:tracks:1.1.0'
     compile 'com.loopj.android:android-async-http:1.4.9'

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -6,6 +6,7 @@ import android.content.ComponentCallbacks2;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.v7.app.AppCompatDelegate;
 
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.analytics.AnalyticsTrackerGoogleAnalytics;
@@ -61,6 +62,8 @@ public class Simplenote extends Application {
         } catch (BucketNameInvalid e) {
             throw new RuntimeException("Could not create bucket", e);
         }
+
+        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
 
         ApplicationLifecycleMonitor applicationLifecycleMonitor = new ApplicationLifecycleMonitor();
         registerComponentCallbacks(applicationLifecycleMonitor);

--- a/Simplenote/src/main/res/drawable/ic_collaborate_selector.xml
+++ b/Simplenote/src/main/res/drawable/ic_collaborate_selector.xml
@@ -1,0 +1,3 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_collaborate_48dp" />
+</selector>

--- a/Simplenote/src/main/res/drawable/ic_publish_selector.xml
+++ b/Simplenote/src/main/res/drawable/ic_publish_selector.xml
@@ -1,0 +1,3 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_publish_48dp" />
+</selector>

--- a/Simplenote/src/main/res/drawable/ic_tags_selector.xml
+++ b/Simplenote/src/main/res/drawable/ic_tags_selector.xml
@@ -1,0 +1,3 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_tags_24dp" />
+</selector>

--- a/Simplenote/src/main/res/drawable/ic_unpublish_selector.xml
+++ b/Simplenote/src/main/res/drawable/ic_unpublish_selector.xml
@@ -1,0 +1,3 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_unpublish_48dp" />
+</selector>

--- a/Simplenote/src/main/res/layout/bottom_sheet_share.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_share.xml
@@ -20,7 +20,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:drawablePadding="@dimen/padding_small"
-            android:drawableTop="@drawable/ic_collaborate_48dp"
+            android:drawableTop="@drawable/ic_collaborate_selector"
             android:gravity="center_horizontal"
             android:text="@string/collaborate"
             android:textColor="@color/simplenote_dark_grey"/>
@@ -32,7 +32,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:drawablePadding="@dimen/padding_small"
-            android:drawableTop="@drawable/ic_publish_48dp"
+            android:drawableTop="@drawable/ic_publish_selector"
             android:gravity="center_horizontal"
             android:text="@string/publish"
             android:textColor="@color/simplenote_dark_grey"/>
@@ -44,7 +44,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:drawablePadding="@dimen/padding_small"
-            android:drawableTop="@drawable/ic_unpublish_48dp"
+            android:drawableTop="@drawable/ic_unpublish_selector"
             android:gravity="center_horizontal"
             android:text="@string/unpublish"
             android:textColor="@color/simplenote_dark_grey"/>

--- a/Simplenote/src/main/res/layout/tags_list_row.xml
+++ b/Simplenote/src/main/res/layout/tags_list_row.xml
@@ -21,7 +21,7 @@
         android:layout_marginRight="8dp"
         android:layout_marginStart="16dp"
         android:layout_weight="1"
-        android:drawableLeft="@drawable/ic_tags_24dp"
+        android:drawableLeft="@drawable/ic_tags_selector"
         android:drawablePadding="32dp"
         android:textColor="?attr/noteTitleColor"
         app:tint="?attr/noteTitleColor"

--- a/Wear/build.gradle
+++ b/Wear/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.0.0'
     }
 }
 apply plugin: 'com.android.application'
@@ -33,8 +33,8 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.support:wearable:1.4.0'
-    compile 'com.google.android.gms:play-services-wearable:10.0.1'
+    compile 'com.google.android.support:wearable:1.3.0'
+    compile 'com.google.android.gms:play-services-wearable:8.3.0'
 }
 
 if(["storeFile", "storePassword", "keyAlias", "keyPassword"].count { !project.hasProperty(it) } == 0 ){

--- a/Wear/build.gradle
+++ b/Wear/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 apply plugin: 'com.android.application'
@@ -33,8 +33,8 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.support:wearable:1.3.0'
-    compile 'com.google.android.gms:play-services-wearable:8.3.0'
+    compile 'com.google.android.support:wearable:1.4.0'
+    compile 'com.google.android.gms:play-services-wearable:10.0.1'
 }
 
 if(["storeFile", "storePassword", "keyAlias", "keyPassword"].count { !project.hasProperty(it) } == 0 ){


### PR DESCRIPTION
Bit of a band-aid solution for #347, but we don't really have time/resources to investigate why some users are getting high battery usage when the app is in the background.

This patch gives the app 10 seconds to finish any remaining operations in Simperium, and then stops the buckets. If there's still changes to be sent, the app will send them the next time it resumes.

I also update the dependencies to the latest and greatest.