### PR TITLE
Save tracks opt-out property as a boolean

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
@@ -333,8 +333,10 @@ public class Note extends BucketObject {
         }
         if (deleted instanceof Boolean) {
             return (Boolean) deleted;
-        } else
+        } else {
+            // Simperium-iOS sets booleans as integer values (0 or 1)
             return deleted instanceof Number && ((Number) deleted).intValue() != 0;
+        }
     }
 
     public void setDeleted(boolean deleted) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
@@ -17,17 +17,22 @@ public class Preferences extends BucketObject {
     }
 
     public boolean getAnalyticsEnabled() {
-        try {
-            return getProperties().getInt(ANALYTICS_ENABLED_KEY) > 0;
-        } catch (JSONException e) {
-            e.printStackTrace();
+        Object isEnabled = getProperty(ANALYTICS_ENABLED_KEY);
+        if (isEnabled == null) {
             return true;
+        }
+
+        if (isEnabled instanceof Boolean) {
+            return (Boolean) isEnabled;
+        } else {
+            // Simperium-iOS sets booleans as integer values (0 or 1)
+            return isEnabled instanceof Integer && ((Integer) isEnabled) > 0;
         }
     }
 
     public void setAnalyticsEnabled(boolean enabled) {
         try {
-            getProperties().put(ANALYTICS_ENABLED_KEY, enabled ? 1 : 0);
+            getProperties().put(ANALYTICS_ENABLED_KEY, enabled);
         } catch (JSONException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Follow-up to #570, we discovered that iOS will always send a `0` or `1` for a boolean, and this won't be fixed anytime soon :)

I've updated to always send a boolean value (the proper way), but when we get the value we check for an int value just in case we are dealing with the value set from iOS. We were already doing something similar for the `Note` class' `deleted` property.

It's easiest to test that this works properly with an iOS device running https://github.com/Automattic/simplenote-ios/pull/228 and verifying that the setting syncs properly between platforms.