### PR TITLE
Update build instructions to use dev app and key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,6 @@ config.properties
 .idea/
 .gradle/
 
-gradle.properties
-
 *.keystore
 
 # When developing against Simperium-android source directly

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 A Simplenote client for Android. Learn more about Simplenote at [Simplenote.com](https://simplenote.com).
 
-## Development Requirements
-* A Simperium account. [Sign up here](https://simperium.com/signup/)
-* A Simperium Application ID and key. [Create a new app here](https://simperium.com/app/new/)
-
 ## How to Configure
 
 * Clone repo
@@ -20,17 +16,12 @@ Sample `local.properties`
 sdk.dir=/Applications/Android Studio.app/sdk
 ```
 
-* Configure Simperium, copy the `Simplenote/gradle.properties-example` file to `Simplenote/gradle.properties` and edit your simperium appid and key (You can keep the `googleAnalyticsId` field empty). Your `Simplenote/gradle.properties` file should look like:
-```
-simperiumAppId=SIMPERIUM_APP_ID
-simperiumAppKey=SIMPERIUM_KEY
-googleAnalyticsId=
-```
-
 * Install debug build with Android Studio or:
 ```shell
 ./gradlew installDebug
 ```
+
+Sign up for a new account within the app. Use the account for **testing purposes only** as all note data will be periodically cleared out on the server.
 
 _Note: Simplenote API features such as sharing and publishing will not work with development builds._
 

--- a/Simplenote/gradle.properties
+++ b/Simplenote/gradle.properties
@@ -1,0 +1,4 @@
+simperiumAppId=history-analyst-dad
+simperiumAppKey=dccacc59bbef4982a15abaeafaf7bc8a
+googleAnalyticsId=
+crashlyticsApiKey=0

--- a/Simplenote/gradle.properties-example
+++ b/Simplenote/gradle.properties-example
@@ -1,0 +1,4 @@
+simperiumAppId=FIXME
+simperiumAppKey=FIXME
+googleAnalyticsId=
+crashlyticsApiKey=0

--- a/Simplenote/gradle.properties-example
+++ b/Simplenote/gradle.properties-example
@@ -1,4 +1,0 @@
-simperiumAppId=FIXME
-simperiumAppKey=FIXME
-googleAnalyticsId=
-crashlyticsApiKey=0


### PR DESCRIPTION
This PR adds a hard coded dev app key to the app so that developers will not need to create a Simperium account and app in order to build and test the app.