### PR TITLE
Fix notes list content preview line length in on Oreo

### DIFF
--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -5,7 +5,6 @@
         by AppBaseTheme from res/values-vXX/styles.xml on newer devices.
     -->
     <style name="UntitledNoteAppearance" parent="@android:style/TextAppearance">
-        <item name="android:textSize">22sp</item>
         <item name="android:textColor">?attr/notePreviewColor</item>
         <item name="android:textStyle">italic</item>
     </style>


### PR DESCRIPTION
Fixes #522 by setting visibility of content preview textview instead of using `maxLines` set to zero.

Apparently in Oreo they've change what `maxLines` does if set to zero on a TextView, it seems to remove the limit:

<img width="483" alt="screen shot 2018-04-23 at 9 41 37 am" src="https://user-images.githubusercontent.com/789137/39140862-b9b21532-46da-11e8-8eb1-a82fb4278f98.png">

We were previously setting the `maxLines` property to zero to essentially hide the note content preview. We can instead simply set the `visibility` of the textview to `gone` when the condensed note list is set.

I also fixed a font size issue with the `new note` placeholder text. It was set to a hard coded size in the styles. This adds an `AbsoluteSizeSpan` so that the font size can be dynamic and look correct no matter what font size was selected in the settings:

<img width="132" alt="screen shot 2018-04-23 at 9 45 03 am" src="https://user-images.githubusercontent.com/789137/39140966-21d80a22-46db-11e8-9a07-bd398d4b2bd0.png">

**To Test**
* Open the app in an Oreo emulator.
* In the settings, toggle 'condensed note list' to on.
* Return to the notes list. You should see only one line of text.
* Turn condensed notes list off, there should be up to two lines of preview text.
* The `New note...` placeholder text for an empty note should be the same font size as other notes in the list.
* Repeat the above on an emulator older than Oreo.