### PR TITLE
Fix shadow on editor toolbar.

### DIFF
--- a/Simplenote/src/main/res/layout/activity_note_editor.xml
+++ b/Simplenote/src/main/res/layout/activity_note_editor.xml
@@ -16,7 +16,7 @@
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/toolbarColor"
             app:contentInsetStart="@dimen/toolbar_title_keyline"
-            app:layout_scrollFlags="scroll|enterAlways|snap|exitUntilCollapsed"
+            app:layout_scrollFlags="scroll|enterAlways"
             app:popupTheme="?attr/toolbarPopupTheme"
             app:theme="@style/ToolbarTheme">
         </android.support.v7.widget.Toolbar>


### PR DESCRIPTION
Somewhere along the line the shadow for the editor toolbar stopped displaying. It appears to be related to the `app:layout_scrollFlags` property that we apply to the toolbar.

I think the issue is having too many options in the field there. If I limit it to two it works fine and the shadow appears. @0nko you added the `snap|exitUntilCollapsed` options to it back in your redesign PR. Do you remember why?

This PR reverts it to how @theck13 had it for his markdown PR.

Before:
<img width="541" alt="screen shot 2016-12-22 at 3 30 54 pm" src="https://cloud.githubusercontent.com/assets/789137/21443913/88eea534-c85d-11e6-816f-1a6e50044076.png">

After:
<img width="542" alt="screen shot 2016-12-22 at 3 31 07 pm" src="https://cloud.githubusercontent.com/assets/789137/21443916/8ddd58ce-c85d-11e6-9f5c-2979680a233d.png">

_Note: This was not an issue on pre-lollipop devices._