### PR TITLE
Added a warning when signing out with unsynced notes.

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -179,7 +179,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
                 AlertDialog.Builder builder = new AlertDialog.Builder(fragment.getContext());
                 builder.setTitle(R.string.unsynced_notes);
                 builder.setMessage(R.string.unsynced_notes_message);
-                builder.setPositiveButton(R.string.sign_out, fragment.signOutClickListener);
+                builder.setPositiveButton(R.string.delete_notes, fragment.signOutClickListener);
                 builder.setNeutralButton(R.string.visit_web_app, fragment.loadWebAppClickListener);
                 builder.setNegativeButton(R.string.cancel, null);
                 builder.show();

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -174,7 +174,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
         Bucket.ObjectCursor<Note> notesCursor = notesBucket.allObjects();
         while (notesCursor.moveToNext()) {
             Note note = notesCursor.getObject();
-            if (note.getVersion() == 0) {
+            if (note.isNew() || note.isModified()) {
                 return true;
             }
         }

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -156,6 +156,11 @@
     <string name="no_browser_available">\"Unable to open website. No browser available.\"</string>
     <string name="simplenote_blog_url" translatable="false">simplenote.com/blog</string>
 
+    <!-- Unsynced note warnings -->
+    <string name="unsynced_notes">Unsynced Notes Detected</string>
+    <string name="unsynced_notes_message">Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App.</string>
+    <string name="visit_web_app">Visit Web App</string>
+
     <!-- Note publishing -->
     <string name="content_description_copy_button">Copy Button</string>
     <string name="public_link">Public link</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -157,9 +157,10 @@
     <string name="simplenote_blog_url" translatable="false">simplenote.com/blog</string>
 
     <!-- Unsynced note warnings -->
-    <string name="unsynced_notes">Unsynced Notes Detected</string>
+    <string name="unsynced_notes">Unsynced notes detected</string>
     <string name="unsynced_notes_message">Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App.</string>
-    <string name="visit_web_app">Visit Web App</string>
+    <string name="visit_web_app">Visit web app</string>
+    <string name="delete_notes">Delete notes</string>
 
     <!-- Note publishing -->
     <string name="content_description_copy_button">Copy Button</string>


### PR DESCRIPTION
Some users have attempted to sign out of the app to sync fixing issues, not realizing that all notes get deleted when doing so. This PR adds a prompt to show the user if they sign out and have notes that have never been synced. An unsynced note can be identified as having a `version` of `0`.

<img width="480" alt="screen shot 2018-01-31 at 1 09 02 pm" src="https://user-images.githubusercontent.com/789137/35647613-f0e4a7b0-0687-11e8-8471-95262dd3f1fd.png">

We give the user the option to view the web app to reconcile which notes haven't synced. The performance was really fast for me for an account with 1,000 notes. But just in case I've put the process of checking for the unsynced note in an `AsyncTask`.

**To Test**
* Create a note while offline.
* Go to settings, tap `Sign Out`.
* Verify you received the prompt and that all of the buttons work as expected.
* Verify that signing out with all notes synced does not show the prompt, and just signs you out.