### PR TITLE
feature: encryption

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     }
 
     wearApp project(':Wear')
+    compile 'com.scottyab:secure-preferences-lib:0.1.4'
+    compile 'com.madgag.spongycastle:pg:1.54.0.0'
+    compile 'com.madgag.spongycastle:prov:1.54.0.0'
 }
 
 version "1.5.5"

--- a/Simplenote/src/main/java/com/automattic/simplenote/BouncyCastleOpenPgpCryptographyAgent.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/BouncyCastleOpenPgpCryptographyAgent.java
@@ -1,0 +1,81 @@
+package com.automattic.simplenote;
+
+import com.automattic.simplenote.utils.PassphraseUtils;
+import com.simperium.client.CryptographyAgent;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.spongycastle.bcpg.SymmetricKeyAlgorithmTags;
+import org.spongycastle.jce.provider.BouncyCastleProvider;
+import org.spongycastle.openpgp.PGPException;
+import org.spongycastle.openpgp.examples.ByteArrayHandler;
+
+import java.io.IOException;
+import java.security.NoSuchProviderException;
+import java.security.Security;
+
+// ATTRIBUTION:
+// parts of this file were extracted from
+// https://github.com/rtyley/spongycastle/blob/spongy-master/pg/src/main/java/org/spongycastle/openpgp/examples/ByteArrayHandler.java
+// which uses this license from the original BouncyCastle:
+//
+// Except where otherwise stated, this software is distributed under a license
+// based on the MIT X Consortium license. To view the license, see here:
+// http://www.bouncycastle.org/licence.html
+//
+// Resources:
+// https://www.codeproject.com/Articles/549119/Encryption-Wrapper-for-Android-SharedPreferences
+// https://github.com/scottyab/secure-preferences
+// https://github.com/tozny/java-aes-crypto
+
+public class BouncyCastleOpenPgpCryptographyAgent extends CryptographyAgent {
+
+    private static final String CIPHERTEXT_PROPERTY_NAME = "cipherText";
+
+    public BouncyCastleOpenPgpCryptographyAgent() {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    // Encrypts the rawObject into a string as property "cipherText" of a JSONObject.
+    @Override
+    public final JSONObject encryptJson(JSONObject rawObject) {
+        String rawText = rawObject.toString();
+        if (rawText == null || rawText.length() < 1) {
+            return null;
+        }
+        try {
+            JSONObject encryptedObject = new JSONObject();
+            String cipherText;
+            byte[] encryptedBytes = ByteArrayHandler.encrypt(
+                    rawText.getBytes("UTF-8"),
+                    PassphraseUtils.getPassphrase(),
+                    "bcopca",
+                    SymmetricKeyAlgorithmTags.AES_256,
+                    true
+            );
+            cipherText = new String(encryptedBytes);
+            encryptedObject.put(CIPHERTEXT_PROPERTY_NAME, cipherText);
+            return encryptedObject;
+        } catch (IOException | NoSuchProviderException | PGPException | JSONException e) {
+            throw new RuntimeException("Exception encrypting text", e); // todo how to handle this?  We really want to stop syncing at this point and throw up an error screen. No possible recovery.
+        }
+    }
+
+    // Decrypts the "cipherText" property of the JSONObject into a new JSONObject.
+    @Override
+    public final JSONObject decryptJson(JSONObject encryptedObject) {
+        if (encryptedObject.has(CIPHERTEXT_PROPERTY_NAME)) {
+            String cipherText = encryptedObject.optString(CIPHERTEXT_PROPERTY_NAME, "");
+            if (cipherText == null || cipherText.length() < 1) {
+                return new JSONObject(); // todo  is there a better way to handle this?
+            }
+            try {
+                return new JSONObject(new JSONTokener(new String(ByteArrayHandler.decrypt(cipherText.getBytes("UTF-8"), PassphraseUtils.getPassphrase()))));
+            } catch (IOException | NoSuchProviderException | PGPException | JSONException e) {
+                throw new RuntimeException("Exception decrypting text ", e); // todo  how to handle this?  We really want to stop syncing at this point and throw up an error screen. No possible recovery.
+            }
+        }
+        return encryptedObject;
+    }
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -10,11 +10,13 @@ import android.support.v7.preference.Preference;
 import android.widget.Toast;
 
 import com.automattic.simplenote.analytics.AnalyticsTracker;
+import com.automattic.simplenote.utils.PassphraseUtils;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.automattic.simplenote.utils.ThemeUtils;
 import com.simperium.Simperium;
 import com.simperium.android.LoginActivity;
 import com.simperium.client.User;
+import com.takisoft.fix.support.v7.preference.EditTextPreference;
 import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
 import com.takisoft.fix.support.v7.preference.SwitchPreferenceCompat;
 
@@ -141,7 +143,17 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
         Preference versionPref = findPreference("pref_key_build");
         versionPref.setSummary(PrefUtils.versionInfo());
 
-        SwitchPreferenceCompat switchPreference = (SwitchPreferenceCompat) findPreference("pref_key_condensed_note_list");
+        SwitchPreferenceCompat switchPreference = (SwitchPreferenceCompat) findPreference(PrefUtils.PREF_CONDENSED_LIST);
+        switchPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object o) {
+                PassphraseUtils.setCryptographyAgentInstance();
+
+                return true;
+            }
+        });
+
+        EditTextPreference passPreference = (EditTextPreference) findPreference(PrefUtils.PREF_CRYPTO_PASS_PHRASE);
         switchPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object o) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
