### PR TITLE
Fixing build for latest version of gradle

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -4,7 +4,6 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'io.fabric.tools:gradle:1.+'
     }
 }

--- a/Simplenote/src/main/res/layout/auth_preference.xml
+++ b/Simplenote/src/main/res/layout/auth_preference.xml
@@ -28,7 +28,7 @@
         android:layout_weight="1"
         android:ellipsize="marquee"
         android:gravity="right"
-        android:maxLines="1"
+        android:singleLine="true"
         android:textAlignment="gravity"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textColor="@color/mediumgrey"/>

--- a/Simplenote/src/main/res/layout/simplenote_spinner_dropdown_item.xml
+++ b/Simplenote/src/main/res/layout/simplenote_spinner_dropdown_item.xml
@@ -4,4 +4,4 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:ellipsize="marquee"
-    android:maxLines="1"/>
+    android:singleLine="true"/>

--- a/Wear/build.gradle
+++ b/Wear/build.gradle
@@ -2,9 +2,6 @@ buildscript {
     repositories {
         jcenter()
     }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-    }
 }
 apply plugin: 'com.android.application'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.0.1'
+    }
+}
+
+
 def gitHash() {
     try {
         def code = new ByteArrayOutputStream()

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 buildscript {
     repositories {
         jcenter()
+        maven { url 'https://maven.google.com' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 09 15:32:02 PDT 2017
+#Tue Nov 21 16:01:55 PST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
I was getting this error in the console when building:

https://developer.android.com/studio/build/gradle-plugin-3-0-0.html?utm_source=android-studio#known_issues

I moved the gradle plugin dependency to the main `build.gradle` and deleted it from the sub modules, and everything is happy again.