### PR TITLE
Fixing Window Resize Issues on Chrome OS

### DIFF
--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:theme="@style/Theme.Simplestyle">
         <activity
             android:name="com.automattic.simplenote.NotesActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:configChanges="screenSize|smallestScreenSize|orientation|screenLayout"
+            android:resizeableActivity="true"
             android:label="@string/app_launcher_name"
             android:windowSoftInputMode="adjustResize|stateHidden">
             <intent-filter>

--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
         </activity>
         <activity
             android:name="com.automattic.simplenote.NoteEditorActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:configChanges="screenSize|smallestScreenSize|orientation|screenLayout"
             android:windowSoftInputMode="stateHidden" />
         <activity
             android:name="com.automattic.simplenote.PreferencesActivity"

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -1,7 +1,9 @@
 package com.automattic.simplenote;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
@@ -13,6 +15,7 @@ import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 
+import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.widgets.NoteEditorViewPager;
 
@@ -25,6 +28,7 @@ public class NoteEditorActivity extends AppCompatActivity {
     private NoteEditorFragmentPagerAdapter mNoteEditorFragmentPagerAdapter;
     private NoteEditorViewPager mViewPager;
     private boolean isMarkdownEnabled;
+    private String mNoteId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -54,8 +58,8 @@ public class NoteEditorActivity extends AppCompatActivity {
             Intent intent = getIntent();
             // Create the note editor fragment
             Bundle arguments = new Bundle();
-            arguments.putString(NoteEditorFragment.ARG_ITEM_ID,
-                    intent.getStringExtra(NoteEditorFragment.ARG_ITEM_ID));
+            mNoteId = intent.getStringExtra(NoteEditorFragment.ARG_ITEM_ID);
+            arguments.putString(NoteEditorFragment.ARG_ITEM_ID, mNoteId);
 
             boolean isNewNote = intent.getBooleanExtra(NoteEditorFragment.ARG_NEW_NOTE, false);
             arguments.putBoolean(NoteEditorFragment.ARG_NEW_NOTE, isNewNote);
@@ -138,6 +142,22 @@ public class NoteEditorActivity extends AppCompatActivity {
                 .putFragment(outState, getString(R.string.tab_preview), mNoteEditorFragmentPagerAdapter.getItem(1));
         outState.putBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED, isMarkdownEnabled);
         super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        // If changing to large screen landscape, we finish the activity to go back to
+        // NotesActivity with the note selected in the multipane layout.
+        if (DisplayUtils.isLargeScreen(this) &&
+                newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE && mNoteId != null) {
+            Intent resultIntent = new Intent();
+            resultIntent.putExtra(Simplenote.SELECTED_NOTE_ID, mNoteId);
+            resultIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+            setResult(Activity.RESULT_OK, resultIntent);
+            finish();
+        }
     }
 
     protected NoteMarkdownFragment getNoteMarkdownFragment() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -68,8 +68,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     public static final String ARG_ITEM_ID = "item_id";
     public static final String ARG_NEW_NOTE = "new_note";
-    static public final String ARG_MATCH_OFFSETS = "match_offsets";
-    static public final String ARG_MARKDOWN_ENABLED = "markdown_enabled";
+    public static final String ARG_MATCH_OFFSETS = "match_offsets";
+    public static final String ARG_MARKDOWN_ENABLED = "markdown_enabled";
     public static final int THEME_LIGHT = 0;
     public static final int THEME_DARK = 1;
     private static final int AUTOSAVE_DELAY_MILLIS = 2000;
@@ -1163,7 +1163,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                             inputMethodManager.showSoftInput(mContentEditText, 0);
                     }
                 }, 100);