@@ -223,7 +223,7 @@ public class Note extends BucketObject {
     }
 
     public boolean hasTag(Tag tag) {
-        return hasTag(tag.getSimperiumKey());
+        return hasTag(tag.getName()); // note: uses the name instead of the key, since the key will be a UUID
     }
 
     public List<String> getTags() {
@@ -271,7 +271,7 @@ public class Note extends BucketObject {
 
     /**
      * Sets the note's tags by providing it with a {@link String} of space
-     * seperated tags. Filters out duplicate tags.
+     * separated tags. Filters out duplicate tags.
      *
      * @param tagString a space delimited list of tags
      */

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/NoteTagger.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/NoteTagger.java
@@ -5,8 +5,8 @@
 package com.automattic.simplenote.models;
 
 import com.simperium.client.Bucket;
-import com.simperium.client.BucketObjectMissingException;
 import com.simperium.client.BucketObjectNameInvalid;
+import com.simperium.util.Uuid;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -31,19 +31,28 @@ public class NoteTagger implements Bucket.Listener<Note> {
         List<String> tags = note.getTags();
         for (String tagName : tags) {
             // find the tag by the lowercase tag string
-            String tagKey = null;
+            String tagKey;
             try {
-                tagKey = URLEncoder.encode(tagName.toLowerCase(), KEY_ENCODING);
-                mTagsBucket.getObject(tagKey);
-            } catch (BucketObjectMissingException e) {
-                // tag doesn't exist, so we'll create one using the key
-                try {
-                    Tag tag = mTagsBucket.newObject(tagKey);
-                    tag.setName(tagName);
-                    tag.setIndex(mTagsBucket.count());
-                    tag.save();
-                } catch (BucketObjectNameInvalid invalid) {
-                    android.util.Log.e("Simplenote.NoteTagger", "Could not create tag object for note", invalid);
+                tagKey = URLEncoder.encode(Uuid.uuid(), KEY_ENCODING); // keys shouldn't be plain text versions of the name, for encryption purposes
+                // I couldn't figure out how to do a query successfully, and how long could walking these really take, anyway?
+                boolean tagExists = false;
+                Bucket.ObjectCursor tagsCursor = mTagsBucket.allObjects();
+                while (tagsCursor.moveToNext()) {
+                    Tag tag = (Tag)(tagsCursor.getObject());
+                    if(tag.getName().equals(tagName)) {
+                        tagExists = true;
+                        break;
+                    }
+                }
+                if (!tagExists) {
+                    try {
+                        Tag tag = mTagsBucket.newObject(tagKey);
+                        tag.setName(tagName);
+                        tag.setIndex(mTagsBucket.count());
+                        tag.save();
+                    } catch (BucketObjectNameInvalid invalid) {
+                        android.util.Log.e("Simplenote.NoteTagger", "Could not create tag object for note", invalid);
+                    }
                 }
             } catch (UnsupportedEncodingException e) {
                 android.util.Log.e("Simplenote.NoteTagger", "Invalid tag key", e);

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PassphraseUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PassphraseUtils.java
@@ -1,0 +1,30 @@
+package com.automattic.simplenote.utils;
+
+import com.automattic.simplenote.BouncyCastleOpenPgpCryptographyAgent;
+import com.automattic.simplenote.Simplenote;
+import com.simperium.client.CryptographyAgent;
+
+public class PassphraseUtils {
+
+    public static char[] getPassphrase() {
+        String encryptedStringPref = PrefUtils.getStringPref(Simplenote.getCryptoContext(), PrefUtils.PREF_CRYPTO_PASS_PHRASE, null);
+        char[] passPhrase = encryptedStringPref == null ? null : encryptedStringPref.toCharArray();
+
+        if (!CryptographyAgent.isEnabled()) { // in case the passPhrase is set _after_ the app has been started and the agent didn't get set yet.
+            setCryptographyAgentInstance(passPhrase);
+        }
+        return passPhrase;
+    }
+
+    public static void setCryptographyAgentInstance() {
+        setCryptographyAgentInstance(PassphraseUtils.getPassphrase());
+    }
+
+    private static void setCryptographyAgentInstance(char[] passPhrase) {
+        CryptographyAgent cryptographyAgent = (passPhrase != null && passPhrase.length > 0) ? new BouncyCastleOpenPgpCryptographyAgent() : null;
+        CryptographyAgent.setInstance(cryptographyAgent);
+        // for testing
+        // CryptographyAgent.setInstance(new Base64TestCryptographyAgent());
+    }
+
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -8,7 +8,6 @@ package com.automattic.simplenote.utils;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-import android.text.Html;
 
 import com.automattic.simplenote.BuildConfig;
 
@@ -44,7 +43,12 @@ public class PrefUtils {
     // boolean, determines if the theme was ever changed
     public static final String PREF_THEME_MODIFIED = "pref_theme_modified";
 
+    // string, the cryptography passphrase (can be easily seen in rooted devices)
+    public static final String PREF_CRYPTO_PASS_PHRASE = "pref_crypto_pass_phrase";
+
     private static SharedPreferences getPrefs(Context context) {
+        // todo we should cache this instance instead of getting it fresh each time, for better performance.
+        // see: http://stackoverflow.com/a/4371883/4718652
         return PreferenceManager.getDefaultSharedPreferences(context);
     }
 

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -59,6 +59,8 @@
     <string name="markdown">Markdown</string>
     <string name="markdown_hide">Hide Markdown</string>
     <string name="markdown_show">Show Markdown</string>
+    <string name="crypto_pass_phrase">Encryption Pass Phrase (permanent, per account)</string>
+    <string name="crypto_pass_phrase_summary">Enter a pass phrase to save in preferences</string>
 
     <!-- Undo -->
     <string name="undo">Undo</string>

--- a/Simplenote/src/main/res/xml/preferences.xml
+++ b/Simplenote/src/main/res/xml/preferences.xml
@@ -30,6 +30,12 @@
             android:key="pref_key_theme"
             android:summary="%s"
             android:title="@string/theme"/>
+        <EditTextPreference
+            android:name="@string/crypto_pass_phrase"
+            android:summary="@string/crypto_pass_phrase_summary"
+            android:defaultValue=""
+            android:title="@string/crypto_pass_phrase"
+            android:key="pref_crypto_pass_phrase" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Hello!

I have added an encryption feature to simplenote-android (and also to simperium-android, which I will submit a separate pull request for), and would like to discuss whether it is something that would be desirable in the base product.

The encryption happens only on the wire to/from the server.   When encrypted, the data is kept in ASCII-ARMOR mode, so that it is text-diffable.  Consequently, the client/server communications still work as always.  The server just deals with the data as though it were not encrypted, as though it were simple text, even though the client secretly encrypts it.  There is a performance hit, I am sure, as when changing a single byte (like the first character), all subsequent bytes will likely change.  So, most of the time, full-note transmission will probably occur on changes.  A cost for having encryption, I suppose.

Since the ghost is unencrypted, searching still works.

I have had this working on my local for a while, but have not dealt with adding it to other implementations yet (e.g. electron/ios/mac/etc.).  I'm not sure how much work that would be.

Note that the current implementation uses spongycastle passphrase symmetric encryption, with the passphrase stored in preferences.

I look forward to your comments and ideas!

Thanks!