### PR TITLE
Adding new setting that will sort the tags list alphabetically

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -435,7 +435,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
         if (notesActivity.getSelectedTag() != null && notesActivity.getSelectedTag().name != null) {
             String tagName = notesActivity.getSelectedTag().name;
-            if (!tagName.equals(getString(R.string.notes)) && !tagName.equals(getString(R.string.trash)) && !tagName.equals(getString(R.string.untagged_notes)))
+            if (!tagName.equals(getString(R.string.all_notes)) && !tagName.equals(getString(R.string.trash)) && !tagName.equals(getString(R.string.untagged_notes)))
                 note.setTagString(tagName);
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -379,7 +379,14 @@ public class NotesActivity extends AppCompatActivity implements
     }
 
     private void updateNavigationDrawerItems() {
-        Bucket.ObjectCursor<Tag> tagCursor = Tag.allWithCount(mTagsBucket).execute();
+        boolean isAlphaSort = PrefUtils.getBoolPref(this, PrefUtils.PREF_SORT_TAGS_ALPHA);
+        Bucket.ObjectCursor<Tag> tagCursor;
+        if (isAlphaSort) {
+            tagCursor = Tag.allSortedAlphabetically(mTagsBucket).execute();
+        } else {
+            tagCursor = Tag.allWithName(mTagsBucket).execute();
+        }
+
         mTagsAdapter.changeCursor(tagCursor);
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Tag.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Tag.java
@@ -12,6 +12,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class Tag extends BucketObject {
 
@@ -38,7 +39,8 @@ public class Tag extends BucketObject {
     }
 
     public static Query<Tag> allSortedAlphabetically(Bucket<Tag> bucket) {
-        return bucket.query().include(NAME_PROPERTY).order(NAME_PROPERTY, Query.SortType.ASCENDING);
+        String lowerCaseOrderBy = String.format(Locale.US, "LOWER(%s)", NAME_PROPERTY);
+        return bucket.query().include(NAME_PROPERTY).order(lowerCaseOrderBy);
     }
 
     public String getName() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Tag.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Tag.java
@@ -15,10 +15,10 @@ import java.util.List;
 
 public class Tag extends BucketObject {
 
-    public static final String BUCKET_NAME = "tag";
+    private static final String BUCKET_NAME = "tag";
     public static final String NOTE_COUNT_INDEX_NAME = "note_count";
     public static final String NAME_PROPERTY = "name";
-    public static final String INDEX_PROPERTY = "index";
+    private static final String INDEX_PROPERTY = "index";
     protected String name = "";
 
     public Tag(String key) {
@@ -33,8 +33,12 @@ public class Tag extends BucketObject {
         return bucket.query().order(INDEX_PROPERTY).orderByKey();
     }
 
-    public static Query<Tag> allWithCount(Bucket<Tag> bucket) {
-        return all(bucket).include(NAME_PROPERTY, NOTE_COUNT_INDEX_NAME);
+    public static Query<Tag> allWithName(Bucket<Tag> bucket) {
+        return all(bucket).include(NAME_PROPERTY);
+    }
+
+    public static Query<Tag> allSortedAlphabetically(Bucket<Tag> bucket) {
+        return bucket.query().include(NAME_PROPERTY).order(NAME_PROPERTY, Query.SortType.ASCENDING);
     }
 
     public String getName() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -23,6 +23,9 @@ public class PrefUtils {
     // boolean, determines # of preview lines
     public static final String PREF_CONDENSED_LIST = "pref_key_condensed_note_list";
 
+    // boolean, determines whether to sort the tags list alphabetically
+    public static final String PREF_SORT_TAGS_ALPHA = "pref_key_sort_tags_alpha";
+
     // boolean, determines whether dates are shown
     public static final String PREF_SHOW_DATES = "pref_key_show_dates";
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsAdapter.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsAdapter.java
@@ -26,21 +26,21 @@ import com.simperium.client.Query;
  */
 public class TagsAdapter extends BaseAdapter {
 
-    public static final String ID_COLUMN = "_id";
-    public static final long ALL_NOTES_ID = -1L;
-    public static final long TRASH_ID = -2L;
-    public static final long UNTAGGED_NOTES_ID = -3L;
+    private static final String ID_COLUMN = "_id";
+    private static final long ALL_NOTES_ID = -1L;
+    private static final long TRASH_ID = -2L;
+    private static final long UNTAGGED_NOTES_ID = -3L;
 
     public static final int DEFAULT_ITEM_POSITION = 0;
-    protected static final int[] topItems = {R.string.notes, R.string.trash};
-    protected static final int[] bottomItems = {R.string.untagged_notes};
-    protected Cursor mCursor;
-    protected Context mContext;
-    protected LayoutInflater mInflater;
-    protected Bucket<Note> mNotesBucket;
-    protected TagMenuItem mAllNotesItem;
-    protected TagMenuItem mTrashItem;
-    protected TagMenuItem mUntaggedNotesItem;
+    private static final int[] topItems = {R.string.all_notes, R.string.trash};
+    private static final int[] bottomItems = {R.string.untagged_notes};
+    private Cursor mCursor;
+    private Context mContext;
+    private LayoutInflater mInflater;
+    private Bucket<Note> mNotesBucket;
+    private TagMenuItem mAllNotesItem;
+    private TagMenuItem mTrashItem;
+    private TagMenuItem mUntaggedNotesItem;
     private int mNameColumn;
     private int mRowIdColumn;
     private int mTextColorId;
@@ -60,11 +60,11 @@ public class TagsAdapter extends BaseAdapter {
         mHeaderCount = headerCount;
     }
 
-    public TagsAdapter(Context context, Bucket<Note> notesBucket, Cursor cursor) {
+    private TagsAdapter(Context context, Bucket<Note> notesBucket, Cursor cursor) {
         mContext = context;
         mNotesBucket = notesBucket;
         mInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-        mAllNotesItem = new TagMenuItem(ALL_NOTES_ID, R.string.notes) {
+        mAllNotesItem = new TagMenuItem(ALL_NOTES_ID, R.string.all_notes) {
 
             @Override
             public Query<Note> query() {
@@ -96,7 +96,7 @@ public class TagsAdapter extends BaseAdapter {
         swapCursor(cursor);
     }
 
-    public Cursor swapCursor(Cursor cursor) {
+    private Cursor swapCursor(Cursor cursor) {
         Cursor oldCursor = mCursor;
         mCursor = cursor;
         if (mCursor != null) {

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -40,7 +40,7 @@
     <string name="notes_selected">%d notes selected</string>
     <string name="note_added">Note added</string>
     <string name="search">Search notes</string>
-    <string name="notes">All Notes</string>
+    <string name="notes">Notes</string>
     <string name="trash">Trash</string>
     <string name="untagged_notes">Untagged Notes</string>
     <string name="today">Today</string>
@@ -228,5 +228,8 @@
     <string name="wordpress_post_link">Share WordPress Post</string>
     <string name="could_not_access_site_data">Could not access site data.</string>
     <string name="empty_note_post">Can\'t post an empty note.</string>
+    <string name="sort_tags_alphabetically">Sort alphabetically</string>
+    <string name="appearance">Appearance</string>
+    <string name="all_notes">All Notes</string>
 
 </resources>

--- a/Simplenote/src/main/res/xml/preferences.xml
+++ b/Simplenote/src/main/res/xml/preferences.xml
@@ -3,7 +3,7 @@
 
     <PreferenceCategory
         android:key="pref_key_note_preferences"
-        android:title="@string/general">
+        android:title="@string/notes">
 
         <SwitchPreferenceCompat
             android:defaultValue="false"
@@ -16,6 +16,20 @@
             android:key="pref_key_sort_order"
             android:summary="%s"
             android:title="@string/sort_order"/>
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="pref_key_tags_preferences"
+        android:title="@string/tags">
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_key_sort_tags_alpha"
+            android:title="@string/sort_tags_alphabetically" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="pref_key_appearance_preferences"
+        android:title="@string/appearance">
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/array_theme_names"
@@ -23,8 +37,6 @@
             android:key="pref_key_theme"
             android:summary="%s"
             android:title="@string/theme"/>
-
-
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
A popular user request has been to sort the tags list alphabetically. I'm adding a new preference for just that! I also added a few more categories to the preferences in order to organize things a bit better:

![screenshot_1543363494](https://user-images.githubusercontent.com/789137/49119877-2288b680-f25f-11e8-924c-733fc6303e11.png)

I also fixed a few warnings near the code I was looking at while making this :)

**To Test**
* Enable the `Sort alphabetically` switch in the preferences. The tags in the app drawer should now be sorted alphabetically.
* Ensure other preferences still work, since they have been shuffled around a bit in this PR.