### PR TITLE
Stop note bucket on pause

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -343,7 +343,11 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     @Override
     public void onPause() {
+        super.onPause();  // Always call the superclass method first
+
         mNotesBucket.removeListener(this);
+        mNotesBucket.stop();
+
         // Hide soft keyboard if it is showing...
         if (getActivity() != null) {
             InputMethodManager inputMethodManager = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -368,8 +372,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         mHighlighter.stop();
         saveNote();
-
-        super.onPause();
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -229,13 +229,15 @@ public class NotesActivity extends AppCompatActivity implements
 
     @Override
     protected void onPause() {
-        super.onPause();
+        super.onPause();  // Always call the superclass method first
 
         mTagsBucket.removeListener(mTagsMenuUpdater);
+        mTagsBucket.stop();
 
         mNotesBucket.removeOnNetworkChangeListener(this);
         mNotesBucket.removeOnSaveObjectListener(this);
         mNotesBucket.removeOnDeleteObjectListener(this);
+        mNotesBucket.stop();
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
@@ -96,6 +96,9 @@ public class TagsListFragment extends ListFragment implements AdapterView.OnItem
         mTagsBucket.removeOnNetworkChangeListener(this);
         mTagsBucket.removeOnSaveObjectListener(this);
         mTagsBucket.removeOnDeleteObjectListener(this);
+
+        mNotesBucket.stop();
+        mTagsBucket.stop();
     }
 
     protected void refreshTags() {


### PR DESCRIPTION
Issue: Note is stale when app is resumed. New change on app will
overwrite the server version. There are duplicate issues opened.

- https://github.com/Automattic/simplenote-android/issues/350
- https://github.com/Automattic/simplenote-android/issues/290
- https://github.com/Automattic/simplenote-android/issues/243

Step to reproduce:

1. Open a note and put it in the background.
2. Make change to the same note from web or other client
3. Bring the simplenote android app to the foreground.

Expected: New changes should appear.
Actual:   No change from the server. Editing note on Android will
          overwrite the server version.

This is because the app does not sync note from server on resume.

Changes: Stop bucket on pause so that bucket could be started correctly
onResume.

Also see https://simperium.com/docs/reference/android/#bucket-stop,
> It's recommended to "stop" (typo on the actual web page) buckets in
> activities or fragments in the onPause() method.

Tested: Perform the above repro steps and get the expected behavior.