### PR TITLE
Added the option `Auto` to the themes to use the Dark theme when it is night and the Light one when it is daytime

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -30,7 +30,7 @@ public class ThemeUtils {
             if (data.getAuthority().equals(PREFERENCES_URI_AUTHORITY)) {
                 List<String> segments = data.getPathSegments();
 
-                // check if we have reched /preferences/theme
+                // check if we have reached /preferences/theme
                 if (segments.size() > 0 && segments.get(0).equals(URI_SEGMENT_THEME)) {
 
                     // activate the theme preference

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -7,8 +7,7 @@ import android.content.SharedPreferences;
 import android.graphics.Point;
 import android.net.Uri;
 import android.preference.PreferenceManager;
-
-import com.automattic.simplenote.R;
+import android.support.v7.app.AppCompatDelegate;
 
 import java.util.List;
 
@@ -16,8 +15,9 @@ public class ThemeUtils {
 
     // theme constants
     public static final int THEME_LIGHT = 0;
-    @SuppressWarnings("unused")
     public static final int THEME_DARK = 1;
+    @SuppressWarnings("unused")
+    public static final int THEME_AUTO = 2;
     static public final String PREFERENCES_URI_AUTHORITY = "preferences";
     static public final String URI_SEGMENT_THEME = "theme";
     public static String THEME_CHANGED_EXTRA = "themeChanged";
@@ -45,9 +45,11 @@ public class ThemeUtils {
 
         int theme = PrefUtils.getIntPref(activity, PrefUtils.PREF_THEME, THEME_LIGHT);
         if (theme == THEME_LIGHT)
-            activity.setTheme(R.style.Theme_Simplestyle);
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+        else if (theme == THEME_DARK)
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
         else
-            activity.setTheme(R.style.Theme_Simplestyle_Dark);
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
     }
 
     public static boolean isLightTheme(Context context) {

--- a/Simplenote/src/main/res/values-night/styles_simplestyle.xml
+++ b/Simplenote/src/main/res/values-night/styles_simplestyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Base.Theme.Simplestyle.Dark" parent="Theme.AppCompat.NoActionBar">
+    <style name="Base.Theme.Simplestyle" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Material theme -->
         <item name="colorPrimary">@color/simplenote_toolbar_dark</item>
         <item name="colorPrimaryDark">@color/black</item>
@@ -9,11 +9,11 @@
 
         <item name="windowActionModeOverlay">true</item>
         <item name="actionModeStyle">@style/ActionMode.Simplestyle</item>
-        <item name="drawerArrowStyle">@style/DrawerArrowStyle.Dark</item>
+        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
 
         <item name="android:actionBarItemBackground">@drawable/selectable_background_simplestyle
         </item>
-        <item name="android:popupMenuStyle">@style/PopupMenu.Simplestyle.Dark</item>
+        <item name="android:popupMenuStyle">@style/PopupMenu.Simplestyle</item>
         <item name="android:dropDownListViewStyle">@style/DropDownListView.Simplestyle</item>
         <item name="android:actionBarTabStyle">@style/ActionBarTabStyle.Simplestyle</item>
         <item name="android:spinnerDropDownItemStyle">@style/SpinnerDropDownItem.Simplestyle</item>
@@ -56,13 +56,14 @@
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 
-    <style name="Theme.Simplestyle.Dark" parent="Base.Theme.Simplestyle.Dark"/>
+    <style name="Theme.Simplestyle" parent="Base.Theme.Simplestyle"/>
 
-    <style name="DrawerArrowStyle.Dark" parent="DrawerArrowStyle">
+    <style name="DrawerArrowStyle" parent="Widget.AppCompat.DrawerArrowToggle">
+        <item name="spinBars">true</item>
         <item name="color">@color/simplenote_blue</item>
     </style>
 
-    <style name="PopupMenu.Simplestyle.Dark" parent="@android:style/Widget.Holo.ListPopupWindow">
+    <style name="PopupMenu.Simplestyle" parent="@android:style/Widget.Holo.ListPopupWindow">
         <item name="android:popupBackground">@drawable/menu_dropdown_panel_simplestyle_dark</item>
     </style>
 

--- a/Simplenote/src/main/res/values-v17/styles.xml
+++ b/Simplenote/src/main/res/values-v17/styles.xml
@@ -4,9 +4,4 @@
         <item name="android:listPreferredItemPaddingStart">16dp</item>
         <item name="android:listPreferredItemPaddingEnd">16dp</item>
     </style>
-
-    <style name="Theme.Simplestyle.Dark" parent="Base.Theme.Simplestyle.Dark">
-        <item name="android:listPreferredItemPaddingStart">16dp</item>
-        <item name="android:listPreferredItemPaddingEnd">16dp</item>
-    </style>
 </resources>

--- a/Simplenote/src/main/res/values-v21/styles.xml
+++ b/Simplenote/src/main/res/values-v21/styles.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.Simplestyle" parent="Base.Theme.Simplestyle"/>
-
-    <style name="Theme.Simplestyle.Dark" parent="Base.Theme.Simplestyle.Dark"/>
 </resources>

--- a/Simplenote/src/main/res/values/arrays.xml
+++ b/Simplenote/src/main/res/values/arrays.xml
@@ -28,7 +28,7 @@
     <string-array name="array_theme_values" translatable="false">
         <item>0</item>
         <item>1</item>
-        <item>-1</item>
+        <item>2</item>
     </string-array>
 
     <string-array name="array_font_size">

--- a/Simplenote/src/main/res/values/arrays.xml
+++ b/Simplenote/src/main/res/values/arrays.xml
@@ -22,11 +22,13 @@
     <string-array name="array_theme_names">
         <item>@string/theme_light</item>
         <item>@string/theme_dark</item>
+        <item>@string/theme_auto</item>
     </string-array>
 
     <string-array name="array_theme_values" translatable="false">
         <item>0</item>
         <item>1</item>
+        <item>-1</item>
     </string-array>
 
     <string-array name="array_font_size">

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -151,6 +151,7 @@
     <!-- Themes -->
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
+    <string name="theme_auto">Auto</string>
     <string name="theme">Theme</string>
     <string name="version">Version</string>
 

--- a/Simplenote/src/main/res/values/styles_simplestyle.xml
+++ b/Simplenote/src/main/res/values/styles_simplestyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Base.Theme.Simplestyle" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="Base.Theme.Simplestyle" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Material theme -->
         <item name="colorPrimary">@color/simplenote_toolbar_light</item>
         <item name="colorPrimaryDark">@color/lightgrey</item>


### PR DESCRIPTION
This is the implementation of feature #581 

Visual appearance of the themes are NOT tempered with. They are still the same as before. I only refactored their values for the `DayNight` theme to work out. No dramatic change of code is involved and the application can now determine when it is night and when it is daylight and according to that chooses the right theme (if `Auto` theme option is selected)

**P.S:** Although I've been developing for Android for a while, I am a little bit excited as this is my first *meaningful* open source contribution. I hope this little feature does not get shut down and that it actually makes it to release. Fingers crossed xD.

### Some References:
- https://medium.com/androiddevelopers/appcompat-v23-2-daynight-d10f90c83e94
- https://blog.iamsuleiman.com/daynight-theme-android-tutorial-example
- http://www.androidtutorialshub.com/android-daynight-theme-example-using-appcompat-support-library