### PR TITLE
Issue/post wordpress dialog

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/WordPressDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/WordPressDialogFragment.java
@@ -105,6 +105,7 @@ public class WordPressDialogFragment extends AppCompatDialogFragment {
                 if (clipboard != null) {
                     ClipData clip = ClipData.newPlainText("Simplenote", mPostUrl);
                     clipboard.setPrimaryClip(clip);
+                    Toast.makeText(requireContext(), R.string.copied_to_clipboard, Toast.LENGTH_SHORT).show();
                 }
             }
         });

--- a/Simplenote/src/main/java/com/automattic/simplenote/WordPressDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/WordPressDialogFragment.java
@@ -105,7 +105,7 @@ public class WordPressDialogFragment extends AppCompatDialogFragment {
                 if (clipboard != null) {
                     ClipData clip = ClipData.newPlainText("Simplenote", mPostUrl);
                     clipboard.setPrimaryClip(clip);
-                    Toast.makeText(requireContext(), R.string.copied_to_clipboard, Toast.LENGTH_SHORT).show();
+                    Toast.makeText(requireContext(), R.string.link_copied, Toast.LENGTH_SHORT).show();
                 }
             }
         });

--- a/Simplenote/src/main/java/com/automattic/simplenote/WordPressDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/WordPressDialogFragment.java
@@ -63,8 +63,9 @@ public class WordPressDialogFragment extends AppCompatDialogFragment {
     private View mConnectSection, mPostingSection, mFieldsSection, mSuccessSection;
     private ListView mListView;
     private CheckBox mDraftCheckbox;
-    private TextView mPostUrlTextView;
+    private TextView mPostSuccessTextView;
     private Button mPostButton, mCancelButton;
+    private String mPostUrl;
 
     private JSONArray mSitesArray = new JSONArray();
     private Note mNote;
@@ -91,7 +92,7 @@ public class WordPressDialogFragment extends AppCompatDialogFragment {
 
         Button copyUrlButton = view.findViewById(R.id.wp_dialog_copy_url);
         Button shareUrlButton = view.findViewById(R.id.wp_dialog_share);
-        mPostUrlTextView = view.findViewById(R.id.wp_dialog_success_url);
+        mPostSuccessTextView = view.findViewById(R.id.wp_dialog_success_summary);
 
         copyUrlButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -102,7 +103,7 @@ public class WordPressDialogFragment extends AppCompatDialogFragment {
 
                 ClipboardManager clipboard = (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
                 if (clipboard != null) {
-                    ClipData clip = ClipData.newPlainText("Simplenote", mPostUrlTextView.getText());
+                    ClipData clip = ClipData.newPlainText("Simplenote", mPostUrl);
                     clipboard.setPrimaryClip(clip);
                 }
             }
@@ -117,7 +118,7 @@ public class WordPressDialogFragment extends AppCompatDialogFragment {
 
                 Intent share = new Intent(android.content.Intent.ACTION_SEND);
                 share.setType("text/plain");
-                share.putExtra(Intent.EXTRA_TEXT, mPostUrlTextView.getText());
+                share.putExtra(Intent.EXTRA_TEXT, mPostUrl);
 
                 startActivity(Intent.createChooser(share, getString(R.string.wordpress_post_link)));
             }
@@ -429,7 +430,8 @@ public class WordPressDialogFragment extends AppCompatDialogFragment {
                                     String responseString = response.body().string();
                                     JSONObject postResult = new JSONObject(responseString);
 
-                                    mPostUrlTextView.setText(postResult.getString(API_FIELD_URL));
+                                    mPostUrl = postResult.getString(API_FIELD_URL);
+                                    mPostSuccessTextView.setText(getString(R.string.success, mPostUrl));
                                     setDialogStatus(DialogStatus.SUCCESS);
 
                                     AnalyticsTracker.track(

--- a/Simplenote/src/main/java/com/automattic/simplenote/WordPressDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/WordPressDialogFragment.java
@@ -280,9 +280,8 @@ public class WordPressDialogFragment extends AppCompatDialogFragment {
         mPostingSection.setVisibility(status == DialogStatus.POSTING ? View.VISIBLE : View.GONE);
         mSuccessSection.setVisibility(status == DialogStatus.SUCCESS ? View.VISIBLE : View.GONE);
         mCancelButton.setVisibility(status == DialogStatus.FIELDS || status == DialogStatus.CONNECT ? View.VISIBLE : View.GONE);
+        mPostButton.setVisibility(status == DialogStatus.POSTING ? View.GONE : View.VISIBLE);
 
-        // Set state and text of the dialog positive button
-        mPostButton.setEnabled(!(status == DialogStatus.POSTING));
         if (status == DialogStatus.SUCCESS) {
             mPostButton.setText(R.string.done);
         } else if (status == DialogStatus.CONNECT) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/WordPressDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/WordPressDialogFragment.java
@@ -221,7 +221,7 @@ public class WordPressDialogFragment extends AppCompatDialogFragment {
                 JSONObject site = mSitesArray.getJSONObject(position);
                 Spanned rowText = Html.fromHtml(String.format(
                         Locale.ENGLISH,
-                        "<big>%s</big><br /><em>%s</em>",
+                        "%s<br/><small><span style=\"color:#899199\">%s</span></small>",
                         site.getString(API_FIELD_NAME),
                         site.getString(API_FIELD_URL)
                 ));

--- a/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
+++ b/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
@@ -98,8 +98,8 @@
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
         android:paddingBottom="@dimen/padding_large"
-        android:paddingLeft="24dp"
-        android:paddingRight="24dp"
+        android:paddingLeft="@dimen/padding_extra_extra_large"
+        android:paddingRight="@dimen/padding_extra_extra_large"
         android:paddingTop="@dimen/padding_large" >
 
         <TextView

--- a/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
+++ b/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
@@ -138,21 +138,24 @@
 
     <RelativeLayout
         android:id="@+id/wp_dialog_section_connect"
-        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingLeft="24dp"
-        android:paddingRight="24dp"
-        android:paddingTop="@dimen/padding_large"
-        android:orientation="vertical">
+        android:layout_width="match_parent"
+        android:paddingBottom="@dimen/padding_medium"
+        android:paddingEnd="@dimen/padding_extra_extra_large"
+        android:paddingLeft="@dimen/padding_extra_extra_large"
+        android:paddingRight="@dimen/padding_extra_extra_large"
+        android:paddingStart="@dimen/padding_extra_extra_large"
+        android:paddingTop="@dimen/padding_large" >
 
         <TextView
             android:id="@+id/wp_dialog_connect_summary"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/padding_medium"
             android:gravity="start"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
             android:text="@string/wordpress_connect_summary"
-            android:textColor="?attr/noteTitleColor" />
+            android:textColor="?attr/noteTitleColor" >
+        </TextView>
 
     </RelativeLayout>
+
 </LinearLayout>

--- a/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
+++ b/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
@@ -129,7 +129,7 @@
             android:layout_below="@id/wp_dialog_share"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"
-            android:text="@string/copy_url"
+            android:text="@string/copy"
             android:theme="@style/FlatButton.Simplestyle" >
         </android.support.v7.widget.AppCompatButton>
 

--- a/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
+++ b/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
@@ -94,63 +94,45 @@
 
     <RelativeLayout
         android:id="@+id/wp_dialog_section_success"
-        android:layout_width="match_parent"
+        android:layout_gravity="center_horizontal"
         android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:paddingBottom="@dimen/padding_large"
         android:paddingLeft="24dp"
         android:paddingRight="24dp"
-        android:paddingTop="@dimen/padding_large"
-        android:paddingBottom="@dimen/padding_large"
-        android:layout_gravity="center_horizontal">
+        android:paddingTop="@dimen/padding_large" >
 
         <TextView
             android:id="@+id/wp_dialog_success_summary"
-            android:layout_width="match_parent"
+            android:autoLink="web"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/padding_medium"
-            android:gravity="center_horizontal"
+            android:layout_width="match_parent"
             android:text="@string/success"
             android:textColor="?attr/noteTitleColor"
-            android:textSize="16sp" />
+            android:textSize="16sp" >
+        </TextView>
 
-        <TextView
-            android:id="@+id/wp_dialog_success_url"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/wp_dialog_share"
+            android:drawablePadding="@dimen/padding_extra_small"
             android:layout_below="@id/wp_dialog_success_summary"
-            android:layout_centerHorizontal="true"
-            android:layout_marginBottom="@dimen/padding_medium"
-            android:autoLink="web"
-            android:textSize="16sp" />
-
-        <LinearLayout
-            android:id="@+id/wp_dialog_share_buttons"
-            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/wp_dialog_success_url"
-            android:layout_centerHorizontal="true"
-            android:orientation="horizontal">
+            android:layout_width="wrap_content"
+            android:text="@string/share"
+            android:theme="@style/FlatButton.Simplestyle" >
+        </android.support.v7.widget.AppCompatButton>
 
-            <android.support.v7.widget.AppCompatButton
-                android:id="@+id/wp_dialog_share"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginEnd="@dimen/padding_extra_small"
-                android:layout_marginRight="@dimen/padding_extra_small"
-                android:drawablePadding="@dimen/padding_extra_small"
-                android:text="@string/share"
-                android:theme="@style/FlatButton.Simplestyle" />
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/wp_dialog_copy_url"
+            android:drawablePadding="@dimen/padding_extra_small"
+            android:layout_below="@id/wp_dialog_share"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:text="@string/copy_url"
+            android:theme="@style/FlatButton.Simplestyle" >
+        </android.support.v7.widget.AppCompatButton>
 
-            <android.support.v7.widget.AppCompatButton
-                android:id="@+id/wp_dialog_copy_url"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:drawablePadding="@dimen/padding_extra_small"
-                android:text="@string/copy_url"
-                android:theme="@style/FlatButton.Simplestyle" />
-
-        </LinearLayout>
     </RelativeLayout>
 
     <RelativeLayout

--- a/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
+++ b/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
@@ -59,31 +59,37 @@
 
     <LinearLayout
         android:id="@+id/wp_dialog_section_posting"
-        android:layout_width="match_parent"
+        android:layout_gravity="center_vertical"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:paddingLeft="24dp"
-        android:paddingRight="24dp"
-        android:paddingTop="@dimen/padding_large"
+        android:layout_width="match_parent"
+        android:orientation="horizontal"
         android:paddingBottom="@dimen/padding_large"
-        android:orientation="vertical"
-        android:visibility="gone">
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/padding_medium"
-            android:layout_marginBottom="@dimen/padding_medium"
-            android:gravity="center_horizontal"
-            android:text="@string/uploading_post"
-            android:textColor="?attr/noteTitleColor" />
+        android:paddingEnd="@dimen/padding_extra_extra_large"
+        android:paddingLeft="@dimen/padding_extra_extra_large"
+        android:paddingRight="@dimen/padding_extra_extra_large"
+        android:paddingStart="@dimen/padding_extra_extra_large"
+        android:paddingTop="@dimen/padding_large"
+        android:visibility="gone" >
 
         <ProgressBar
-            android:layout_width="match_parent"
+            android:indeterminate="true"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/padding_large"
-            android:gravity="center_horizontal"
-            android:indeterminate="true" />
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginRight="@dimen/padding_extra_extra_large"
+            android:layout_width="wrap_content" >
+        </ProgressBar>
+
+        <TextView
+            android:ellipsize="end"
+            android:layout_gravity="center_vertical"
+            android:layout_height="wrap_content"
+            android:layout_width="fill_parent"
+            android:maxLines="1"
+            android:text="@string/uploading_post"
+            android:textColor="?attr/noteTitleColor"
+            tools:ignore="RtlSymmetry" >
+        </TextView>
+
     </LinearLayout>
 
     <RelativeLayout

--- a/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
+++ b/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
@@ -1,49 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_width="match_parent"
+    android:orientation="vertical" >
 
     <LinearLayout
         android:id="@+id/wp_dialog_section_fields"
-        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_width="match_parent"
         android:orientation="vertical"
-        android:visibility="gone">
+        android:visibility="gone" >
 
         <ListView
             android:id="@+id/wp_dialog_list_view"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
             android:choiceMode="singleChoice"
             android:clipToPadding="false"
             android:divider="@null"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:layout_width="match_parent"
+            android:listSelector="@drawable/selectable_background_simplestyle"
             android:paddingLeft="@dimen/padding_extra_small"
             android:paddingRight="@dimen/padding_extra_small"
-            android:listSelector="@drawable/selectable_background_simplestyle"
-            android:paddingTop="@dimen/padding_medium" />
+            android:paddingTop="@dimen/padding_medium" >
+        </ListView>
 
         <LinearLayout
-            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_width="match_parent"
             android:orientation="horizontal"
-            android:padding="@dimen/padding_large">
+            android:padding="@dimen/padding_large" >
 
             <CheckBox
                 android:id="@+id/wp_dialog_draft_checkbox"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
                 android:layout_gravity="start|center_vertical"
+                android:layout_height="wrap_content"
+                android:layout_width="fill_parent"
+                android:paddingLeft="@dimen/padding_medium"
+                android:paddingStart="@dimen/padding_medium"
                 android:text="@string/wordpress_post_draft"
+                android:textColor="?attr/noteTitleColor"
                 android:textSize="16sp"
-                android:textColor="?attr/noteTitleColor" />
+                tools:ignore="RtlSymmetry" >
+            </CheckBox>
 
             <Space
                 android:layout_width="0dp"
                 android:layout_height="0dp"
-                android:layout_weight="1" />
+                android:layout_weight="1" >
+            </Space>
+
         </LinearLayout>
+
     </LinearLayout>
 
     <LinearLayout

--- a/Simplenote/src/main/res/layout/list_item_single_choice.xml
+++ b/Simplenote/src/main/res/layout/list_item_single_choice.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.AppCompatCheckedTextView xmlns:android="http://schemas.android.com/apk/res/android"
+
+<android.support.v7.widget.AppCompatCheckedTextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@android:id/text1"
-    android:layout_width="match_parent"
-    android:layout_height="?android:attr/listPreferredItemHeightSmall"
-    android:textAppearance="?android:attr/textAppearanceListItemSmall"
-    android:gravity="center_vertical"
     android:checkMark="@null"
-    android:drawableStart="?android:attr/listChoiceIndicatorSingle"
     android:drawableLeft="?android:attr/listChoiceIndicatorSingle"
-    android:paddingStart="@dimen/padding_medium"
+    android:drawablePadding="@dimen/padding_medium"
+    android:drawableStart="?android:attr/listChoiceIndicatorSingle"
+    android:gravity="center_vertical"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:lineSpacingExtra="4dp"
+    android:minHeight="?android:attr/listPreferredItemHeight"
     android:paddingEnd="@dimen/padding_medium"
     android:paddingLeft="@dimen/padding_medium"
-    android:paddingRight="@dimen/padding_medium" />
+    android:paddingRight="@dimen/padding_medium"
+    android:paddingStart="@dimen/padding_medium"
+    android:textColor="?attr/noteTitleColor"
+    android:textSize="18sp"
+    tools:text="Example Item" >
+</android.support.v7.widget.AppCompatCheckedTextView>

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -9,6 +9,7 @@
     <dimen name="padding_medium">12dp</dimen>
     <dimen name="padding_large">16dp</dimen>
     <dimen name="padding_extra_large">20dp</dimen>
+    <dimen name="padding_extra_extra_large">24dp</dimen>
 
     <!-- http://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-keylines-spacing -->
     <dimen name="nav_row_height">48dp</dimen>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -216,7 +216,6 @@
     <string name="wordpress_post_draft">Set status to draft</string>
     <string name="uploading_post">Uploading post</string>
     <string name="copy_url">Copy URL</string>
-    <string name="copied_to_clipboard">Copied to clipboard</string>
     <string name="success">Successfully posted note to: %1$s</string>
     <string name="done">Done</string>
     <string name="wordpress_connect_summary">To post a note directly to a WordPress site, connect your WordPress.com account.</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -216,7 +216,7 @@
     <string name="wordpress_post_draft">Set status to draft</string>
     <string name="uploading_post">Uploading post</string>
     <string name="copy_url">Copy URL</string>
-    <string name="success">Successfully posted to</string>
+    <string name="success">Successfully posted note to: %1$s</string>
     <string name="done">Done</string>
     <string name="wordpress_connect_summary">To post a note directly to a WordPress site, connect your WordPress.com account.</string>
     <string name="connect_with_wordpress">Connect</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -215,7 +215,6 @@
     <string name="send_post">Post</string>
     <string name="wordpress_post_draft">Set status to draft</string>
     <string name="uploading_post">Uploading post</string>
-    <string name="copy_url">Copy URL</string>
     <string name="success">Successfully posted note to: %1$s</string>
     <string name="done">Done</string>
     <string name="wordpress_connect_summary">To post a note directly to a WordPress site, connect your WordPress.com account.</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -216,6 +216,7 @@
     <string name="wordpress_post_draft">Set status to draft</string>
     <string name="uploading_post">Uploading post</string>
     <string name="copy_url">Copy URL</string>
+    <string name="copied_to_clipboard">Copied to clipboard</string>
     <string name="success">Successfully posted note to: %1$s</string>
     <string name="done">Done</string>
     <string name="wordpress_connect_summary">To post a note directly to a WordPress site, connect your WordPress.com account.</string>


### PR DESCRIPTION
### Fix
Update the ***Post to WordPress*** dialog layout with the following:
- site list view mimics notes list view
- posting progress view mimics default progress dialog view
- finished view uses left-align to move touch targets far from ***Done*** button.

See the screenshots below for illustration

![simplenote_ptw_post](https://user-images.githubusercontent.com/3827611/49181638-87a2e180-f31d-11e8-8b24-5e5f98b22f40.png)

![simplenote_ptw_progress](https://user-images.githubusercontent.com/3827611/49181645-8a053b80-f31d-11e8-85de-5e89f0c625d9.png)

![simplenote_ptw_done](https://user-images.githubusercontent.com/3827611/49181646-8bceff00-f31d-11e8-97c5-68b5d2751b4b.png)

### Test
1. Tap note in list.
2. Tap ***Share*** action in toolbar.
3. Tap ***Post to WordPress*** action in sheet.
4. Tap ***Connect*** button in dialog.
5. Tap ***Approve*** button in browser.
6. Notice list view in dialog as shown in screenshots above.
7. Tap ***Post*** button in dialog.
8. Notice progress view in dialog as shown in screenshots above.
9. Notice finished view in dialog as shown in screenshots above.