### PR TITLE
Use dynamic copyright date in about fragment

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/AboutFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AboutFragment.java
@@ -12,6 +12,9 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import java.util.Calendar;
+import java.util.Locale;
+
 /**
  * Created by Ondrej Ruttkay on 24/03/2016.
  */
@@ -31,13 +34,17 @@ public class AboutFragment extends Fragment {
 
         View view = inflater.inflate(R.layout.fragment_about, container, false);
 
-        TextView version = (TextView) view.findViewById(R.id.about_version);
+        TextView version = view.findViewById(R.id.about_version);
+        TextView copyright = view.findViewById(R.id.about_copyright);
         View blog = view.findViewById(R.id.about_blog);
         View twitter = view.findViewById(R.id.about_twitter);
         View playStore = view.findViewById(R.id.about_play_store);
         View hiring = view.findViewById(R.id.about_hiring);
 
         version.setText(String.format("%s %s", getString(R.string.version), BuildConfig.VERSION_NAME));
+
+        int thisYear = Calendar.getInstance().get(Calendar.YEAR);
+        copyright.setText(String.format(Locale.getDefault(), "© %1d Automattic", thisYear));
 
         blog.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/Simplenote/src/main/res/layout/fragment_about.xml
+++ b/Simplenote/src/main/res/layout/fragment_about.xml
@@ -173,6 +173,7 @@
             android:background="@color/white"/>
 
         <com.automattic.simplenote.widgets.RobotoLightTextView
+            android:id="@+id/about_copyright"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginBottom="@dimen/padding_large"
@@ -184,7 +185,6 @@
             android:paddingLeft="@dimen/padding_large"
             android:paddingRight="@dimen/padding_large"
             android:paddingStart="@dimen/padding_large"
-            android:text="@string/automattic_copyright"
             android:textSize="15sp"/>
 
     </LinearLayout>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -150,7 +150,6 @@
     <string name="about_twitter_handle" translatable="false">\@simplenoteapp</string>
     <string name="twitter">Twitter</string>
     <string name="rate_us">Rate Us</string>
-    <string name="automattic_copyright" translatable="false">©2016 Automattic, Inc.</string>
     <string name="blog">Blog</string>
     <string name="simplenote_for_android">Simplenote for Android</string>
     <string name="no_browser_available">\"Unable to open website. No browser available.\"</string>


### PR DESCRIPTION
The copyright is now two years old in the about fragment:

<img width="247" alt="screen shot 2018-02-01 at 10 28 33 am" src="https://user-images.githubusercontent.com/789137/35695911-b203b7e4-073a-11e8-85c1-0d767be619eb.png">

Since it doesn't require translation I've taken it out of `strings.xml` and formatted it directly in the fragment. It was also requested to remove `, inc` and add a space between the copyright symbol and the year:

<img width="200" alt="screen shot 2018-02-01 at 10 28 41 am" src="https://user-images.githubusercontent.com/789137/35695956-d5679200-073a-11e8-8ec7-0b49c80ef9fc.png">

We will have some leftover `automattic_copyright` strings in the translated files, but those will go away when we update the translations for the next release.

@0nko care to take a look?
