### PR TITLE
Added `windowLightStatusBar` settings for light and dark theme.

### DIFF
--- a/Simplenote/src/main/res/values-v23/styles.xml
+++ b/Simplenote/src/main/res/values-v23/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Simplestyle" parent="Base.Theme.Simplestyle">
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
+
+    <style name="Theme.Simplestyle.Dark" parent="Base.Theme.Simplestyle.Dark">
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
+</resources>


### PR DESCRIPTION
Fixes #413. You should see dark icons when using the light theme, and light icons when using the dark theme if on Android 6.0 or higher:

<img width="468" alt="screen shot 2016-12-22 at 3 40 51 pm" src="https://cloud.githubusercontent.com/assets/789137/21443994/03cf521c-c85e-11e6-84fa-4846339324b1.png">

Thanks for the idea @Lokesh-Krishna!
