### PR TITLE
Use Higher Font Size Values for Large and High DPI Screens

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -335,7 +335,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mTagView.setOnTagAddedListener(this);
 
         if (mContentEditText != null) {
-            mContentEditText.setTextSize(TypedValue.COMPLEX_UNIT_SP, PrefUtils.getIntPref(getActivity(), PrefUtils.PREF_FONT_SIZE, 14));
+            mContentEditText.setTextSize(TypedValue.COMPLEX_UNIT_SP, PrefUtils.getFontSize(getActivity()));
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -189,7 +189,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     protected void getPrefs() {
         boolean condensedList = PrefUtils.getBoolPref(getActivity(), PrefUtils.PREF_CONDENSED_LIST, false);
         mNumPreviewLines = (condensedList) ? 0 : 2;
-        mPreviewFontSize = PrefUtils.getIntPref(getActivity(), PrefUtils.PREF_FONT_SIZE, 14);
+        mPreviewFontSize = PrefUtils.getFontSize(getActivity());
         mTitleFontSize = mPreviewFontSize + 2;
     }
 
@@ -239,6 +239,14 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
         getListView().setOnItemLongClickListener(this);
         getListView().setMultiChoiceModeListener(this);
+
+        if (savedInstanceState != null) {
+            int savedActivatedPosition = savedInstanceState.getInt(STATE_ACTIVATED_POSITION, -1);
+            if (savedActivatedPosition >= 0) {
+                setActivatedPosition(savedActivatedPosition);
+            }
+        }
+
     }
 
     private void createNewNote(String label){

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -239,14 +239,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
         getListView().setOnItemLongClickListener(this);
         getListView().setMultiChoiceModeListener(this);
-
-        if (savedInstanceState != null) {
-            int savedActivatedPosition = savedInstanceState.getInt(STATE_ACTIVATED_POSITION, -1);
-            if (savedActivatedPosition >= 0) {
-                setActivatedPosition(savedActivatedPosition);
-            }
-        }
-
     }
 
     private void createNewNote(String label){

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -134,7 +134,7 @@ public class NoteMarkdownFragment extends Fragment {
             return;
         }
 
-        int fontSize = PrefUtils.getIntPref(getActivity(), PrefUtils.PREF_FONT_SIZE, 14);
+        int fontSize = PrefUtils.getFontSize(getActivity());
 
         mCss = "<style>"
                 + mRawCss.replace("${H1-SIZE}", String.valueOf(fontSize + 16))

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -11,6 +11,7 @@ import android.preference.PreferenceManager;
 import android.text.Html;
 
 import com.automattic.simplenote.BuildConfig;
+import com.automattic.simplenote.R;
 
 @SuppressWarnings("unused")
 public class PrefUtils {
@@ -27,7 +28,7 @@ public class PrefUtils {
     public static final String PREF_SHOW_DATES = "pref_key_show_dates";
 
     // int, preferred font size
-    public static final String PREF_FONT_SIZE = "pref_key_font_size";
+    private static final String PREF_FONT_SIZE = "pref_key_font_size";
 
     // boolean, set on first launch
     public static final String PREF_FIRST_LAUNCH = "pref_key_first_launch";
@@ -95,7 +96,19 @@ public class PrefUtils {
         }
 
         return BuildConfig.VERSION_NAME;
+    }
 
+    public static int getFontSize(Context context) {
+        int defaultFontSize = 16;
+        // Just in case
+        if (context == null) {
+            return defaultFontSize;
+        }
+
+        // Get default value for normal font size (differs based on screen/dpi size)
+        defaultFontSize = context.getResources().getInteger(R.integer.default_font_size);
+
+        return getIntPref(context, PREF_FONT_SIZE, defaultFontSize);
     }
 
 }

--- a/Simplenote/src/main/res/values-large-xxxhdpi/dimens.xml
+++ b/Simplenote/src/main/res/values-large-xxxhdpi/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="nav_drawer_item_text_size">18sp</dimen>
+</resources>

--- a/Simplenote/src/main/res/values-xlarge-xxxhdpi/arrays.xml
+++ b/Simplenote/src/main/res/values-xlarge-xxxhdpi/arrays.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="array_font_size_values" translatable="false">
+        <item>14</item>
+        <item>16</item>
+        <item>18</item>
+        <item>20</item>
+        <item>24</item>
+    </string-array>
+</resources>

--- a/Simplenote/src/main/res/values-xlarge-xxxhdpi/integers.xml
+++ b/Simplenote/src/main/res/values-xlarge-xxxhdpi/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="default_font_size">18</integer>
+</resources>

--- a/Simplenote/src/main/res/values/integers.xml
+++ b/Simplenote/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="default_font_size">16</integer>
+</resources>

--- a/Simplenote/src/main/res/xml/preferences.xml
+++ b/Simplenote/src/main/res/xml/preferences.xml
@@ -17,7 +17,7 @@
             android:summary="%s"
             android:title="@string/sort_order"/>
         <ListPreference
-            android:defaultValue="16"
+            android:defaultValue="@integer/default_font_size"
             android:entries="@array/array_font_size"
             android:entryValues="@array/array_font_size_values"
             android:key="pref_key_font_size"


### PR DESCRIPTION
On a Chrome OS device with a high DPI screen, the default font size of 16pt is too small. This PR bumps up the font sizes for those devices. The new default 'Normal' font size is 18pt.

Before:
![screenshot 2018-03-13 at 12 49 25 pm](https://user-images.githubusercontent.com/789137/37366306-53d55d42-26bd-11e8-9967-b4fead1135fe.png)

After:
![screenshot 2018-03-13 at 12 49 52 pm](https://user-images.githubusercontent.com/789137/37366316-5a4a5678-26bd-11e8-8b30-7b955ce08b37.png)

**To Test**
- Ensure font sizes are normal/readable on a device like a phone.
- Check font size readability on a large/high dpi screen device (I have a Samsung Chromebook Pro)