### PR TITLE
Only update the markdown view if markdown is enabled for the note

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1159,11 +1159,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
             }
 
-            // Show tabs if markdown is enabled globally, for current note, and not tablet landscape
-            if (mIsMarkdownEnabled) {
-                // Get markdown view and update content
-                updateMarkdownView();
-            }
+            updateMarkdownView();
 
             getActivity().invalidateOptionsMenu();
 
@@ -1191,9 +1187,13 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         }
     }
 
+    // Show tabs if markdown is enabled globally, for current note, and not tablet landscape
     private void updateMarkdownView() {
-        Activity activity = getActivity();
+        if (!mIsMarkdownEnabled) {
+            return;
+        }
 
+        Activity activity = getActivity();
         if (activity instanceof NotesActivity) {
             // This fragment lives in NotesActivity, so load markdown in this fragment's WebView.
             loadMarkdownData();


### PR DESCRIPTION
A regression occurred in #453 that would show the markdown tabs after the note saved, even if it didn't have markdown enabled.

![howdy](https://user-images.githubusercontent.com/789137/33139281-a70700e6-cf61-11e7-9fc8-2283b9a0e316.gif)

This fixes that, you should be able to edit a non-markdown note normally without the tabs ever appearing.

@theck13 mind taking a look?
