### PR TITLE
Fix loss of selected note when switching to/from tablet mode on Chrome OS

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -70,6 +70,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     public static final String ARG_NEW_NOTE = "new_note";
     public static final String ARG_MATCH_OFFSETS = "match_offsets";
     public static final String ARG_MARKDOWN_ENABLED = "markdown_enabled";
+    private static final String STATE_NOTE_ID = "state_note_id";
     public static final int THEME_LIGHT = 0;
     public static final int THEME_DARK = 1;
     private static final int AUTOSAVE_DELAY_MILLIS = 2000;
@@ -312,15 +313,21 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         mTagView.setAdapter(mAutocompleteAdapter);
 
-        // Load note if we were passed a note Id
         Bundle arguments = getArguments();
         if (arguments != null && arguments.containsKey(ARG_ITEM_ID)) {
+            // Load note if we were passed a note Id
             String key = arguments.getString(ARG_ITEM_ID);
             if (arguments.containsKey(ARG_MATCH_OFFSETS)) {
                 mMatchOffsets = arguments.getString(ARG_MATCH_OFFSETS);
             }
             new loadNoteTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, key);
             setIsNewNote(getArguments().getBoolean(ARG_NEW_NOTE, false));
+        } else if (DisplayUtils.isLargeScreenLandscape(getActivity()) && savedInstanceState != null ) {
+            // Restore selected note when in dual pane mode
+            String noteId = savedInstanceState.getString(STATE_NOTE_ID);
+            if (noteId != null) {
+                setNote(noteId);
+            }
         }
 
         return rootView;
@@ -374,6 +381,15 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mHighlighter.stop();
 
         super.onPause();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        if (DisplayUtils.isLargeScreenLandscape(getActivity()) && mNote != null) {
+            outState.putString(STATE_NOTE_ID, mNote.getSimperiumKey());
+        }
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -920,7 +920,11 @@ public class NotesActivity extends AppCompatActivity implements
 
             if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
                 // Add the editor fragment
-                addEditorFragment();
+                if (getSupportFragmentManager().findFragmentByTag(TAG_NOTE_EDITOR) != null) {
+                    mNoteEditorFragment = (NoteEditorFragment) getSupportFragmentManager().findFragmentByTag(TAG_NOTE_EDITOR);
+                } else if (DisplayUtils.isLandscape(this)) {
+                    addEditorFragment();
+                }
                 if (mNoteListFragment != null) {
                     mNoteListFragment.setActivateOnItemClick(true);
                     mNoteListFragment.setDividerVisible(true);


### PR DESCRIPTION
Fixing an issue reported here:

https://github.com/Automattic/simplenote-android/pull/503#issuecomment-376322801

The fix was to save and restore the active note in the note editor when in the dual-pane mode (large screen device in landscape).

There also appeared to be some sort of merge conflict with some code in `NotesActivity` and develop with recent PRs that were merged. I added some missing code back in this PR.

**To Test**
* Start with the app in 'desktop' mode (not full screen, in a window)
* Select a note!
* Flip the device around to turn it to 'tablet mode'.
* The note should still be selected and active in the editor.
* Switching back to desktop mode should keep the current note selected as well.