### PR TITLE
Fix key navigation from note editor to tags field.

### DIFF
--- a/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
@@ -42,6 +42,8 @@
                     android:textColor="?attr/noteEditorTextColor"
                     android:textColorLink="@color/simplenote_blue"
                     android:textSize="14sp"
+                    android:nextFocusForward="@id/tag_view"
+                    android:nextFocusDown="@id/tag_view"
                     tools:context=".NoteEditorFragment"/>
 
             </android.support.v4.widget.NestedScrollView>

--- a/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
@@ -62,7 +62,7 @@
                 android:minHeight="48dp"
                 android:nextFocusForward="@+id/note_content"
                 android:nextFocusLeft="@id/tag_view"
-                android:nextFocusUp="@id/tag_view"
+                android:nextFocusUp="@id/note_editor"
                 android:textColor="?attr/noteEditorTextColor"
                 android:textColorHint="?attr/hintTextColor"
                 android:textSize="16sp"/>

--- a/Simplenote/src/main/res/layout/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_editor.xml
@@ -42,6 +42,8 @@
                     android:textColor="?attr/noteEditorTextColor"
                     android:textColorLink="@color/simplenote_blue"
                     android:textSize="16sp"
+                    android:nextFocusForward="@id/tag_view"
+                    android:nextFocusDown="@id/tag_view"
                     tools:context=".NoteEditorFragment"/>
 
             </android.support.v4.widget.NestedScrollView>

--- a/Simplenote/src/main/res/layout/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_editor.xml
@@ -62,7 +62,7 @@
                 android:minHeight="48dp"
                 android:nextFocusForward="@+id/note_content"
                 android:nextFocusLeft="@id/tag_view"
-                android:nextFocusUp="@id/tag_view"
+                android:nextFocusUp="@id/note_editor"
                 android:textColor="?attr/noteEditorTextColor"
                 android:textColorHint="?attr/hintTextColor"
                 android:textSize="16sp"/>


### PR DESCRIPTION
Pressing the down arrow key should now focus the tags field when the note editor is active. Similarly, pressing up while the tags editor is active should focus the note editor again.