### PR TITLE
Search: Fix within-word search using like query fallback

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -403,6 +403,13 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             query.include(new Query.FullTextSnippet(Note.MATCHED_TITLE_INDEX_NAME, Note.TITLE_INDEX_NAME));
             query.include(new Query.FullTextSnippet(Note.MATCHED_CONTENT_INDEX_NAME, Note.CONTENT_PROPERTY));
             query.include(Note.TITLE_INDEX_NAME, Note.CONTENT_PREVIEW_INDEX_NAME);
+
+            // Fall back to a 'LIKE' query if no full text results were found. See issue #463
+            if (query.execute().getCount() == 0) {
+                query = notesActivity.getSelectedTag().query();
+                query.where(Note.CONTENT_PROPERTY, Query.ComparisonType.LIKE, String.format("%%%s%%", mSearchString));
+                query.include(Note.TITLE_INDEX_NAME, Note.CONTENT_PREVIEW_INDEX_NAME);
+            }
         } else {
             query.include(Note.TITLE_INDEX_NAME, Note.CONTENT_PREVIEW_INDEX_NAME);
         }


### PR DESCRIPTION
The app uses Full Text Search, which works well for most use cases but doesn't work for searches within words. See #463.

I've fixed this by falling back to using a `LIKE` query if the full text search fails:

<img width="311" alt="screen shot 2018-09-06 at 2 26 20 pm" src="https://user-images.githubusercontent.com/789137/45186462-616c1a80-b1e2-11e8-985b-a2e08598cd3d.png">

**BUT**

This may cause some unexpected results for the user, because the full text search does nice stuff such as highlighting the search results and showing it in context, which we can't do for the LIKE query as far as I know:

<img width="312" alt="screen shot 2018-09-06 at 2 26 57 pm" src="https://user-images.githubusercontent.com/789137/45186506-8cef0500-b1e2-11e8-9c9d-b2cdfa91ede6.png">

So it may not be worth adding this based on the different experience you get when searching in certain scenarios. But it does help match up the search results with the other Simplenote apps, which all do a similar `LIKE` query.

Fixes #463.