### PR TITLE
Bugs #615 and #616 Fixed

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -89,7 +90,9 @@ public class NoteEditorActivity extends AppCompatActivity {
                             if (position == 1) {
                                 final InputMethodManager imm = (InputMethodManager) getSystemService(
                                         Context.INPUT_METHOD_SERVICE);
-                                imm.hideSoftInputFromWindow(mViewPager.getWindowToken(), 0);
+                                if (imm != null) {
+                                    imm.hideSoftInputFromWindow(mViewPager.getWindowToken(), 0);
+                                }
                             }
                         }
 
@@ -183,7 +186,7 @@ public class NoteEditorActivity extends AppCompatActivity {
         private final ArrayList<Fragment> mFragments = new ArrayList<>();
         private final ArrayList<String> mTitles = new ArrayList<>();
 
-        public NoteEditorFragmentPagerAdapter(FragmentManager manager) {
+        NoteEditorFragmentPagerAdapter(FragmentManager manager) {
             super(manager);
         }
 
@@ -198,7 +201,7 @@ public class NoteEditorActivity extends AppCompatActivity {
         }
 
         @Override
-        public int getItemPosition(Object object) {
+        public int getItemPosition(@NonNull Object object) {
             return PagerAdapter.POSITION_NONE;
         }
 
@@ -207,7 +210,7 @@ public class NoteEditorActivity extends AppCompatActivity {
             return mTitles.get(position);
         }
 
-        public void addFragment(Fragment fragment, String title) {
+        void addFragment(Fragment fragment, String title) {
             mFragments.add(fragment);
             mTitles.add(title);
             notifyDataSetChanged();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -56,6 +56,7 @@ import com.automattic.simplenote.utils.SpaceTokenizer;
 import com.automattic.simplenote.utils.TagsMultiAutoCompleteTextView;
 import com.automattic.simplenote.utils.TagsMultiAutoCompleteTextView.OnTagAddedListener;
 import com.automattic.simplenote.utils.TextHighlighter;
+import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.widgets.SimplenoteEditText;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObjectMissingException;
@@ -76,8 +77,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     public static final String ARG_MATCH_OFFSETS = "match_offsets";
     public static final String ARG_MARKDOWN_ENABLED = "markdown_enabled";
     private static final String STATE_NOTE_ID = "state_note_id";
-    public static final int THEME_LIGHT = 0;
-    public static final int THEME_DARK = 1;
     private static final int AUTOSAVE_DELAY_MILLIS = 2000;
     private static final int MAX_REVISIONS = 30;
     private static final int PUBLISH_TIMEOUT = 20000;
@@ -302,15 +301,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             mPlaceholderView.setVisibility(View.VISIBLE);
             getActivity().invalidateOptionsMenu();
             mMarkdown = mRootView.findViewById(R.id.markdown);
-
-            switch (PrefUtils.getIntPref(getActivity(), PrefUtils.PREF_THEME, THEME_LIGHT)) {
-                case THEME_DARK:
-                    mCss = ContextUtils.readCssFile(getActivity(), "dark.css");
-                    break;
-                case THEME_LIGHT:
-                    mCss = ContextUtils.readCssFile(getActivity(), "light.css");
-                    break;
-            }
+            mCss = ThemeUtils.isLightTheme(requireContext())
+                    ? ContextUtils.readCssFile(requireContext(), "light.css")
+                    : ContextUtils.readCssFile(requireContext(), "dark.css");
         }
 
         mTagView.setAdapter(mAutocompleteAdapter);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -299,7 +299,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mPlaceholderView = mRootView.findViewById(R.id.placeholder);
         if (DisplayUtils.isLargeScreenLandscape(getActivity()) && mNote == null) {
             mPlaceholderView.setVisibility(View.VISIBLE);
-            getActivity().invalidateOptionsMenu();
+            requireActivity().invalidateOptionsMenu();
             mMarkdown = mRootView.findViewById(R.id.markdown);
             mCss = ThemeUtils.isLightTheme(requireContext())
                     ? ContextUtils.readCssFile(requireContext(), "light.css")

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -15,14 +15,12 @@ import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.utils.ContextUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.NoteUtils;
-import com.automattic.simplenote.utils.PrefUtils;
+import com.automattic.simplenote.utils.ThemeUtils;
 import com.commonsware.cwac.anddown.AndDown;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObjectMissingException;
 
 public class NoteMarkdownFragment extends Fragment {
-    public static final int THEME_LIGHT = 0;
-    public static final int THEME_DARK = 1;
     public static final String ARG_ITEM_ID = "item_id";
     private Note mNote;
     private String mCss;
@@ -56,26 +54,16 @@ public class NoteMarkdownFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         // Load note if we were passed an ID.
         Bundle arguments = getArguments();
-
         if (arguments != null && arguments.containsKey(ARG_ITEM_ID)) {
             String key = arguments.getString(ARG_ITEM_ID);
             new loadNoteTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, key);
         }
-
         setHasOptionsMenu(true);
-
+        mCss = ThemeUtils.isLightTheme(requireActivity())
+                ? ContextUtils.readCssFile(requireContext(), "light.css")
+                : ContextUtils.readCssFile(requireContext(), "dark.css");
         View layout = inflater.inflate(R.layout.fragment_note_markdown, container, false);
         mMarkdown = layout.findViewById(R.id.markdown);
-
-        switch (PrefUtils.getIntPref(getActivity(), PrefUtils.PREF_THEME, THEME_LIGHT)) {
-            case THEME_DARK:
-                mCss = ContextUtils.readCssFile(getActivity(), "dark.css");
-                break;
-            case THEME_LIGHT:
-                mCss = ContextUtils.readCssFile(getActivity(), "light.css");
-                break;
-        }
-
         return layout;
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -59,7 +59,7 @@ public class NoteMarkdownFragment extends Fragment {
             new loadNoteTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, key);
         }
         setHasOptionsMenu(true);
-        mCss = ThemeUtils.isLightTheme(requireActivity())
+        mCss = ThemeUtils.isLightTheme(requireContext())
                 ? ContextUtils.readCssFile(requireContext(), "light.css")
                 : ContextUtils.readCssFile(requireContext(), "dark.css");
         View layout = inflater.inflate(R.layout.fragment_note_markdown, container, false);

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.graphics.Point;
 import android.net.Uri;
 import android.preference.PreferenceManager;
@@ -53,8 +54,9 @@ public class ThemeUtils {
     }
 
     public static boolean isLightTheme(Context context) {
-        return context == null ||
-                PrefUtils.getIntPref(context, PrefUtils.PREF_THEME, THEME_LIGHT) == THEME_LIGHT;
+        int uiMode = context.getResources().getConfiguration().uiMode &
+                        Configuration.UI_MODE_NIGHT_MASK;
+        return uiMode != Configuration.UI_MODE_NIGHT_YES;
     }
 
     public static boolean themeWasChanged(Intent intent) {


### PR DESCRIPTION
There were two problems:
1- There was no case to what `css` file `NoteMarkdownFragment` should choose when `Dark at night only` theme is selected. This led to weird rendering of the Markdown preview including the `null` appearing at the top.
2- `isLightTheme()` method in `ThemeUtils` only checked the value in `SharedPreferences` and not the actual applied theme. If the value is `THEME_AUTO`, one cannot tell whether dark or light theme is chosen.

I fixed both problems by simplifying `isLightTheme()` method to only check the actual UI state (night mode or not, regardless of the value in `SharedPreferences`) which is simple and sufficient. I then swapped all the code instances that checks what theme is chosen with `ThemeUtils.isLightTheme(context)`. This ensures better and cleaner code as well as fixing the issue.

Check it out @roundhill. I believe this needs to be pushed to production asap.