### PR TITLE
Fix stale note on resume

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -17,7 +17,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.view.ActionMode;
 import android.text.Editable;
 import android.text.Spanned;
-import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.text.style.RelativeSizeSpan;
 import android.text.style.URLSpan;
@@ -338,6 +337,14 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         if (mContentEditText != null) {
             mContentEditText.setTextSize(TypedValue.COMPLEX_UNIT_SP, PrefUtils.getFontSize(getActivity()));
+        }
+
+        // Sync all changes made on server since last pause. It allows the client to pick up the new
+        // changes immediately and also prevents the old note on the app from overwriting the newer
+        // note on the server.
+        if (mNote != null) {
+            new loadNoteTask().executeOnExecutor(
+                    AsyncTask.THREAD_POOL_EXECUTOR, mNote.getSimperiumKey());
         }
     }
 


### PR DESCRIPTION
Issue: Note is stale when app is resumed.

Step to reproduce:
1. Open a note and put it in the background.
2. Make change to the same note from web or other client
3. Bring the simplenote android app to the foreground.

Expected: New changes should appear.
Actual:   No change from the server. Editing note on Android will
          overwrite the server version.

This is because the app does not sync note from server on resume.

Changes:
- Runs loadNoteTask on resume.

Tested: Perform the above repro steps and get the expected behavior.