### PR TITLE
Adds multiple tag search

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -7,7 +7,6 @@ import android.database.sqlite.SQLiteException;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
-import android.os.PatternMatcher;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.ListFragment;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -7,10 +7,12 @@ import android.database.sqlite.SQLiteException;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.PatternMatcher;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.ListFragment;
 import android.text.SpannableString;
+import android.text.TextUtils;
 import android.text.style.TextAppearanceSpan;
 import android.util.SparseBooleanArray;
 import android.util.TypedValue;
@@ -48,6 +50,10 @@ import com.simperium.client.Query.SortType;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.automattic.simplenote.models.Note.TAGS_PROPERTY;
 
 /**
  * A list fragment representing a list of Notes. This fragment also supports
@@ -383,8 +389,12 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         NotesActivity notesActivity = (NotesActivity) getActivity();
         Query<Note> query = notesActivity.getSelectedTag().query();
 
+        String searchString = mSearchString;
         if (hasSearchQuery()) {
-            query.where(new Query.FullTextMatch(new SearchTokenizer(mSearchString)));
+            searchString = queryTags(query, mSearchString);
+        }
+        if (!TextUtils.isEmpty(searchString)) {
+            query.where(new Query.FullTextMatch(new SearchTokenizer(searchString)));
             query.include(new Query.FullTextOffsets("match_offsets"));
             query.include(new Query.FullTextSnippet(Note.MATCHED_TITLE_INDEX_NAME, Note.TITLE_INDEX_NAME));
             query.include(new Query.FullTextSnippet(Note.MATCHED_CONTENT_INDEX_NAME, Note.CONTENT_PROPERTY));
@@ -398,6 +408,15 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         sortNoteQuery(query);
 
         return query.execute();
+    }
+
+    private String queryTags(Query<Note> query, String searchString) {
+        Pattern pattern = Pattern.compile("tag:(.*?)( |$)");
+        Matcher matcher = pattern.matcher(searchString);
+        while (matcher.find()) {
+            query.where(TAGS_PROPERTY, Query.ComparisonType.LIKE, matcher.group(1));
+        }
+        return matcher.replaceAll("");
     }
 
     public void addNote() {


### PR DESCRIPTION
You can now search for notes with tag "tag1" AND tag "tag2", and with text "text", by writing "tag:yourtag1 tag:yourtag2 text" in the searchbar. This solves #430. 
Maybe it isn't the best way of implementing it, but I did it to show that it is not so hard to implement, and it was the only thing stopping me from migrating from Google Keep. Hope it helps! 