### PR TITLE
Add Tracks Opt-Out to Settings

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -1,14 +1,14 @@
 package com.automattic.simplenote;
 
 
-import android.content.DialogInterface;
-import android.content.SharedPreferences;
-import android.os.AsyncTask;
-import android.support.v7.app.AlertDialog;
 import android.app.Fragment;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceManager;
@@ -16,23 +16,33 @@ import android.widget.Toast;
 
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
+import com.automattic.simplenote.models.Preferences;
+import com.automattic.simplenote.utils.HtmlCompat;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.automattic.simplenote.utils.ThemeUtils;
 import com.simperium.Simperium;
 import com.simperium.android.LoginActivity;
 import com.simperium.client.Bucket;
+import com.simperium.client.BucketObjectMissingException;
+import com.simperium.client.BucketObjectNameInvalid;
 import com.simperium.client.User;
 import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
 import com.takisoft.fix.support.v7.preference.SwitchPreferenceCompat;
 
 import java.lang.ref.WeakReference;
 
+import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
+
 /**
  * A simple {@link Fragment} subclass.
  */
-public class PreferencesFragment extends PreferenceFragmentCompat implements User.StatusChangeListener, Simperium.OnUserCreatedListener {
+public class PreferencesFragment extends PreferenceFragmentCompat implements User.StatusChangeListener,
+        Simperium.OnUserCreatedListener {
 
     private static final String WEB_APP_URL = "https://app.simplenote.com";
+
+    private Bucket<Preferences> mPreferencesBucket;
+    private SwitchPreferenceCompat mAnalyticsSwitch;
 
     public PreferencesFragment() {
         // Required empty public constructor
@@ -49,10 +59,14 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
 
         Preference authenticatePreference = findPreference("pref_key_authenticate");
         Simplenote currentApp = (Simplenote) getActivity().getApplication();
-        currentApp.getSimperium().setUserStatusChangeListener(this);
-        currentApp.getSimperium().setOnUserCreatedListener(this);
+        Simperium simperium = currentApp.getSimperium();
+        simperium.setUserStatusChangeListener(this);
+        simperium.setOnUserCreatedListener(this);
+        mPreferencesBucket = currentApp.getPreferencesBucket();
+        mPreferencesBucket.start();
+
         authenticatePreference.setSummary(currentApp.getSimperium().getUser().getEmail());
-        if (currentApp.getSimperium().needsAuthorization()) {
+        if (simperium.needsAuthorization()) {
             authenticatePreference.setTitle(R.string.sign_in);
         } else {
             authenticatePreference.setTitle(R.string.sign_out);
@@ -154,6 +168,40 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
                 return true;
             }
         });
+
+        // Add the hyperlink to the analytics summary
+        Preference analyticsSummaryPreference = findPreference("pref_key_analytics_enabled_summary");
+        String formattedSummary = String.format(
+                getString(R.string.share_analytics_summary),
+                "<a href=\"https://automattic.com/cookies\">",
+                "</a>"
+        );
+        analyticsSummaryPreference.setSummary(HtmlCompat.fromHtml(formattedSummary));
+
+        mAnalyticsSwitch = (SwitchPreferenceCompat)findPreference("pref_key_analytics_switch");
+        mAnalyticsSwitch.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                try {
+                    boolean isChecked = (boolean)newValue;
+                    Preferences prefs = mPreferencesBucket.get(PREFERENCES_OBJECT_KEY);
+                    prefs.setAnalyticsEnabled(isChecked);
+                    prefs.save();
+                } catch (BucketObjectMissingException e) {
+                    e.printStackTrace();
+                }
+
+                return true;
+            }
+        });
+
+        updateAnalyticsSwitchState();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        mPreferencesBucket.stop();
     }
 
     private DialogInterface.OnClickListener signOutClickListener = new DialogInterface.OnClickListener() {
@@ -237,6 +285,22 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
                 AnalyticsTracker.CATEGORY_USER,
                 "account_created_from_preferences_activity"
         );
