### PR TITLE
Update Simperium to Fix Case-Insensitive UTF Search

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -37,7 +37,7 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Automattic and WordPress dependencies
-    compile 'com.simperium.android:simperium:0.6.9'
+    compile 'com.simperium.android:simperium:0.7.0'
     compile 'com.automattic:tracks:1.1.0'
     compile 'org.wordpress:passcodelock:1.5.1'
     // Google Support


### PR DESCRIPTION
Fixes #278 

**To Test**
* Add some Capitalized UTF text to note, such as `Бабушка`.
* Search for the lower-case version of that word: `бабушка`.
* You should see the match in the search results. Other searches should work as usual.