### PR TITLE
Fix new and empty notes from not deleting properly

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -82,7 +82,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
      */
     private static Callbacks sCallbacks = new Callbacks() {
         @Override
-        public void onNoteSelected(String noteID, int position, boolean isNew, String matchOffsets, boolean isMarkdownEnabled) {
+        public void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled) {
         }
     };
     protected NotesCursorAdapter mNotesAdapter;
@@ -303,7 +303,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         NoteViewHolder holder = (NoteViewHolder) view.getTag();
         String noteID = holder.getNoteId();
         if (noteID != null) {
-            mCallbacks.onNoteSelected(noteID, position, false, holder.matchOffsets, mNotesAdapter.getItem(position).isMarkdownEnabled());
+            mCallbacks.onNoteSelected(noteID, position, holder.matchOffsets, mNotesAdapter.getItem(position).isMarkdownEnabled());
         }
 
         mActivatedPosition = position;
@@ -315,7 +315,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     public void selectFirstNote() {
         if (mNotesAdapter.getCount() > 0) {
             Note selectedNote = mNotesAdapter.getItem(0);
-            mCallbacks.onNoteSelected(selectedNote.getSimperiumKey(), 0, false, null, selectedNote.isMarkdownEnabled());
+            mCallbacks.onNoteSelected(selectedNote.getSimperiumKey(), 0, null, selectedNote.isMarkdownEnabled());
         }
     }
 
@@ -452,7 +452,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             new Handler().postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    mCallbacks.onNoteSelected(note.getSimperiumKey(), 0, true, null, note.isMarkdownEnabled());
+                    mCallbacks.onNoteSelected(note.getSimperiumKey(), 0, null, note.isMarkdownEnabled());
                 }
             }, 50);
         } else {
@@ -541,7 +541,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         /**
          * Callback for when a note has been selected.
          */
-        void onNoteSelected(String noteID, int position, boolean isNew, String matchOffsets, boolean isMarkdownEnabled);
+        void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled);
     }
 
     // view holder for NotesCursorAdapter

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -218,7 +218,7 @@ public class NotesActivity extends AppCompatActivity implements
         setSelectedTagActive();
 
         if (mCurrentNote != null && mShouldSelectNewNote) {
-            onNoteSelected(mCurrentNote.getSimperiumKey(), 0, true, null, mCurrentNote.isMarkdownEnabled());
+            onNoteSelected(mCurrentNote.getSimperiumKey(), 0, null, mCurrentNote.isMarkdownEnabled());
             mShouldSelectNewNote = false;
         }
 
@@ -728,12 +728,11 @@ public class NotesActivity extends AppCompatActivity implements
      * the item with the given ID was selected. Used for tablets only.
      */
     @Override
-    public void onNoteSelected(String noteID, int position, boolean isNew, String matchOffsets, boolean isMarkdownEnabled) {
+    public void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled) {
         if (!DisplayUtils.isLargeScreenLandscape(this)) {
             // Launch the editor activity
             Bundle arguments = new Bundle();
             arguments.putString(NoteEditorFragment.ARG_ITEM_ID, noteID);
-            arguments.putBoolean(NoteEditorFragment.ARG_NEW_NOTE, isNew);
             arguments.putBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED, isMarkdownEnabled);
 
             if (matchOffsets != null)
@@ -743,7 +742,6 @@ public class NotesActivity extends AppCompatActivity implements
             editNoteIntent.putExtras(arguments);
             startActivityForResult(editNoteIntent, Simplenote.INTENT_EDIT_NOTE);
         } else {
-            mNoteEditorFragment.setIsNewNote(isNew);
             mNoteEditorFragment.setNote(noteID, matchOffsets);
             getNoteListFragment().setNoteSelected(noteID);
 
@@ -950,7 +948,7 @@ public class NotesActivity extends AppCompatActivity implements
                 }
                 // Select the current note on a tablet
                 if (mCurrentNote != null)
-                    onNoteSelected(mCurrentNote.getSimperiumKey(), 0, false, null, mCurrentNote.isMarkdownEnabled());
+                    onNoteSelected(mCurrentNote.getSimperiumKey(), 0, null, mCurrentNote.isMarkdownEnabled());
                 else {
                     mNoteEditorFragment.setPlaceholderVisible(true);
                     mNoteListFragment.getListView().clearChoices();


### PR DESCRIPTION
#330 was caused because a note will not be deleted from Simperium unless it was previously trashed (trashed means having a `deleted` property set to true).

Here's what happened before this patch, observe the phone on the right not deleting the new note:
![broken](https://user-images.githubusercontent.com/789137/40851345-00e4baee-657c-11e8-86d4-d2001e7afec9.gif)

After the patch, the note is deleted as expected:
![fixed](https://user-images.githubusercontent.com/789137/40851358-0ab22a3e-657c-11e8-9ea4-f31b462f2c10.gif)

I've also change the logic for detecting if a note is new and empty. Simperium's bucket object has an `isNew` property, so I've used that in stead of passing a boolean to the fragment. I also matched up the behavior to the iOS app where it sets a boolean as soon as the user types something, signifying that the new note was edited and shouldn't be deleted. This also works better because it will preserve the history of the note even if the user erroneously clears it out and then hits the back button.

_p.s. `NoteEditorFragment` is getting a little crazy. Might be a good hack day project to reorganize it :)_

**To Test**
* Run this on an Android device, and have another device or the web app running with the same account.
* Add a new note, observe that it is added to the other app.
* Press the back button without making any changes. The note should be deleted from the other app.
* Add a new note, and type something in the content field. Pressing back should save the note and show it in the list.
* Add a new note, type something and then clear it all out so the note is blank. Pressing back should show the new, blank note in the list