### PR TITLE
Fix NPE when callbacks attempt to load markdown in the wrong view.

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1162,14 +1162,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             // Show tabs if markdown is enabled globally, for current note, and not tablet landscape
             if (mIsMarkdownEnabled) {
                 // Get markdown view and update content
-                if (DisplayUtils.isLargeScreenLandscape(getActivity())) {
-                    loadMarkdownData();
-                } else {
-                    mNoteMarkdownFragment =
-                            ((NoteEditorActivity) getActivity()).getNoteMarkdownFragment();
-                    mNoteMarkdownFragment.updateMarkdown(getNoteContentString());
-                    ((NoteEditorActivity) getActivity()).showTabs();
-                }
+                updateMarkdownView();
             }
 
             getActivity().invalidateOptionsMenu();
@@ -1193,14 +1186,25 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             if (getActivity() != null && !getActivity().isFinishing()) {
                 // Update links
                 SimplenoteLinkify.addLinks(mContentEditText, Linkify.ALL);
-
-                // Update markdown fragment
-                if (DisplayUtils.isLargeScreenLandscape(getActivity())) {
-                    loadMarkdownData();
-                } else if (mNoteMarkdownFragment != null) {
-                    mNoteMarkdownFragment.updateMarkdown(getNoteContentString());
-                }
+                updateMarkdownView();
             }
+        }
+    }
+
+    private void updateMarkdownView() {
+        Activity activity = getActivity();
+
+        if (activity instanceof NotesActivity) {
+            // This fragment lives in NotesActivity, so load markdown in this fragment's WebView.
+            loadMarkdownData();
+        } else {
+            // This fragment lives in the NoteEditorActivity's ViewPager.
+            if (mNoteMarkdownFragment == null) {
+                mNoteMarkdownFragment = ((NoteEditorActivity) getActivity()).getNoteMarkdownFragment();
+                ((NoteEditorActivity) getActivity()).showTabs();
+            }
+            // Load markdown in the sibling NoteMarkdownFragment's WebView.
+            mNoteMarkdownFragment.updateMarkdown(getNoteContentString());
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/simplenote-android/issues/444 and https://github.com/Automattic/simplenote-android/issues/423

Bug is reproducible with these steps:

1. Device is a tablet (large screen)
2. Markdown is enabled
3. User starts NotesActivity in _portrait_ orientation
4. User selects a note, which starts NoteEditorActivity (instead of remaining in the NotesActivity's master-detail flow, which occurs if device is in landscape)
5. NoteEditorFragment is loaded into the NoteEditorActivity's ViewPager, along with a sibling NoteMarkdownFragment, which is now the correct target for the markdown data.

Previous code was assuming large screen size + landscape orientation (`DisplayUtils.isLargeScreenLandscape(getActivity())`) meant markdown should display in the NoteEditorFragment's embedded WebView. Callbacks were attempting to load the markdown data into this null WebView, causing NPEs.