### PR TITLE
Updating to the latest Android dependencies.

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'io.fabric.tools:gradle:1.+'
     }
 }
@@ -25,15 +25,15 @@ dependencies {
     compile 'org.wordpress:passcodelock:1.5.1'
 
     // Google Support
-    compile "com.android.support:appcompat-v7:25.0.1"
-    compile 'com.android.support:design:25.0.1'
-    compile 'com.android.support:support-vector-drawable:25.0.1'
-    compile 'com.android.support:preference-v7:25.0.1'
-    compile 'com.android.support:preference-v14:25.0.1'
+    compile "com.android.support:appcompat-v7:25.2.0"
+    compile 'com.android.support:design:25.2.0'
+    compile 'com.android.support:support-vector-drawable:25.2.0'
+    compile 'com.android.support:preference-v7:25.2.0'
+    compile 'com.android.support:preference-v14:25.2.0'
 
     // Google Play Services
-    compile "com.google.android.gms:play-services-analytics:10.0.1"
-    compile "com.google.android.gms:play-services-wearable:10.0.1"
+    compile "com.google.android.gms:play-services-analytics:10.2.0"
+    compile "com.google.android.gms:play-services-wearable:10.2.0"
 
     // Third Party
     compile 'com.takisoft.fix:preference-v7:24.2.1.0'

--- a/Wear/build.gradle
+++ b/Wear/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 apply plugin: 'com.android.application'
@@ -33,8 +33,9 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.support:wearable:1.4.0'
-    compile 'com.google.android.gms:play-services-wearable:10.0.1'
+    compile 'com.google.android.support:wearable:2.0.0'
+    provided 'com.google.android.wearable:wearable:2.0.0'
+    compile 'com.google.android.gms:play-services-wearable:10.2.0'
 }
 
 if(["storeFile", "storePassword", "keyAlias", "keyPassword"].count { !project.hasProperty(it) } == 0 ){

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 04 19:22:26 CEST 2016
+#Fri Mar 03 12:38:27 PST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
Enables niceties for devs like instant run.

Note: I did test the upgrade to Android Wear 2.0 and the 'take a note' google now functionality still works fine.