### PR TITLE
Update CSS for Markdown Preview

### DIFF
--- a/Simplenote/src/main/assets/dark.css
+++ b/Simplenote/src/main/assets/dark.css
@@ -1,77 +1,192 @@
+<style>
+@charset "UTF-8";
+* , body {
+    margin: 0;
+    padding: 0;
+}
+
 body {
-    color: #dbdee0;
-    background-color: #2d3034;
-}
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-    line-height: 1.15;
-}
-h1 {
-    font-weight: 300;
-}
-h5,
-h6 {
-    text-transform: uppercase;
-}
-hr {
-    border: 0;
-    border-top: 1px solid #575e65;
-}
-a {
-    color: #4895d9;
-    cursor: pointer;
-    overflow-wrap: break-word;
-    text-decoration: none;
-    word-wrap: break-word;
-}
-img {
-    height: auto;
-    max-width: 100%;
-}
-blockquote {
-    border-left: 4px solid #575e65;
-    font-style: italic;
-    margin-left: 0;
-    padding-left: 1em;
-}
-code {
-    background: #404549;
-    font-size: 85%;
-}
-p {
-    margin: 0 0 1.5em;
-}
-pre {
-    border: 1px solid #575e65;
-    padding: 1em;
-}
-pre code {
-    color: #dbdee0;
     background: transparent;
 }
-p,
-h4,
-ul li,
-ol li {
-    font-size: ${P-SIZE}px;
+
+img {
+    border: 0;
 }
-h1 {
-    font-size: ${H1-SIZE}px;
+
+* :focus {
+    outline: none;
 }
-h2 {
-    font-size: ${H2-SIZE}px;
+
+html {
+    margin: 0;
+    padding: 0;
+    background: #2d3034;
+    color: #dbdee0;
+    text-rendering: optimizeLegibility;
 }
-h3 {
-    font-size: ${H3-SIZE}px;
+
+::-webkit-scrollbar {
+    width: 6px;
 }
-pre,
-h5 {
-    font-size: ${H5-SIZE}px;
+
+::-webkit-scrollbar-track {
+    background-color: transparent;
 }
-h6 {
-    font-size: ${H6-SIZE}px;
+
+::-webkit-scrollbar-thumb {
+    border-radius: 6px;
+    background: #84878a;
 }
+
+/* Same styles as app.simplenote.com/publish */
+.note-detail-markdown {
+    user-select: auto;
+    font-family: 'Noto Serif', serif;
+    font-size: 18px;
+    line-height: 1.7;
+    word-wrap: break-word;
+    padding: 20px 20px 20px 24px;
+}
+
+.note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
+.note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
+.note-detail-markdown #title {
+    line-height: 1.15;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    margin: 1.7em 0 1em 0;
+}
+
+.note-detail-markdown h1, .note-detail-markdown #title {
+    font-size: 2em;
+}
+
+.note-detail-markdown h1:first-of-type, .note-detail-markdown #title:first-of-type {
+    margin-top: 0;
+}
+
+.note-detail-markdown h2 {
+    font-size: 1.8em;
+}
+
+.note-detail-markdown h3 {
+    font-size: 1.4em;
+}
+
+.note-detail-markdown h4 {
+    font-size: 1.2em;
+}
+
+.note-detail-markdown h5, .note-detail-markdown h6 {
+    font-size: 1em;
+    text-transform: uppercase;
+}
+
+.note-detail-markdown #title {
+    margin-bottom: 0.5em;
+    font-weight: bold;
+}
+
+.note-detail-markdown p, .note-detail-markdown ul, .note-detail-markdown ol,
+.note-detail-markdown blockquote, .note-detail-markdown pre, .note-detail-markdown table,
+.note-detail-markdown code, .note-detail-markdown img {
+    margin-bottom: 1.7em;
+    box-sizing: border-box;
+}
+
+.note-detail-markdown ul, .note-detail-markdown ol {
+    margin-left: 2em;
+}
+
+.note-detail-markdown img {
+    display: block;
+    margin: 0 auto;
+    max-width: 100%;
+    height: auto;
+}
+
+.note-detail-markdown a {
+    color: #4895d9;
+}
+
+.note-detail-markdown hr {
+    border: 0;
+    margin: 3.4em 0;
+    color: #4895d9;
+    height: 1em;
+}
+
+.note-detail-markdown hr:before {
+    content: '...';
+    display: block;
+    width: 100%;
+    letter-spacing: 2em;
+    text-indent: 2em;
+    z-index: 1;
+    line-height: .5;
+    text-align: center;
+}
+
+.note-detail-markdown blockquote {
+    font-style: italic;
+    border-left: 4px solid currentColor;
+    margin-left: 0;
+    padding-left: 1.7em;
+}
+
+.note-detail-markdown code {
+    color: #84878a;
+}
+
+.note-detail-markdown pre {
+    padding: 1em;
+    border-radius: 3px;
+    background: #f6f7f8;
+}
+
+.note-detail-markdown pre code {
+    font-size: 85%;
+    color: #616870;
+    background: transparent;
+    width: 100%;
+    overflow-x: auto;
+    display: block;
+    margin-bottom: 0;
+}
+
+.note-detail-markdown table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    display: block;
+    width: 100%;
+}
+
+.note-detail-markdown table tr:nth-child(2n) {
+    background-color: #383d41;
+}
+
+.note-detail-markdown table th, .note-detail-markdown table td {
+    border: 1px solid #575e65;
+    padding: 6px 13px;
+}
+
+.note-detail-markdown table th {
+    font-weight: 600;
+}
+
+@media only screen and (max-width: 480px) {
+    .note-detail-markdown {
+        font-size: 16px;
+    }
+
+    .note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
+    .note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
+    .note-detail-markdown #title {
+        margin: 1.19em 0 0.7em 0;
+    }
+
+    .note-detail-markdown #title {
+        margin-bottom: 0;
+    }
+}
+
+</style>

