### PR TITLE
Fix Search Highlighting in Note Editor

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -340,7 +340,10 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                     }
 
                     // Get the character location of the first search match
-                    int matchLocation = MatchOffsetHighlighter.getFirstMatchLocation(mMatchOffsets);
+                    int matchLocation = MatchOffsetHighlighter.getFirstMatchLocation(
+                            mContentEditText.getText(),
+                            mMatchOffsets
+                    );
                     if (matchLocation == 0) {
                         return;
                     }
@@ -348,8 +351,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                     // Calculate how far to scroll to bring the match into view
                     Layout layout = mContentEditText.getLayout();
                     int lineTop = layout.getLineTop(layout.getLineForOffset(matchLocation));
-                    lineTop -= DisplayUtils.getActionBarHeight(getActivity());
-                    lineTop -= getResources().getDimensionPixelSize(R.dimen.padding_large);
 
                     // We use different scroll views in the root of the layout files... yuck.
                     // So we have to cast appropriately to do a smooth scroll

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/MatchOffsetHighlighter.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/MatchOffsetHighlighter.java
@@ -117,7 +117,6 @@ public class MatchOffsetHighlighter implements Runnable {
     // indices and lengths in bytes. See: https://www.sqlite.org/fts3.html#offsets
     protected static int getByteOffset(CharSequence text, int start, int end) {
         String source = text.toString();
-
         byte[] sourceBytes = source.getBytes();
 
         String substring;


### PR DESCRIPTION
Beta testers who have been testing the search improvements have noticed that is quite easy to get #546 to occur. ~~I dug into this and discovered that the search match indices we get from sqlite were counting escape sequences such as `\n` as two characters. This would cause the highlighting to be off depending on how many escape sequences were in the note before the match.~~ The real bug was that we were note getting the correct substring in the `getByteOffset()` method, because we weren't getting the substring using the byte location of the match (which is what SQLite provides us in the FullTextSearch).

Also added fix for #562, which was simply a removal of a `length - 1` check when setting the span. It appears that you can set the span to the length of the string without a zero index and it will still work.

**To Test**
* Create a note that has line breaks and UTF-8 characters in it (like a cyrillic lorem ipsum).
* Return to the notes list and search for the term.
* Tapping the search result should be highlighted correctly.
* Now add a search term to the very end of a note, on its own line.
* Searching for this term should highlight at the very bottom of the note editor.