### PR TITLE
Fixing menu misaligned (#598)

### DIFF
--- a/Simplenote/src/main/res/layout/activity_notes.xml
+++ b/Simplenote/src/main/res/layout/activity_notes.xml
@@ -33,6 +33,7 @@
         android:id="@+id/navigation_view"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
+        android:fitsSystemWindows="false"
         android:layout_gravity="start">
 
         <LinearLayout


### PR DESCRIPTION
This commit fix the issue #598 

You can see prints of device with and without notch.

Print 1 - Device with notch
![image](https://user-images.githubusercontent.com/4356793/50054457-eb107a00-0139-11e9-9760-be8f4db07d20.png)

Print 2 - Device without notch
![image](https://user-images.githubusercontent.com/4356793/50054462-f368b500-0139-11e9-9795-62192f016a43.png)