+    }
+
+    private void updateAnalyticsSwitchState() {
+        try {
+            Preferences preferences = mPreferencesBucket.get(PREFERENCES_OBJECT_KEY);
+            mAnalyticsSwitch.setChecked(preferences.getAnalyticsEnabled());
+        } catch (BucketObjectMissingException e) {
+            // The preferences object doesn't exist for this user yet, create it
+            try {
+                Preferences prefs = mPreferencesBucket.newObject(PREFERENCES_OBJECT_KEY);
+                prefs.setAnalyticsEnabled(true);
+                prefs.save();
+            } catch (BucketObjectNameInvalid bucketObjectNameInvalid) {
+                bucketObjectNameInvalid.printStackTrace();
+            }
+        }
     }
 
     private static class SignOutAsyncTask extends AsyncTask<Void, Void, Boolean> {

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -289,8 +289,8 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
 
     private void updateAnalyticsSwitchState() {
         try {
-            Preferences preferences = mPreferencesBucket.get(PREFERENCES_OBJECT_KEY);
-            mAnalyticsSwitch.setChecked(preferences.getAnalyticsEnabled());
+            Preferences prefs = mPreferencesBucket.get(PREFERENCES_OBJECT_KEY);
+            mAnalyticsSwitch.setChecked(prefs.getAnalyticsEnabled());
         } catch (BucketObjectMissingException e) {
             // The preferences object doesn't exist for this user yet, create it
             try {

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -235,10 +235,15 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
     private void signOut() {
         Simplenote application = (Simplenote) getActivity().getApplication();
         application.getSimperium().deauthorizeUser();
+
         application.getNotesBucket().reset();
         application.getTagsBucket().reset();
+        application.getPreferencesBucket().reset();
+
         application.getNotesBucket().stop();
         application.getTagsBucket().stop();
+        application.getPreferencesBucket().stop();
+
         AnalyticsTracker.track(
                 AnalyticsTracker.Stat.USER_SIGNED_OUT,
                 AnalyticsTracker.CATEGORY_USER,

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -14,16 +14,20 @@ import com.automattic.simplenote.analytics.AnalyticsTrackerNosara;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.NoteCountIndexer;
 import com.automattic.simplenote.models.NoteTagger;
+import com.automattic.simplenote.models.Preferences;
 import com.automattic.simplenote.models.Tag;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.crashlytics.android.Crashlytics;
 import com.simperium.Simperium;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketNameInvalid;
+import com.simperium.client.BucketObjectMissingException;
 
 import org.wordpress.passcodelock.AppLockManager;
 
 import io.fabric.sdk.android.Fabric;
+
+import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
 
 public class Simplenote extends Application {
 
@@ -41,6 +45,7 @@ public class Simplenote extends Application {
     private Simperium mSimperium;
     private Bucket<Note> mNotesBucket;
     private Bucket<Tag> mTagsBucket;
+    private static Bucket<Preferences> mPreferencesBucket;
 
     public void onCreate() {
         super.onCreate();
@@ -64,6 +69,7 @@ public class Simplenote extends Application {
             Tag.Schema tagSchema = new Tag.Schema();
             tagSchema.addIndex(new NoteCountIndexer(mNotesBucket));
             mTagsBucket = mSimperium.bucket(tagSchema);
+            mPreferencesBucket = mSimperium.bucket(new Preferences.Schema());
 
             // Every time a note changes or is deleted we need to reindex the tag counts
             mNotesBucket.addListener(new NoteTagger(mTagsBucket));
@@ -88,6 +94,19 @@ public class Simplenote extends Application {
         return PrefUtils.getBoolPref(this, PrefUtils.PREF_FIRST_LAUNCH, true);
     }
 
+    public static boolean analyticsIsEnabled() {
+        if (mPreferencesBucket == null) {
+            return true;
+        }
+
+        try {
+            Preferences Preferences = mPreferencesBucket.get(PREFERENCES_OBJECT_KEY);
+            return Preferences.getAnalyticsEnabled();
+        } catch (BucketObjectMissingException e) {
+            return true;
+        }
+    }
+
     public Simperium getSimperium() {
         return mSimperium;
     }
@@ -98,6 +117,10 @@ public class Simplenote extends Application {
 
     public Bucket<Tag> getTagsBucket() {
         return mTagsBucket;
+    }
+
+    public Bucket<Preferences> getPreferencesBucket() {
+        return mPreferencesBucket;
     }
 
     private class ApplicationLifecycleMonitor implements Application.ActivityLifecycleCallbacks,
@@ -123,6 +146,9 @@ public class Simplenote extends Application {
                         }
                         if (mTagsBucket != null) {
                             mTagsBucket.stop();
+                        }
+                        if (mPreferencesBucket != null) {
+                            mPreferencesBucket.stop();
                         }
                     }
                 }, TEN_SECONDS_MILLIS);

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -70,6 +70,7 @@ public class Simplenote extends Application {
             tagSchema.addIndex(new NoteCountIndexer(mNotesBucket));
             mTagsBucket = mSimperium.bucket(tagSchema);
             mPreferencesBucket = mSimperium.bucket(new Preferences.Schema());
+            mPreferencesBucket.start();
 
             // Every time a note changes or is deleted we need to reindex the tag counts
             mNotesBucket.addListener(new NoteTagger(mTagsBucket));

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -100,8 +100,8 @@ public class Simplenote extends Application {
         }
 
         try {
-            Preferences Preferences = mPreferencesBucket.get(PREFERENCES_OBJECT_KEY);
-            return Preferences.getAnalyticsEnabled();
+            Preferences prefs = mPreferencesBucket.get(PREFERENCES_OBJECT_KEY);
+            return prefs.getAnalyticsEnabled();
         } catch (BucketObjectMissingException e) {
             return true;
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
@@ -1,12 +1,14 @@
 package com.automattic.simplenote.analytics;
 
+import com.automattic.simplenote.Simplenote;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public final class AnalyticsTracker {
 
-    private static final List<Tracker> TRACKERS = new ArrayList<>();
+    private static List<Tracker> TRACKERS = new ArrayList<>();
     public static String CATEGORY_NOTE = "note";
     public static String CATEGORY_TAG = "tag";
     public static String CATEGORY_USER = "user";
@@ -21,36 +23,60 @@ public final class AnalyticsTracker {
     }
 
     public static void track(Stat stat, String category, String label) {
+        if (!Simplenote.analyticsIsEnabled()) {
+            return;
+        }
+
         for (Tracker tracker : TRACKERS) {
             tracker.track(stat, category, label, null);
         }
     }
 
     public static void track(Stat stat, String category, String label, Map<String, ?> properties) {
+        if (!Simplenote.analyticsIsEnabled()) {
+            return;
+        }
+
         for (Tracker tracker : TRACKERS) {
             tracker.track(stat, category, label, properties);
         }
     }
 
     public static void refreshMetadata(String username) {
+        if (!Simplenote.analyticsIsEnabled()) {
+            return;
+        }
+
         for (Tracker tracker : TRACKERS) {
             tracker.refreshMetadata(username);
         }
     }
 
     public static void flush() {
+        if (!Simplenote.analyticsIsEnabled()) {
+            return;
+        }
+
         for (Tracker tracker : TRACKERS) {
             tracker.flush();
         }
     }
 
     public void track(Stat stat) {
+        if (!Simplenote.analyticsIsEnabled()) {
+            return;
+        }
+
         for (Tracker tracker : TRACKERS) {
             tracker.track(stat, null, null);
         }
     }
 
     public void track(Stat stat, Map<String, ?> properties) {
+        if (!Simplenote.analyticsIsEnabled()) {
+            return;
+        }
+
         for (Tracker tracker : TRACKERS) {
             tracker.track(stat, null, null, properties);
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public final class AnalyticsTracker {
 
-    private static List<Tracker> TRACKERS = new ArrayList<>();
+    private static final List<Tracker> TRACKERS = new ArrayList<>();
     public static String CATEGORY_NOTE = "note";
     public static String CATEGORY_TAG = "tag";
     public static String CATEGORY_USER = "user";

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
@@ -1,0 +1,54 @@
+package com.automattic.simplenote.models;
+
+import com.simperium.client.BucketObject;
+import com.simperium.client.BucketSchema;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class Preferences extends BucketObject {
+    public static String PREFERENCES_OBJECT_KEY = "preferences-key";
+
+    private static final String BUCKET_NAME = "preferences";
+    private static final String ANALYTICS_ENABLED_KEY = "analytics_enabled";
+
+    private Preferences(String key, JSONObject properties) {
+        super(key, properties);
+    }
+
+    public boolean getAnalyticsEnabled() {
+        try {
+            return getProperties().getInt(ANALYTICS_ENABLED_KEY) > 0;
+        } catch (JSONException e) {
+            e.printStackTrace();
+            return true;
+        }
+    }
+
+    public void setAnalyticsEnabled(boolean enabled) {
+        try {
+            getProperties().put(ANALYTICS_ENABLED_KEY, enabled ? 1 : 0);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static class Schema extends BucketSchema<Preferences> {
+
+        public Schema() {
+            autoIndex();
+        }
+
+        public String getRemoteName() {
+            return BUCKET_NAME;
+        }
+
+        public Preferences build(String key, JSONObject properties) {
+            return new Preferences(key, properties);
+        }
+
+        public void update(Preferences Preferences, JSONObject properties) {
+            Preferences.setProperties(properties);
+        }
+    }
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
@@ -47,8 +47,8 @@ public class Preferences extends BucketObject {
             return new Preferences(key, properties);
         }
 
-        public void update(Preferences Preferences, JSONObject properties) {
-            Preferences.setProperties(properties);
+        public void update(Preferences prefs, JSONObject properties) {
+            prefs.setProperties(properties);
         }
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -53,6 +53,9 @@ public class PrefUtils {
     // string. WordPress.com access token
     public static final String PREF_WP_TOKEN = "pref_key_wp_token";
 
+    // boolean. determines if analytics is enabled
+    public static final String PREF_ANALYTICS_ENABLED = "pref_key_analytics_enabled";
+
     private static SharedPreferences getPrefs(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context);
     }

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -68,6 +68,8 @@
     <string name="condensed_note_list">Condensed note list</string>
     <string name="sort_order">Sort order</string>
     <string name="detect_links">Detect links</string>
+    <string name="share_analytics">Share analytics</string>
+    <string name="share_analytics_summary">Help us improve Simplenote by sharing usage data with our analytics tool. %1$sLearn more%2$s</string>
 
     <!-- Undo -->
     <string name="undo">Undo</string>

--- a/Simplenote/src/main/res/xml/preferences.xml
+++ b/Simplenote/src/main/res/xml/preferences.xml
@@ -65,14 +65,24 @@
         <Preference
             android:key="pref_key_authenticate"
             android:layout="@layout/auth_preference"/>
-        <!--<Preference
-                android:key="pref_key_billing"
-                android:persistent="false"
-                android:title="@string/premium_title" />-->
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="pref_key_account_preferences"
+        android:key="pref_key_privacy"
+        android:title="Privacy">
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="pref_key_analytics_switch"
+            android:title="@string/share_analytics" />
+        <Preference
+            android:key="pref_key_analytics_enabled_summary"
+            android:summary="@string/share_analytics_summary">
+            <intent android:action="android.intent.action.VIEW"
+                android:data="https://automattic.com/cookies" />
+        </Preference>
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/more_info">
         <Preference
             android:key="pref_key_about"


### PR DESCRIPTION
Adding tracks opt out setting using new `preferences` simperium bucket. 

**To Test**
* Flip the `Share analytics` switch to off in the settings.
* Verify that this method returns `false`: https://github.com/Automattic/simplenote-android/compare/add/558-tracks-opt-out?expand=1#diff-58aa35843c844af9f358fff48efda40bR97
* Switch it back to on, tracks events should resume sending.
* Tap the row with the `learn more` link in settings, it should load `https://automattic.com/cookies` in the browser.

Screenshot:
<img width="385" alt="screen shot 2018-09-19 at 11 31 06 am" src="https://user-images.githubusercontent.com/789137/45773562-852a5a00-bbff-11e8-9abc-9847e2aa81c9.png">

Fixes #558 