### PR TITLE
Revert right click to start multi select

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -1,6 +1,5 @@
 package com.automattic.simplenote;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
@@ -21,7 +20,6 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AbsListView;
@@ -118,15 +116,11 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
     @Override
     public boolean onItemLongClick(AdapterView<?> adapterView, View view, int position, long l) {
-        toggleMultiSelectActionMode(position);
-        return true;
-    }
-
-    private void toggleMultiSelectActionMode(int position) {
         getListView().setChoiceMode(ListView.CHOICE_MODE_MULTIPLE_MODAL);
         getListView().setItemChecked(position, true);
         if (mActionMode == null)
             getActivity().startActionMode(this);
+        return true;
     }
 
     @Override
@@ -662,20 +656,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                 else
                     holder.contentTextView.setText(contentPreview);
             }
-
-            // Add mouse right click support for starting multi-select mode
-            view.setOnTouchListener(new View.OnTouchListener() {
-                @SuppressLint("ClickableViewAccessibility")
-                @Override
-                public boolean onTouch(View v, MotionEvent event) {
-                    if (event.getButtonState() == MotionEvent.BUTTON_SECONDARY) {
-                        toggleMultiSelectActionMode(position);
-                        return true;
-                    }
-
-                    return false;
-                }
-            });
 
             return view;
         }


### PR DESCRIPTION
Reverting #506 based on feedback from Google.

Revert "Adding support for right-clicking on the list view to start multi select note mode."

This reverts commit c4aa0fb826925b3e77526030906de3fe44dbf0e2.

**To Test**
* Right clicking the notes list should no longer start multi select mode.
* Long press should still start multi select mode.