### PR TITLE
Cleanup for misc inspection errors and warnings.

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'com.commonsware.cwac:anddown:0.4.0'
     implementation 'net.openid:appauth:0.7.0'
     implementation('com.crashlytics.sdk.android:crashlytics:2.9.5@aar') {
-        transitive = true;
+        transitive = true
     }
     implementation "com.android.support:customtabs:$googleVersion"
     implementation 'com.karumi:dexter:5.0.0'

--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -61,11 +61,13 @@
             android:windowSoftInputMode="stateHidden" />
 
         <!-- Passcode Unlock-->
+        <!--suppress AndroidDomInspection -->
         <activity
             android:name="org.wordpress.passcodelock.PasscodeUnlockActivity"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar"
             android:windowSoftInputMode="stateHidden" >
         </activity>
+        <!--suppress AndroidDomInspection -->
         <activity
             android:name="org.wordpress.passcodelock.PasscodeManagePasswordActivity"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar"

--- a/Simplenote/src/main/java/com/automattic/simplenote/AboutActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AboutActivity.java
@@ -20,7 +20,7 @@ public class AboutActivity extends AppCompatActivity {
 
         setTitle("");
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && toolbar != null) {
             toolbar.setElevation(0);
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -52,7 +52,7 @@ public class NoteEditorActivity extends AppCompatActivity {
         mNoteEditorFragmentPagerAdapter =
                 new NoteEditorFragmentPagerAdapter(getSupportFragmentManager());
         mViewPager = findViewById(R.id.pager);
-        mTabLayout = (TabLayout) findViewById(R.id.tabs);
+        mTabLayout = findViewById(R.id.tabs);
 
         Intent intent = getIntent();
         mNoteId = intent.getStringExtra(NoteEditorFragment.ARG_ITEM_ID);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -51,7 +51,7 @@ public class NoteEditorActivity extends AppCompatActivity {
 
         mNoteEditorFragmentPagerAdapter =
                 new NoteEditorFragmentPagerAdapter(getSupportFragmentManager());
-        mViewPager = (NoteEditorViewPager) findViewById(R.id.pager);
+        mViewPager = findViewById(R.id.pager);
         mTabLayout = (TabLayout) findViewById(R.id.tabs);
 
         Intent intent = getIntent();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -40,7 +40,7 @@ public class NoteEditorActivity extends AppCompatActivity {
         // No title, please.
         setTitle("");
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -285,11 +285,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mCallbacks = sCallbacks;
     }
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-    }
-
     public void setEmptyListMessage(String message) {
         if (mEmptyListTextView != null && message != null)
             mEmptyListTextView.setText(HtmlCompat.fromHtml(message));

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -272,7 +272,7 @@ public class NotesActivity extends AppCompatActivity implements
     }
 
     private void configureNavigationDrawer(Toolbar toolbar) {
-        mDrawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+        mDrawerLayout = findViewById(R.id.drawer_layout);
         mDrawerLayout.setDrawerShadow(R.drawable.drawer_shadow, GravityCompat.START);
         mNavigationView = (NavigationView) findViewById(R.id.navigation_view);
         mDrawerList = (ListView) findViewById(R.id.drawer_list);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -274,8 +274,8 @@ public class NotesActivity extends AppCompatActivity implements
     private void configureNavigationDrawer(Toolbar toolbar) {
         mDrawerLayout = findViewById(R.id.drawer_layout);
         mDrawerLayout.setDrawerShadow(R.drawable.drawer_shadow, GravityCompat.START);
-        mNavigationView = (NavigationView) findViewById(R.id.navigation_view);
-        mDrawerList = (ListView) findViewById(R.id.drawer_list);
+        mNavigationView = findViewById(R.id.navigation_view);
+        mDrawerList = findViewById(R.id.drawer_list);
 
         View settingsButton = findViewById(R.id.nav_settings);
         settingsButton.setOnClickListener(new View.OnClickListener() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -141,7 +141,7 @@ public class NotesActivity extends AppCompatActivity implements
             mTagsBucket = currentApp.getTagsBucket();
         }
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         configureNavigationDrawer(toolbar);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesActivity.java
@@ -30,7 +30,7 @@ public class PreferencesActivity extends AppCompatActivity {
 
         setContentView(R.layout.activity_preferences);
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
         setTitle(R.string.settings);

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -23,7 +23,7 @@ public class TagsActivity extends AppCompatActivity {
 
         setContentView(R.layout.activity_tags);
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
         SpannableString title = new SpannableString(getString(R.string.edit_tags));

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ContextUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ContextUtils.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+@SuppressWarnings("TryFinallyCanBeTryWithResources") // try with resources requires API 19+
 public class ContextUtils {
     public static String readCssFile(Context context, String css) {
         InputStream stream = null;

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ def gitHash() {
         return code.toString().trim()
     }
     catch (ignored) {
-        return "<unknown>";
+        return "<unknown>"
     }
 }
 


### PR DESCRIPTION
**This is partial cleanup** for task https://github.com/Automattic/simplenote-android/issues/564:
- Suppress warning in manifest for unresolved passcode activities
- Suppress Java 7 Try with Resources suggestion in `ContextUtils`
- Remove unneeded semicolons from gradle files
- Remove unneeded View casts in various activities/fragments.

**To Test:**
- Build and launch app
- Visit all major screens (Notes List, Note Editor, Tags, Preferences/Settings, About) and make sure there are no crashes.