### PR TITLE
Search: Scroll to first match in the note editor

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/MatchOffsetHighlighter.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/MatchOffsetHighlighter.java
@@ -15,6 +15,8 @@ import java.util.Scanner;
 public class MatchOffsetHighlighter implements Runnable {
 
     static public final String CHARSET = "UTF-8";
+    static private final int FIRST_MATCH_LOCATION = 2;
+
     protected static OnMatchListener sListener = new DefaultMatcher();
     private static List<Object> mMatchedSpans = Collections.synchronizedList(new ArrayList<>());
     private SpanFactory mFactory;
@@ -85,6 +87,24 @@ public class MatchOffsetHighlighter implements Runnable {
             listener.onMatch(factory, content, span_start, span_end);
 
         }
+    }
+
+    // Returns the character location of the first match (3rd index)
+    public static int getFirstMatchLocation(String matches) {
+        if (TextUtils.isEmpty(matches)) {
+            return 0;
+        }
+
+        String[] values = matches.split("\\s+", 4);
+        if (values.length > FIRST_MATCH_LOCATION) {
+            try {
+                return Integer.valueOf(values[FIRST_MATCH_LOCATION]);
+            } catch (NumberFormatException exception) {
+                return 0;
+            }
+        }
+
+        return 0;
     }
 
     // TODO: get ride of memory pressure by preventing the toString()

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/MatchOffsetHighlighter.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/MatchOffsetHighlighter.java
@@ -89,7 +89,9 @@ public class MatchOffsetHighlighter implements Runnable {
         }
     }
 
-    // Returns the character location of the first match (3rd index)
+    // Returns the character location of the first match (3rd index, the 'start' value)
+    // The data format for a match is 4 space-separated integers that represent the location
+    // of the match: "column token start length" ex: "1 0 42 7"
     public static int getFirstMatchLocation(String matches) {
         if (TextUtils.isEmpty(matches)) {
             return 0;


### PR DESCRIPTION
When loading a note after searching, the note editor will now attempt to scroll to the first match in the text:

![search-scroll](https://user-images.githubusercontent.com/789137/45231930-9cbe2600-b282-11e8-97fd-99b205d77e44.gif)

I was hoping this would be less code, but there's a few weird things with getting this to work:
1. You have to get the `layout` of the EditText, which could be null before the first layout pass. So I've added a `addOnGlobalLayoutListener()` which is where the scrolling code lives.
2. We use two layout files for `NoteEditorFragment`, one for small screens and another for large screens. The root scroll view is different in both of these files (`NestedScrollView` and `ScrollView`) so I had to do some goofy casting in order to use `smoothScrollTo`.

I also noticed #562 while testing this.

**To Test**
1. Add a note that has a lot of text, so the note editor needs to scroll.
2. Test searching for various words within the note. They should all be visible in the note editor when loaded.