### PR TITLE
Make Sure Activity is Still Active After loadNoteTask Finishes

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -162,7 +162,9 @@ public class NoteMarkdownFragment extends Fragment {
             mIsLoadingNote = false;
 
             if (mNote != null) {
-                getActivity().invalidateOptionsMenu();
+                if(getActivity() != null) {
+                    getActivity().invalidateOptionsMenu();
+                }
             }
         }
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -162,7 +162,7 @@ public class NoteMarkdownFragment extends Fragment {
             mIsLoadingNote = false;
 
             if (mNote != null) {
-                if(getActivity() != null) {
+                if (getActivity() != null) {
                     getActivity().invalidateOptionsMenu();
                 }
             }


### PR DESCRIPTION
Fixes #489 by making sure the activity is still active and preventing a NPE.