### PR TITLE
Issue/469 trash icon state

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -38,7 +38,6 @@ import android.widget.ProgressBar;
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
-import com.automattic.simplenote.utils.AniUtils;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
@@ -408,10 +407,8 @@ public class NotesActivity extends AppCompatActivity implements
         // Disable the trash icon if there are no notes trashed.
         Query<Note> query = Note.allDeleted(mNotesBucket);
         if (query.count() == 0) {
-            mEmptyTrashMenuItem.getIcon().setAlpha(127);
             mEmptyTrashMenuItem.setEnabled(false);
         } else {
-            mEmptyTrashMenuItem.getIcon().setAlpha(255);
             mEmptyTrashMenuItem.setEnabled(true);
         }
     }

--- a/Simplenote/src/main/res/drawable/ic_trash_disabled_24dp.xml
+++ b/Simplenote/src/main/res/drawable/ic_trash_disabled_24dp.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24" >
+
+    <path
+        android:fillColor="#80000000"
+        android:pathData="M18,8.5V18c0,1.105-0.895,2-2,2H6c-1.105,0-2-0.895-2-2V8.5h2V18h10V8.5H18z M15,5V4c0-1.105-0.895-2-2-2H9 C7.895,2,7,2.895,7,4v1H3v2h3.333h9.333H19V5H15z M9,4h4v1H9V4z M10,16V8.5H8V16H10z M14,16V8.5h-2V16H14z" >
+    </path>
+
+</vector>

--- a/Simplenote/src/main/res/drawable/ic_trash_selector.xml
+++ b/Simplenote/src/main/res/drawable/ic_trash_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/ic_trash_disabled_24dp" android:state_enabled="false" />
+    <item android:drawable="@drawable/ic_trash_24dp" />
+
+</selector>

--- a/Simplenote/src/main/res/menu/notes_list.xml
+++ b/Simplenote/src/main/res/menu/notes_list.xml
@@ -42,7 +42,7 @@
 
     <item
         android:id="@+id/menu_empty_trash"
-        android:icon="@drawable/ic_trash_24dp"
+        android:icon="@drawable/ic_trash_selector"
         android:title="@string/empty_trash"
         app:showAsAction="ifRoom"/>
 


### PR DESCRIPTION
### Fix
Update empty trash icon state logic as described in https://github.com/Automattic/simplenote-android/issues/469.

### Test
1. Go to ***Trash***.
2. Empty trash if trashed notes exist.
3. Notice disabled ***Trash*** icon and disabled action.
4. Go to ***All Notes***.
5. Open any note.
6. Notice disabled ***Trash*** icon and enabled action.