--- a/Simplenote/src/main/assets/light.css
+++ b/Simplenote/src/main/assets/light.css
@@ -1,77 +1,192 @@
+<style>
+@charset "UTF-8";
+* , body {
+    margin: 0;
+    padding: 0;
+}
+
 body {
-    color: #2d3034;
-    background-color: #fff;
-}
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-    line-height: 1.15;
-}
-h1 {
-    font-weight: 300;
-}
-h5,
-h6 {
-    text-transform: uppercase;
-}
-hr {
-    border: 0;
-    border-top: 1px solid #dbdee0;
-}
-a {
-    color: #4895d9;
-    cursor: pointer;
-    overflow-wrap: break-word;
-    text-decoration: none;
-    word-wrap: break-word;
-}
-img {
-    height: auto;
-    max-width: 100%;
-}
-blockquote {
-    border-left: 4px solid #dbdee0;
-    font-style: italic;
-    margin-left: 0;
-    padding-left: 1em;
-}
-code {
-    background: #f1f2f3;
-    font-size: 85%;
-}
-p {
-    margin: 0 0 1.5em;
-}
-pre {
-    border: 1px solid #dbdee0;
-    padding: 1em;
-}
-pre code {
-    color: #6f7880;
     background: transparent;
 }
-p,
-h4,
-ul li,
-ol li {
-    font-size: ${P-SIZE}px;
+
+img {
+    border: 0;
 }
-h1 {
-    font-size: ${H1-SIZE}px;
+
+* :focus {
+    outline: none;
 }
-h2 {
-    font-size: ${H2-SIZE}px;
+
+html {
+    margin: 0;
+    padding: 0;
+    background: #FFFFFF;
+    color: #2d3034;
+    text-rendering: optimizeLegibility;
 }
-h3 {
-    font-size: ${H3-SIZE}px;
+
+::-webkit-scrollbar {
+    width: 6px;
 }
-pre,
-h5 {
-    font-size: ${H5-SIZE}px;
+
+::-webkit-scrollbar-track {
+    background-color: transparent;
 }
-h6 {
-    font-size: ${H6-SIZE}px;
+
+::-webkit-scrollbar-thumb {
+    border-radius: 6px;
+    background: #84878a;
 }
+
+/* Same styles as app.simplenote.com/publish */
+.note-detail-markdown {
+    user-select: auto;
+    font-family: 'Noto Serif', serif;
+    font-size: 18px;
+    line-height: 1.7;
+    word-wrap: break-word;
+    padding: 20px 20px 20px 24px;
+}
+
+.note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
+.note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
+.note-detail-markdown #title {
+    line-height: 1.15;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    margin: 1.7em 0 1em 0;
+}
+
+.note-detail-markdown h1, .note-detail-markdown #title {
+    font-size: 2em;
+}
+
+.note-detail-markdown h1:first-of-type, .note-detail-markdown #title:first-of-type {
+    margin-top: 0;
+}
+
+.note-detail-markdown h2 {
+    font-size: 1.8em;
+}
+
+.note-detail-markdown h3 {
+    font-size: 1.4em;
+}
+
+.note-detail-markdown h4 {
+    font-size: 1.2em;
+}
+
+.note-detail-markdown h5, .note-detail-markdown h6 {
+    font-size: 1em;
+    text-transform: uppercase;
+}
+
+.note-detail-markdown #title {
+    margin-bottom: 0.5em;
+    font-weight: bold;
+}
+
+.note-detail-markdown p, .note-detail-markdown ul, .note-detail-markdown ol,
+.note-detail-markdown blockquote, .note-detail-markdown pre, .note-detail-markdown table,
+.note-detail-markdown code, .note-detail-markdown img {
+    margin-bottom: 1.7em;
+    box-sizing: border-box;
+}
+
+.note-detail-markdown ul, .note-detail-markdown ol {
+    margin-left: 2em;
+}
+
+.note-detail-markdown img {
+    display: block;
+    margin: 0 auto;
+    max-width: 100%;
+    height: auto;
+}
+
+.note-detail-markdown a {
+    color: #4895d9;
+}
+
+.note-detail-markdown hr {
+    border: 0;
+    margin: 3.4em 0;
+    color: #4895d9;
+    height: 1em;
+}
+
+.note-detail-markdown hr:before {
+    content: '...';
+    display: block;
+    width: 100%;
+    letter-spacing: 2em;
+    text-indent: 2em;
+    z-index: 1;
+    line-height: .5;
+    text-align: center;
+}
+
+.note-detail-markdown blockquote {
+    font-style: italic;
+    border-left: 4px solid currentColor;
+    margin-left: 0;
+    padding-left: 1.7em;
+}
+
+.note-detail-markdown code {
+    color: #899199;
+}
+
+.note-detail-markdown pre {
+    padding: 1em;
+    border-radius: 3px;
+    background: #f6f7f8;
+}
+
+.note-detail-markdown pre code {
+    font-size: 85%;
+    color: #616870;
+    background: transparent;
+    width: 100%;
+    overflow-x: auto;
+    display: block;
+    margin-bottom: 0;
+}
+
+.note-detail-markdown table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    display: block;
+    width: 100%;
+}
+
+.note-detail-markdown table tr:nth-child(2n) {
+    background-color: #f6f7f8;
+}
+
+.note-detail-markdown table th, .note-detail-markdown table td {
+    border: 1px solid #c0c4c8;
+    padding: 6px 13px;
+}
+
+.note-detail-markdown table th {
+    font-weight: 600;
+}
+
+@media only screen and (max-width: 480px) {
+    .note-detail-markdown {
+        font-size: 16px;
+    }
+
+    .note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
+    .note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
+    .note-detail-markdown #title {
+        margin: 1.19em 0 0.7em 0;
+    }
+
+    .note-detail-markdown #title {
+        margin-bottom: 0;
+    }
+}
+</style>
+

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -113,14 +113,19 @@ public class NoteMarkdownFragment extends Fragment {
     }
 
     public void updateMarkdown(String text) {
+        String header = "<html><head>" +
+                "<link href=\"https://fonts.googleapis.com/css?family=Noto+Serif\" rel=\"stylesheet\">" +
+                mCss + "</head><body>";
+
         String parsedMarkdown = new AndDown().markdownToHtml(
                 text,
                 AndDown.HOEDOWN_EXT_STRIKETHROUGH | AndDown.HOEDOWN_EXT_FENCED_CODE |
                         AndDown.HOEDOWN_EXT_QUOTE | AndDown.HOEDOWN_EXT_TABLES,
                 AndDown.HOEDOWN_HTML_ESCAPE
         );
-        parsedMarkdown = "<div class=\"note-detail-markdown\">" + parsedMarkdown + "</div>";
-        mMarkdown.loadDataWithBaseURL(null, mCss + parsedMarkdown, "text/html", "utf-8", null);
+        String htmlContent = header + "<div class=\"note-detail-markdown\">" + parsedMarkdown +
+                "</div></body></html>";
+        mMarkdown.loadDataWithBaseURL(null, htmlContent, "text/html", "utf-8", null);
     }
 
     private class loadNoteTask extends AsyncTask<String, Void, Void> {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -26,7 +26,6 @@ public class NoteMarkdownFragment extends Fragment {
     public static final String ARG_ITEM_ID = "item_id";
     private Note mNote;
     private String mCss;
-    private String mRawCss;
     private WebView mMarkdown;
     private boolean mIsLoadingNote;
 
@@ -70,20 +69,14 @@ public class NoteMarkdownFragment extends Fragment {
 
         switch (PrefUtils.getIntPref(getActivity(), PrefUtils.PREF_THEME, THEME_LIGHT)) {
             case THEME_DARK:
-                mRawCss = ContextUtils.readCssFile(getActivity(), "dark.css");
+                mCss = ContextUtils.readCssFile(getActivity(), "dark.css");
                 break;
             case THEME_LIGHT:
-                mRawCss = ContextUtils.readCssFile(getActivity(), "light.css");
+                mCss = ContextUtils.readCssFile(getActivity(), "light.css");
                 break;
         }
 
         return layout;
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        updateCss();
     }
 
     @Override
@@ -122,28 +115,12 @@ public class NoteMarkdownFragment extends Fragment {
     public void updateMarkdown(String text) {
         String parsedMarkdown = new AndDown().markdownToHtml(
                 text,
-                AndDown.HOEDOWN_EXT_STRIKETHROUGH | AndDown.HOEDOWN_EXT_FENCED_CODE | AndDown.HOEDOWN_EXT_QUOTE,
+                AndDown.HOEDOWN_EXT_STRIKETHROUGH | AndDown.HOEDOWN_EXT_FENCED_CODE |
+                        AndDown.HOEDOWN_EXT_QUOTE | AndDown.HOEDOWN_EXT_TABLES,
                 AndDown.HOEDOWN_HTML_ESCAPE
         );
+        parsedMarkdown = "<div class=\"note-detail-markdown\">" + parsedMarkdown + "</div>";
         mMarkdown.loadDataWithBaseURL(null, mCss + parsedMarkdown, "text/html", "utf-8", null);
-    }
-
-    private void updateCss() {
-        if (mRawCss == null) {
-            mCss = "";
-            return;
-        }
-
-        int fontSize = PrefUtils.getFontSize(getActivity());
-
-        mCss = "<style>"
-                + mRawCss.replace("${H1-SIZE}", String.valueOf(fontSize + 16))
-                .replace("${H2-SIZE}", String.valueOf(fontSize + 8))
-                .replace("${H3-SIZE}", String.valueOf(fontSize + 3))
-                .replace("${P-SIZE}", String.valueOf(fontSize))
-                .replace("${H5-SIZE}", String.valueOf(fontSize - 2))
-                .replace("${H6-SIZE}", String.valueOf(fontSize - 5))
-                + "</style>";
     }
 
     private class loadNoteTask extends AsyncTask<String, Void, Void> {


### PR DESCRIPTION
We recently updated the CSS on app.simplenote.com when you view a published note w/ markdown to have more of a 'personal publisher' feel. This PR updates the CSS for the markdown preview to exactly match it.

I've also removed support for injecting the app font size setting into the stylesheets, so that we can preserve how it will truly 'preview' when published to the web.

Screenshots:
![screenshot_1522965730](https://user-images.githubusercontent.com/789137/38394231-86c21ee8-38e2-11e8-8049-d80bb537d690.png)
![screenshot_1522965809](https://user-images.githubusercontent.com/789137/38394232-86d6a0ac-38e2-11e8-9987-aa38c4f574e8.png)

