### PR TITLE
Markdown Preview Updates

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     // Third Party
     compile 'com.takisoft.fix:preference-v7:24.2.1.0'
     compile 'com.loopj.android:android-async-http:1.4.9'
-    compile 'com.commonsware.cwac:anddown:0.2.4'
+    compile 'com.commonsware.cwac:anddown:0.4.0'
     compile('com.crashlytics.sdk.android:crashlytics:2.6.5@aar') {
         transitive = true;
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -66,7 +66,7 @@ public class NoteMarkdownFragment extends Fragment {
         setHasOptionsMenu(true);
 
         View layout = inflater.inflate(R.layout.fragment_note_markdown, container, false);
-        mMarkdown = (WebView) layout.findViewById(R.id.markdown);
+        mMarkdown = layout.findViewById(R.id.markdown);
 
         switch (PrefUtils.getIntPref(getActivity(), PrefUtils.PREF_THEME, THEME_LIGHT)) {
             case THEME_DARK:
@@ -120,7 +120,12 @@ public class NoteMarkdownFragment extends Fragment {
     }
 
     public void updateMarkdown(String text) {
-        mMarkdown.loadDataWithBaseURL(null, mCss + new AndDown().markdownToHtml(text), "text/html", "utf-8", null);
+        String parsedMarkdown = new AndDown().markdownToHtml(
+                text,
+                AndDown.HOEDOWN_EXT_STRIKETHROUGH | AndDown.HOEDOWN_EXT_TABLES | AndDown.HOEDOWN_EXT_FENCED_CODE,
+                AndDown.HOEDOWN_HTML_ESCAPE
+        );
+        mMarkdown.loadDataWithBaseURL(null, mCss + parsedMarkdown, "text/html", "utf-8", null);
     }
 
     private void updateCss() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -122,7 +122,7 @@ public class NoteMarkdownFragment extends Fragment {
     public void updateMarkdown(String text) {
         String parsedMarkdown = new AndDown().markdownToHtml(
                 text,
-                AndDown.HOEDOWN_EXT_STRIKETHROUGH | AndDown.HOEDOWN_EXT_TABLES | AndDown.HOEDOWN_EXT_FENCED_CODE,
+                AndDown.HOEDOWN_EXT_STRIKETHROUGH | AndDown.HOEDOWN_EXT_FENCED_CODE | AndDown.HOEDOWN_EXT_QUOTE,
                 AndDown.HOEDOWN_HTML_ESCAPE
         );
         mMarkdown.loadDataWithBaseURL(null, mCss + parsedMarkdown, "text/html", "utf-8", null);


### PR DESCRIPTION
We received a hackerone report that the app doesn't sanitize/escape html in the markdown view. Because of the shared note system, a markdown note with an html form in it could be used to gather sensitive data from a user.

The latest update to `AndDown` allows for escaping html output 👍

I also added a few extension so that we can get strikethrough, 

**To Test**
* Create a note with markdown.
* Add HTML content and markdown syntax.
* When previewing the note, the markdown should render and the html tags should be escaped.

Here's some example markdown content to test with:

```
# Cool

<h1>Cool</h1>

[click](https://wp.com)

![image](http://cdn.abclocal.go.com/content/wpvi/images/cms/2163296_1280x720.jpg)

<script>alert('hi')</script>

Naughty html:
<input type="text" />
<form><input type="submit" /></form>

~~strike~~

> Quoted

```