-
+            } else if (mNote != null) {
+                // If we have a valid note, hide the placeholder
+                setPlaceholderVisible(false);
             }
 
             updateMarkdownView();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -850,7 +850,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     protected void saveNote() {
-        if (mNote == null || (mHistoryBottomSheet != null && mHistoryBottomSheet.isShowing())) {
+        if (mNote == null || mContentEditText == null ||
+                (mHistoryBottomSheet != null && mHistoryBottomSheet.isShowing())) {
             return;
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -428,7 +428,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         // Create & save new note
         Simplenote simplenote = (Simplenote) getActivity().getApplication();
         Bucket<Note> notesBucket = simplenote.getNotesBucket();
-        Note note = notesBucket.newObject();
+        final Note note = notesBucket.newObject();
         note.setCreationDate(Calendar.getInstance());
         note.setModificationDate(note.getCreationDate());
         note.setMarkdownEnabled(PrefUtils.getBoolPref(getActivity(), PrefUtils.PREF_MARKDOWN_ENABLED, false));
@@ -442,7 +442,14 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         note.save();
 
         if (DisplayUtils.isLargeScreenLandscape(getActivity())) {
-            mCallbacks.onNoteSelected(note.getSimperiumKey(), 0, true, null, note.isMarkdownEnabled());
+            // Hack: Simperium saves async so we add a small delay to ensure the new note is truly
+            // saved before proceeding.
+            new Handler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    mCallbacks.onNoteSelected(note.getSimperiumKey(), 0, true, null, note.isMarkdownEnabled());
+                }
+            }, 50);
         } else {
             Bundle arguments = new Bundle();
             arguments.putString(NoteEditorFragment.ARG_ITEM_ID, note.getSimperiumKey());

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -837,13 +837,21 @@ public class NotesActivity extends AppCompatActivity implements
 
                 break;
             case Simplenote.INTENT_EDIT_NOTE:
-                if (resultCode == RESULT_OK && data != null && data.hasExtra(Simplenote.DELETED_NOTE_ID)) {
-                    String noteId = data.getStringExtra(Simplenote.DELETED_NOTE_ID);
-                    if (noteId != null) {
-                        List<String> deletedNoteIds = new ArrayList<>();
-                        deletedNoteIds.add(noteId);
-                        mUndoBarController.setDeletedNoteIds(deletedNoteIds);
-                        mUndoBarController.showUndoBar(getUndoView(), getString(R.string.note_deleted));
+                if (resultCode == RESULT_OK && data != null) {
+                    if (data.hasExtra(Simplenote.DELETED_NOTE_ID)) {
+                        String noteId = data.getStringExtra(Simplenote.DELETED_NOTE_ID);
+                        if (noteId != null) {
+                            List<String> deletedNoteIds = new ArrayList<>();
+                            deletedNoteIds.add(noteId);
+                            mUndoBarController.setDeletedNoteIds(deletedNoteIds);
+                            mUndoBarController.showUndoBar(getUndoView(), getString(R.string.note_deleted));
+                        }
+                    } else if (DisplayUtils.isLargeScreenLandscape(this) && data.hasExtra(Simplenote.SELECTED_NOTE_ID)) {
+                        String selectedNoteId = data.getStringExtra(Simplenote.SELECTED_NOTE_ID);
+                        mNoteListFragment.setNoteSelected(selectedNoteId);
+                        if (mNoteEditorFragment != null) {
+                            mNoteEditorFragment.setNote(selectedNoteId);
+                        }
                     }
                 }
                 break;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -912,7 +912,11 @@ public class NotesActivity extends AppCompatActivity implements
 
             if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
                 // Add the editor fragment
-                addEditorFragment();
+                if (getSupportFragmentManager().findFragmentByTag(TAG_NOTE_EDITOR) != null) {
+                    mNoteEditorFragment = (NoteEditorFragment) getSupportFragmentManager().findFragmentByTag(TAG_NOTE_EDITOR);
+                } else if (DisplayUtils.isLandscape(this)) {
+                    addEditorFragment();
+                }
                 if (mNoteListFragment != null) {
                     mNoteListFragment.setActivateOnItemClick(true);
                     mNoteListFragment.setDividerVisible(true);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -900,7 +900,7 @@ public class NotesActivity extends AppCompatActivity implements
         // Sync the toggle state after onRestoreInstanceState has occurred.
         mDrawerToggle.syncState();
     }
-
+    
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
@@ -929,23 +929,25 @@ public class NotesActivity extends AppCompatActivity implements
                     mNoteListFragment.getListView().clearChoices();
                 }
                 invalidateOptionsMenu();
-            } else if (newConfig.orientation == Configuration.ORIENTATION_PORTRAIT && mNoteEditorFragment != null) {
-                // Remove the editor fragment when rotating back to portrait
-                mCurrentNote = null;
-                if (mNoteListFragment != null) {
-                    mNoteListFragment.setActivateOnItemClick(false);
-                    mNoteListFragment.setDividerVisible(false);
-                    mNoteListFragment.setActivatedPosition(ListView.INVALID_POSITION);
-                    mNoteListFragment.refreshList();
-                }
-                FragmentManager fm = getSupportFragmentManager();
-                FragmentTransaction ft = fm.beginTransaction();
-                ft.remove(mNoteEditorFragment);
-                mNoteEditorFragment = null;
-                ft.commitAllowingStateLoss();
-                fm.executePendingTransactions();
-                invalidateOptionsMenu();
             }
+        }
+
+        if (newConfig.orientation == Configuration.ORIENTATION_PORTRAIT && mNoteEditorFragment != null) {
+            // Remove the editor fragment when rotating back to portrait
+            mCurrentNote = null;
+            if (mNoteListFragment != null) {
+                mNoteListFragment.setActivateOnItemClick(false);
+                mNoteListFragment.setDividerVisible(false);
+                mNoteListFragment.setActivatedPosition(ListView.INVALID_POSITION);
+                mNoteListFragment.refreshList();
+            }
+            FragmentManager fm = getSupportFragmentManager();
+            FragmentTransaction ft = fm.beginTransaction();
+            ft.remove(mNoteEditorFragment);
+            mNoteEditorFragment = null;
+            ft.commitAllowingStateLoss();
+            fm.executePendingTransactions();
+            invalidateOptionsMenu();
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -36,6 +36,7 @@ public class Simplenote extends Application {
     public static final int INTENT_PREFERENCES = 1;
     public static final int INTENT_EDIT_NOTE = 2;
     public static final String DELETED_NOTE_ID = "deletedNoteId";
+    public static final String SELECTED_NOTE_ID = "selectedNoteId";
     private static final String AUTH_PROVIDER = "simplenote.com";
     private Simperium mSimperium;
     private Bucket<Note> mNotesBucket;

--- a/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
@@ -4,7 +4,7 @@
     android:id="@+id/note_editor"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_weight="3.5"
+    android:layout_weight="3"
     android:fillViewport="true"
     android:scrollbars="vertical">
 

--- a/Simplenote/src/main/res/layout/fragment_notes_list.xml
+++ b/Simplenote/src/main/res/layout/fragment_notes_list.xml
@@ -3,7 +3,7 @@
     android:id="@+id/list_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_weight="6.5"
+    android:layout_weight="7"
     android:orientation="vertical">
 
     <ListView


### PR DESCRIPTION
The app has some really bad layout/configuration change bugs when running on Chrome OS:

https://cloudup.com/cJCuQIhb981

I've fixed up a few things, mainly registering for a new configuration change `screenLayout` in the manifest, and updated how we handle configuration changes in `onConfigurationChanged`.

The main bug was that we were always adding a new fragment (the editor) if we detected that the device was large screen and landscape on configuration change. The fix for that was to simply check if the fragment exists first before adding it.

This guide was helpful: https://developer.android.com/topic/arc/screen-size-comp.html

Here's an `after video`:

https://cloudup.com/cBjh1_PKxHB

**To Test**
- Run the app on Chrome OS. Resizing and maximizing/minimizing windows should work as expected.
- The phone/ small screen experience shouldn't be any different (It should never show a two-panel layout in portrait or landscape)
- The tablet/ large screen experience should be the same. Portrait orientation should behave like the phone, and landscape should show the two panel layout.