### PR TITLE
Issue/preview padding clip

### DIFF
--- a/Simplenote/src/main/res/layout/fragment_note_markdown.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_markdown.xml
@@ -2,6 +2,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:clipToPadding="false"
     android:padding="8dp"
     android:scrollbarStyle="outsideOverlay"
     android:scrollbars="vertical">


### PR DESCRIPTION
### Fix
Add the `android:clipToPadding="false"` attribute and value to the `NestedScrollView` of the layout for the ***Preview*** tab to avoid clipping the `WebView` to the parent view's padding.  See the screenshots below for illustration.

![clip](https://user-images.githubusercontent.com/3827611/34022473-adfa539c-e0fc-11e7-92df-223ca302cac8.png)