### PR TITLE
Allow disabling of link detection

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1205,8 +1205,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
             getActivity().invalidateOptionsMenu();
 
-            SimplenoteLinkify.addLinks(mContentEditText, Linkify.ALL);
-
+            linkifyEditorContent();
             mIsLoadingNote = false;
         }
     }
@@ -1223,9 +1222,19 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         protected void onPostExecute(Void nada) {
             if (getActivity() != null && !getActivity().isFinishing()) {
                 // Update links
-                SimplenoteLinkify.addLinks(mContentEditText, Linkify.ALL);
+                linkifyEditorContent();
                 updateMarkdownView();
             }
+        }
+    }
+
+    private void linkifyEditorContent() {
+        if (getActivity() == null || getActivity().isFinishing()) {
+            return;
+        }
+
+        if (PrefUtils.getBoolPref(getActivity(), PrefUtils.PREF_DETECT_LINKS)) {
+            SimplenoteLinkify.addLinks(mContentEditText, Linkify.ALL);
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -30,6 +30,9 @@ public class PrefUtils {
     // int, preferred font size
     private static final String PREF_FONT_SIZE = "pref_key_font_size";
 
+    // boolean, determines linkifying content in the editor
+    public static final String PREF_DETECT_LINKS = "pref_key_detect_links";
+
     // boolean, set on first launch
     public static final String PREF_FIRST_LAUNCH = "pref_key_first_launch";
 

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -39,13 +39,11 @@
     <string name="note_selected">%d note selected</string>
     <string name="notes_selected">%d notes selected</string>
     <string name="note_added">Note added</string>
-    <string name="sort_order">Sort order</string>
     <string name="search">Search notes</string>
     <string name="notes">All Notes</string>
     <string name="trash">Trash</string>
     <string name="today">Today</string>
     <string name="yesterday">Yesterday</string>
-    <string name="condensed_note_list">Condensed note list</string>
     <string name="note_info">Info</string>
     <string name="tags">Tags</string>
     <string name="edit">Edit</string>
@@ -59,6 +57,13 @@
     <string name="markdown">Markdown</string>
     <string name="markdown_hide">Hide Markdown</string>
     <string name="markdown_show">Show Markdown</string>
+
+    <!-- Preferences -->
+    <string name="general">General</string>
+    <string name="editor">Editor</string>
+    <string name="condensed_note_list">Condensed note list</string>
+    <string name="sort_order">Sort order</string>
+    <string name="detect_links">Detect links</string>
 
     <!-- Undo -->
     <string name="undo">Undo</string>

--- a/Simplenote/src/main/res/xml/preferences.xml
+++ b/Simplenote/src/main/res/xml/preferences.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<android.support.v7.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory
         android:key="pref_key_note_preferences"
-        android:title="@string/settings">
+        android:title="@string/general">
 
         <SwitchPreferenceCompat
             android:defaultValue="false"
@@ -17,19 +17,28 @@
             android:summary="%s"
             android:title="@string/sort_order"/>
         <ListPreference
-            android:defaultValue="@integer/default_font_size"
-            android:entries="@array/array_font_size"
-            android:entryValues="@array/array_font_size_values"
-            android:key="pref_key_font_size"
-            android:summary="%s"
-            android:title="@string/font_size"/>
-        <ListPreference
             android:defaultValue="0"
             android:entries="@array/array_theme_names"
             android:entryValues="@array/array_theme_values"
             android:key="pref_key_theme"
             android:summary="%s"
             android:title="@string/theme"/>
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="pref_key_note_preferences"
+        android:title="@string/editor">
+        <ListPreference
+            android:defaultValue="@integer/default_font_size"
+            android:entries="@array/array_font_size"
+            android:entryValues="@array/array_font_size_values"
+            android:key="pref_key_font_size"
+            android:summary="%s"
+            android:title="@string/font_size"/>
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="pref_key_detect_links"
+            android:title="@string/detect_links"/>
     </PreferenceCategory>
 
     <PreferenceCategory
@@ -78,4 +87,4 @@
             android:title="@string/version"/>
     </PreferenceCategory>
 
-</PreferenceScreen>
+</android.support.v7.preference.PreferenceScreen>


### PR DESCRIPTION
This adds a new preference switch to disable linking content like urls, emails addresses, and phone numbers in the editor. I went for a simple solution here that simply disables all linking. A more advanced option could be to allow enabling/disabling of `Linkify` types individually.

I also added a new `Editor` preference group that houses the new preference as well as font size, and renamed the old `Settings` preference group to `General`.

**To Test**
 * Open the editor, observe that links and other content are linked properly.
 * Disabled the `Detect links` setting in the app preferences.
 * Return to the note editor, no links should appear.

Fixes #357.

