### PR TITLE
Fix Markdown Formatting in Landscape

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -43,6 +43,7 @@ import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
 import com.automattic.simplenote.utils.AutoBullet;
+import com.automattic.simplenote.utils.ContextUtils;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.MatchOffsetHighlighter;
@@ -303,10 +304,10 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
             switch (PrefUtils.getIntPref(getActivity(), PrefUtils.PREF_THEME, THEME_LIGHT)) {
                 case THEME_DARK:
-                    mCss = "<link rel=\"stylesheet\" type=\"text/css\" href=\"dark.css\" />";
+                    mCss = ContextUtils.readCssFile(getActivity(), "dark.css");
                     break;
                 case THEME_LIGHT:
-                    mCss = "<link rel=\"stylesheet\" type=\"text/css\" href=\"light.css\" />";
+                    mCss = ContextUtils.readCssFile(getActivity(), "light.css");
                     break;
             }
         }
@@ -547,8 +548,12 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     private void loadMarkdownData() {
-        mMarkdown.loadDataWithBaseURL("file:///android_asset/", mCss +
-                new AndDown().markdownToHtml(getNoteContentString()), "text/html", "utf-8", null);
+        String formattedContent = NoteMarkdownFragment.getMarkdownFormattedContent(
+                mCss,
+                getNoteContentString()
+        );
+
+        mMarkdown.loadDataWithBaseURL(null, formattedContent, "text/html", "utf-8", null);
     }
 
     public void setNote(String noteID, String matchOffsets) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -113,19 +113,23 @@ public class NoteMarkdownFragment extends Fragment {
     }
 
     public void updateMarkdown(String text) {
+        mMarkdown.loadDataWithBaseURL(null, getMarkdownFormattedContent(mCss, text), "text/html", "utf-8", null);
+    }
+
+    public static String getMarkdownFormattedContent(String cssContent, String sourceContent) {
         String header = "<html><head>" +
                 "<link href=\"https://fonts.googleapis.com/css?family=Noto+Serif\" rel=\"stylesheet\">" +
-                mCss + "</head><body>";
+                cssContent + "</head><body>";
 
         String parsedMarkdown = new AndDown().markdownToHtml(
-                text,
+                sourceContent,
                 AndDown.HOEDOWN_EXT_STRIKETHROUGH | AndDown.HOEDOWN_EXT_FENCED_CODE |
                         AndDown.HOEDOWN_EXT_QUOTE | AndDown.HOEDOWN_EXT_TABLES,
                 AndDown.HOEDOWN_HTML_ESCAPE
         );
-        String htmlContent = header + "<div class=\"note-detail-markdown\">" + parsedMarkdown +
+
+        return header + "<div class=\"note-detail-markdown\">" + parsedMarkdown +
                 "</div></body></html>";
-        mMarkdown.loadDataWithBaseURL(null, htmlContent, "text/html", "utf-8", null);
     }
 
     private class loadNoteTask extends AsyncTask<String, Void, Void> {


### PR DESCRIPTION
Fixes #555 by applying the same markdown formatting in landscape mode that we do in portrait. Looks like we missed in previous PRs that were applying the markdown formatting in two places. I've made a static method so that we can always run the same code from both places.

**To Test**
* Create some markdown in a note!
* Test it in landscape and portrait on a large screen device or emulator. The formatting should look the same in both modes:

<img width="549" alt="screen shot 2018-09-25 at 4 03 20 pm" src="https://user-images.githubusercontent.com/789137/46048244-3c7e0f80-c0dd-11e8-840a-db23b20f7887.png">
