### PR TITLE
Fix: bottomsheet not showing up

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -722,13 +722,17 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onSharePublishClicked() {
         publishNote();
-        mShareBottomSheet.dismiss();
+        if (mShareBottomSheet != null) {
+            mShareBottomSheet.dismiss();
+        }
     }
 
     @Override
     public void onShareUnpublishClicked() {
         unpublishNote();
-        mShareBottomSheet.dismiss();
+        if (mShareBottomSheet != null) {
+            mShareBottomSheet.dismiss();
+        }
     }
 
     @Override
@@ -748,12 +752,16 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onHistoryCancelClicked() {
         mContentEditText.setText(mNote.getContent());
-        mHistoryBottomSheet.dismiss();
+        if (mHistoryBottomSheet != null) {
+            mHistoryBottomSheet.dismiss();
+        }
     }
 
     @Override
     public void onHistoryRestoreClicked() {
-        mHistoryBottomSheet.dismiss();
+        if (mHistoryBottomSheet != null) {
+            mHistoryBottomSheet.dismiss();
+        }
         saveAndSyncNote();
     }
 
@@ -819,7 +827,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     @Override
     public void onInfoShareLinkClicked() {
-        mInfoBottomSheet.dismiss();
+        if (mInfoBottomSheet != null) {
+            mInfoBottomSheet.dismiss();
+        }
         showShareSheet();
     }
 
@@ -1009,18 +1019,14 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     private void showShareSheet() {
         if (isAdded()) {
-            if (mShareBottomSheet == null) {
-                mShareBottomSheet = new ShareBottomSheetDialog(this, this);
-            }
+            mShareBottomSheet = new ShareBottomSheetDialog(this, this);
             mShareBottomSheet.show(mNote);
         }
     }
 
     private void showInfoSheet() {
         if (isAdded()) {
-            if (mInfoBottomSheet == null) {
-                mInfoBottomSheet = new InfoBottomSheetDialog(this, this);
-            }
+            mInfoBottomSheet = new InfoBottomSheetDialog(this, this);
             mInfoBottomSheet.show(mNote);
         }
 
@@ -1028,9 +1034,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     private void showHistorySheet() {
         if (isAdded()) {
-            if (mHistoryBottomSheet == null) {
-                mHistoryBottomSheet = new HistoryBottomSheetDialog(this, this);
-            }
+            mHistoryBottomSheet = new HistoryBottomSheetDialog(this, this);
 
             // Request revisions for the current note
             mNotesBucket.getRevisions(mNote, MAX_REVISIONS, mHistoryBottomSheet.getRevisionsRequestCallbacks());


### PR DESCRIPTION
Similar issues: #394
- **Issue:** If a user drags a bottom sheet down to dismiss it, the bottom sheet
does not show up when the user taps on the share button again
- **Fix:** remove check for null state when creating the bottom sheet.
Instead moved that null check to when the bottom sheet is being dismissed. Now, the bottom sheet will reappear.

**Issue in screenshots:**
Step 1: User taps on Share button for the first time

![image](https://cloud.githubusercontent.com/assets/11140545/22178707/6ac1773a-e004-11e6-9bf9-6c1128966681.png)

Step 2: User drags the bottomsheet down, which should dismiss it [in theory]

![image](https://cloud.githubusercontent.com/assets/11140545/22178715/a0367974-e004-11e6-8b92-aed5dfb9703a.png)

Step 3: User taps the share button again. The bottom sheet does not show up!

![image](https://cloud.githubusercontent.com/assets/11140545/22178718/b88fec4e-e004-11e6-94b8-fee79ec46fb8.png)


