### PR TITLE
Swap the position of the pin and trash note icons in multi select.

### DIFF
--- a/Simplenote/src/main/res/menu/bulk_edit.xml
+++ b/Simplenote/src/main/res/menu/bulk_edit.xml
@@ -3,15 +3,15 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/menu_delete"
-        android:icon="@drawable/ic_trash_24dp"
-        android:title="@string/delete"
-        app:showAsAction="always"/>
-
-    <item
         android:id="@+id/menu_pin"
         android:icon="@drawable/ic_item_list_default_pin_active"
         android:title="@string/pin_to_top"
+        app:showAsAction="always"/>
+
+    <item
+        android:id="@+id/menu_delete"
+        android:icon="@drawable/ic_trash_24dp"
+        android:title="@string/delete"
         app:showAsAction="always"/>
 
 </menu>


### PR DESCRIPTION
I think we discussed this somewhere before, but it makes more sense to have the destructive action at the right side. This PR switches the positioning of the pin and trash icons so the trash is on the right:

<img width="538" alt="screen shot 2017-03-03 at 2 33 00 pm" src="https://cloud.githubusercontent.com/assets/789137/23571503/7b3c9ccc-001e-11e7-825d-693f4216c929.png">
