### PR TITLE
Bugfix. Dark theme is now correctly applied in bottom sheets

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
@@ -10,6 +10,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.ImageButton;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.automattic.simplenote.models.Note;
@@ -30,11 +31,11 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
     private SwitchCompat mInfoPinSwitch;
     private SwitchCompat mInfoMarkdownSwitch;
     private ImageButton mCopyButton;
-    private ImageButton mShareButton;
+    private LinearLayout mShareButton;
     private Fragment mFragment;
 
     public InfoBottomSheetDialog(@NonNull Fragment fragment, @NonNull final InfoSheetListener infoSheetListener) {
-        super(fragment.getActivity());
+        super(fragment.requireActivity());
 
         mFragment = fragment;
 
@@ -95,7 +96,6 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
     }
 
     public void show(Note note) {
-
         if (mFragment.isAdded()) {
             String date = DateTimeUtils.getDateText(mFragment.getActivity(), note.getModificationDate());
             mInfoModifiedDate.setText(String.format(mFragment.getString(R.string.modified_time), date));

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
@@ -114,7 +115,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         public void run() {
             if (!isAdded()) return;
 
-            getActivity().runOnUiThread(new Runnable() {
+            requireActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
 
@@ -175,7 +176,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 case R.id.menu_copy:
                     if (mLinkText != null && getActivity() != null) {
                         copyToClipboard(mLinkText);
-                        Toast.makeText(getActivity(), getString(R.string.link_copied), Toast.LENGTH_SHORT).show();
+                        Toast.makeText(requireActivity(), getString(R.string.link_copied), Toast.LENGTH_SHORT).show();
                         mode.finish();
                     }
                     return true;
@@ -204,7 +205,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         public void run() {
             if (!isAdded()) return;
 
-            getActivity().runOnUiThread(new Runnable() {
+            requireActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
 
@@ -230,11 +231,12 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        mInfoBottomSheet = new InfoBottomSheetDialog(this, this);
+        mShareBottomSheet = new ShareBottomSheetDialog(this, this);
+        mHistoryBottomSheet = new HistoryBottomSheetDialog(this, this);
 
-        if (getActivity() != null) {
-            Simplenote currentApp = (Simplenote) getActivity().getApplication();
-            mNotesBucket = currentApp.getNotesBucket();
-        }
+        Simplenote currentApp = (Simplenote) requireActivity().getApplication();
+        mNotesBucket = currentApp.getNotesBucket();
 
         mCallIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_call_white_24dp, R.attr.actionModeTextColor);
         mEmailIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_email_white_24dp, R.attr.actionModeTextColor);
@@ -245,7 +247,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mPublishTimeoutHandler = new Handler();
         mHistoryTimeoutHandler = new Handler();
 
-        mMatchHighlighter = new TextHighlighter(getActivity(),
+        mMatchHighlighter = new TextHighlighter(requireActivity(),
                 R.attr.editorSearchHighlightForegroundColor, R.attr.editorSearchHighlightBackgroundColor);
         mAutocompleteAdapter = new CursorAdapter(getActivity(), null, 0x0) {
             @Override
@@ -285,15 +287,13 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        setHasOptionsMenu(true);
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         mRootView = inflater.inflate(R.layout.fragment_note_editor, container, false);
         mContentEditText = mRootView.findViewById(R.id.note_content);
         mContentEditText.addOnSelectionChangedListener(this);
         mTagView = mRootView.findViewById(R.id.tag_view);
         mTagView.setTokenizer(new SpaceTokenizer());
         mTagView.setOnFocusChangeListener(this);
-
         mHighlighter = new MatchOffsetHighlighter(mMatchHighlighter, mContentEditText);
 
         mPlaceholderView = mRootView.findViewById(R.id.placeholder);
@@ -359,7 +359,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 }
             }
         });
-
+        setHasOptionsMenu(true);
         return mRootView;
     }
 
@@ -410,7 +410,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
 
         if (DisplayUtils.isLargeScreenLandscape(getActivity()) && mNote != null) {
@@ -420,6 +420,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        super.onCreateOptionsMenu(menu, inflater);
         if (!isAdded() || DisplayUtils.isLargeScreenLandscape(getActivity()) && mNoteMarkdownFragment == null) {
             return;
         }
@@ -440,10 +441,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 trashItem.setIcon(R.drawable.ic_trash_24dp);
             }
         }
-
         DrawableUtils.tintMenuWithAttribute(getActivity(), menu, R.attr.actionBarTextColor);
-
-        super.onCreateOptionsMenu(menu, inflater);
     }
 
     @Override
@@ -464,7 +462,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 return true;
             case android.R.id.home:
                 if (!isAdded()) return false;
-                getActivity().finish();
+                requireActivity().finish();
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
@@ -473,7 +471,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     private void deleteNote() {
         NoteUtils.deleteNote(mNote, getActivity());
-        getActivity().finish();
+        requireActivity().finish();
     }
 
     protected void clearMarkdown() {
@@ -487,20 +485,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     protected void showMarkdown() {
         loadMarkdownData();
         mMarkdown.setVisibility(View.VISIBLE);
-    }
-
-    private void permanentlyDeleteNote() {
-        if (mNote == null) {
-            return;
-        }
-
-        // A note has to be 'trashed' first before it can be deleted forever
-        // setDeleted() sets a 'deleted' property to signify a note is in the trash
-        mNote.setDeleted(true);
-        mNote.save();
-
-        // delete() actually permanently deletes the note from Simperium
-        mNote.delete();
     }
 
     private void shareNote() {
@@ -1031,11 +1015,11 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             if (mNote.isPublished()) {
 
                 if (mIsUndoingPublishing) {
-                    SnackbarUtils.showSnackbar(getActivity(), R.string.publish_successful,
+                    SnackbarUtils.showSnackbar(requireActivity(), R.string.publish_successful,
                             R.color.simplenote_positive_green,
                             Snackbar.LENGTH_LONG);
                 } else {
-                    SnackbarUtils.showSnackbar(getActivity(), R.string.publish_successful,
+                    SnackbarUtils.showSnackbar(requireActivity(), R.string.publish_successful,
                             R.color.simplenote_positive_green,
                             Snackbar.LENGTH_LONG, R.string.undo, new View.OnClickListener() {
                                 @Override
@@ -1048,11 +1032,11 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 copyToClipboard(mNote.getPublishedUrl());
             } else {
                 if (mIsUndoingPublishing) {
-                    SnackbarUtils.showSnackbar(getActivity(), R.string.unpublish_successful,
+                    SnackbarUtils.showSnackbar(requireActivity(), R.string.unpublish_successful,
                             R.color.simplenote_negative_red,
                             Snackbar.LENGTH_LONG);
                 } else {
-                    SnackbarUtils.showSnackbar(getActivity(), R.string.unpublish_successful,
+                    SnackbarUtils.showSnackbar(requireActivity(), R.string.unpublish_successful,
                             R.color.simplenote_negative_red,
                             Snackbar.LENGTH_LONG, R.string.undo, new View.OnClickListener() {
                                 @Override
@@ -1065,10 +1049,10 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             }
         } else {
             if (mNote.isPublished()) {
-                SnackbarUtils.showSnackbar(getActivity(), R.string.unpublish_error,
+                SnackbarUtils.showSnackbar(requireActivity(), R.string.unpublish_error,
                         R.color.simplenote_negative_red, Snackbar.LENGTH_LONG);
             } else {
-                SnackbarUtils.showSnackbar(getActivity(), R.string.publish_error,
+                SnackbarUtils.showSnackbar(requireActivity(), R.string.publish_error,
                         R.color.simplenote_negative_red, Snackbar.LENGTH_LONG);
             }
         }
@@ -1079,7 +1063,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private void publishNote() {
 
         if (isAdded()) {
-            mPublishingSnackbar = SnackbarUtils.showSnackbar(getActivity(), R.string.publishing,
+            mPublishingSnackbar = SnackbarUtils.showSnackbar(requireActivity(), R.string.publishing,
                     R.color.simplenote_blue, Snackbar.LENGTH_INDEFINITE);
         }
         setPublishedNote(true);
@@ -1088,28 +1072,29 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private void unpublishNote() {
 
         if (isAdded()) {
-            mPublishingSnackbar = SnackbarUtils.showSnackbar(getActivity(), R.string.unpublishing,
+            mPublishingSnackbar = SnackbarUtils.showSnackbar(requireActivity(), R.string.unpublishing,
                     R.color.simplenote_blue, Snackbar.LENGTH_INDEFINITE);
         }
         setPublishedNote(false);
     }
 
     private void copyToClipboard(String text) {
-        ClipboardManager clipboard = (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
+        ClipboardManager clipboard = (ClipboardManager) requireActivity()
+                .getSystemService(Context.CLIPBOARD_SERVICE);
         ClipData clip = ClipData.newPlainText(getString(R.string.app_name), text);
-        clipboard.setPrimaryClip(clip);
+        if (clipboard != null) {
+            clipboard.setPrimaryClip(clip);
+        }
     }
 
     private void showShareSheet() {
         if (isAdded()) {
-            mShareBottomSheet = new ShareBottomSheetDialog(this, this);
             mShareBottomSheet.show(mNote);
         }
     }
 
     private void showInfoSheet() {
         if (isAdded()) {
-            mInfoBottomSheet = new InfoBottomSheetDialog(this, this);
             mInfoBottomSheet.show(mNote);
         }
 
@@ -1117,8 +1102,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     private void showHistorySheet() {
         if (isAdded()) {
-            mHistoryBottomSheet = new HistoryBottomSheetDialog(this, this);
-
             // Request revisions for the current note
             mNotesBucket.getRevisions(mNote, MAX_REVISIONS, mHistoryBottomSheet.getRevisionsRequestCallbacks());
             saveNote();
@@ -1275,7 +1258,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
             fragment.updateMarkdownView();
 
-            fragment.getActivity().invalidateOptionsMenu();
+            fragment.requireActivity().invalidateOptionsMenu();
 
             fragment.linkifyEditorContent();
             fragment.mIsLoadingNote = false;
@@ -1332,8 +1315,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         } else {
             // This fragment lives in the NoteEditorActivity's ViewPager.
             if (mNoteMarkdownFragment == null) {
-                mNoteMarkdownFragment = ((NoteEditorActivity) getActivity()).getNoteMarkdownFragment();
-                ((NoteEditorActivity) getActivity()).showTabs();
+                mNoteMarkdownFragment = ((NoteEditorActivity) requireActivity())
+                        .getNoteMarkdownFragment();
+                ((NoteEditorActivity) requireActivity()).showTabs();
             }
             // Load markdown in the sibling NoteMarkdownFragment's WebView.
             mNoteMarkdownFragment.updateMarkdown(getNoteContentString());

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -125,7 +125,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         getListView().setChoiceMode(ListView.CHOICE_MODE_MULTIPLE_MODAL);
         getListView().setItemChecked(position, true);
         if (mActionMode == null)
-            getActivity().startActionMode(this);
+            requireActivity().startActionMode(this);
         return true;
     }
 
@@ -187,7 +187,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mNotesAdapter = new NotesCursorAdapter(getActivity().getBaseContext(), null, 0);
+        mNotesAdapter = new NotesCursorAdapter(requireActivity().getBaseContext(), null, 0);
         setListAdapter(mNotesAdapter);
     }
 
@@ -204,10 +204,10 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     }
 
     @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        NotesActivity notesActivity = (NotesActivity) getActivity();
+        NotesActivity notesActivity = (NotesActivity) requireActivity();
 
         if (ACTION_NEW_NOTE.equals(notesActivity.getIntent().getAction()) &&
                 !notesActivity.userIsUnauthorized()){
@@ -315,7 +315,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         if (mActivatedPosition != ListView.INVALID_POSITION) {
             // Serialize and persist the activated item position.
@@ -385,7 +385,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     public ObjectCursor<Note> queryNotes() {
         if (!isAdded()) return null;
 
-        NotesActivity notesActivity = (NotesActivity) getActivity();
+        NotesActivity notesActivity = (NotesActivity) requireActivity();
         Query<Note> query = notesActivity.getSelectedTag().query();
 
         String searchString = mSearchString;
@@ -421,12 +421,12 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     public void addNote() {
 
         // Prevents jarring 'New note...' from showing in the list view when creating a new note
-        NotesActivity notesActivity = (NotesActivity) getActivity();
+        NotesActivity notesActivity = (NotesActivity) requireActivity();
         if (!DisplayUtils.isLargeScreenLandscape(notesActivity))
             notesActivity.stopListeningToNotesBucket();
 
         // Create & save new note
-        Simplenote simplenote = (Simplenote) getActivity().getApplication();
+        Simplenote simplenote = (Simplenote) requireActivity().getApplication();
         Bucket<Note> notesBucket = simplenote.getNotesBucket();
         final Note note = notesBucket.newObject();
         note.setCreationDate(Calendar.getInstance());
@@ -458,7 +458,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             Intent editNoteIntent = new Intent(getActivity(), NoteEditorActivity.class);
             editNoteIntent.putExtras(arguments);
 
-            getActivity().startActivityForResult(editNoteIntent, Simplenote.INTENT_EDIT_NOTE);
+            requireActivity().startActivityForResult(editNoteIntent, Simplenote.INTENT_EDIT_NOTE);
         }
     }
 
@@ -559,7 +559,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     public class NotesCursorAdapter extends CursorAdapter {
         private ObjectCursor<Note> mCursor;
 
-        private SearchSnippetFormatter.SpanFactory mSnippetHighlighter = new TextHighlighter(getActivity(),
+        private SearchSnippetFormatter.SpanFactory mSnippetHighlighter = new TextHighlighter(requireActivity(),
                 R.attr.listSearchHighlightForegroundColor, R.attr.listSearchHighlightBackgroundColor);
 
         public NotesCursorAdapter(Context context, ObjectCursor<Note> c, int flags) {
@@ -586,7 +586,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
             final NoteViewHolder holder;
             if (view == null) {
-                view = View.inflate(getActivity().getBaseContext(), R.layout.note_list_row, null);
+                view = View.inflate(requireActivity().getBaseContext(), R.layout.note_list_row, null);
                 holder = new NoteViewHolder();
                 holder.titleTextView = view.findViewById(R.id.note_title);
                 holder.contentTextView = view.findViewById(R.id.note_content);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -2,6 +2,7 @@ package com.automattic.simplenote;
 
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -51,7 +52,7 @@ public class NoteMarkdownFragment extends Fragment {
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         // Load note if we were passed an ID.
         Bundle arguments = getArguments();
         if (arguments != null && arguments.containsKey(ARG_ITEM_ID)) {
@@ -76,7 +77,7 @@ public class NoteMarkdownFragment extends Fragment {
                 return true;
             case android.R.id.home:
                 if (!isAdded()) return false;
-                getActivity().finish();
+                requireActivity().finish();
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
@@ -85,7 +86,7 @@ public class NoteMarkdownFragment extends Fragment {
 
     private void deleteNote() {
         NoteUtils.deleteNote(mNote, getActivity());
-        getActivity().finish();
+        requireActivity().finish();
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/ShareBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/ShareBottomSheetDialog.java
@@ -10,7 +10,6 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
 
@@ -37,15 +36,13 @@ public class ShareBottomSheetDialog extends BottomSheetDialogBase {
     private List<ShareButtonAdapter.ShareButtonItem> mShareButtons;
 
     public ShareBottomSheetDialog(@NonNull final Fragment fragment, @NonNull final ShareSheetListener shareSheetListener) {
-        super(fragment.getActivity());
-
+        super(fragment.requireActivity());
         mFragment = fragment;
-
-        View shareView = LayoutInflater.from(fragment.getActivity()).inflate(R.layout.bottom_sheet_share, null, false);
-        TextView mCollaborateButton = shareView.findViewById(R.id.share_collaborate_button);
-        mPublishButton = shareView.findViewById(R.id.share_publish_button);
-        mUnpublishButton = shareView.findViewById(R.id.share_unpublish_button);
-        mWordPressButton = shareView.findViewById(R.id.share_wp_post);
+        setContentView(R.layout.bottom_sheet_share);
+        TextView mCollaborateButton = findViewById(R.id.share_collaborate_button);
+        mPublishButton = findViewById(R.id.share_publish_button);
+        mUnpublishButton = findViewById(R.id.share_unpublish_button);
+        mWordPressButton = findViewById(R.id.share_wp_post);
 
         mCollaborateButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -75,14 +72,14 @@ public class ShareBottomSheetDialog extends BottomSheetDialogBase {
             }
         });
 
-        mRecyclerView = shareView.findViewById(R.id.share_button_recycler_view);
+        mRecyclerView = findViewById(R.id.share_button_recycler_view);
         mRecyclerView.setHasFixedSize(true);
-        mRecyclerView.setLayoutManager(new GridLayoutManager(fragment.getActivity(), SHARE_SHEET_COLUMN_COUNT));
+        mRecyclerView.setLayoutManager(new GridLayoutManager(fragment.requireActivity(), SHARE_SHEET_COLUMN_COUNT));
 
         mShareIntent = new Intent(Intent.ACTION_SEND);
         mShareIntent.setType("text/plain");
 
-        mShareButtons = getShareButtons(fragment.getActivity(), mShareIntent);
+        mShareButtons = getShareButtons(fragment.requireActivity(), mShareIntent);
 
         setOnDismissListener(new OnDismissListener() {
             @Override
@@ -90,12 +87,9 @@ public class ShareBottomSheetDialog extends BottomSheetDialogBase {
                 shareSheetListener.onShareDismissed();
             }
         });
-
-        setContentView(shareView);
     }
 
     public void show(Note note) {
-
         if (mFragment.isAdded()) {
             if (note.isPublished()) {
                 mPublishButton.setVisibility(View.GONE);
@@ -111,7 +105,7 @@ public class ShareBottomSheetDialog extends BottomSheetDialogBase {
                 @Override
                 public void onItemClick(ShareButtonAdapter.ShareButtonItem item) {
                     mShareIntent.setComponent(new ComponentName(item.getPackageName(), item.getActivityName()));
-                    mFragment.getActivity().startActivity(Intent.createChooser(mShareIntent, mFragment.getString(R.string.share)));
+                    mFragment.requireActivity().startActivity(Intent.createChooser(mShareIntent, mFragment.getString(R.string.share)));
                     dismiss();
                 }
             };
@@ -124,7 +118,6 @@ public class ShareBottomSheetDialog extends BottomSheetDialogBase {
 
     @NonNull
     private List<ShareButtonAdapter.ShareButtonItem> getShareButtons(Activity activity, Intent intent) {
-
         List<ShareButtonAdapter.ShareButtonItem> shareButtons = new ArrayList<>();
         final List<ResolveInfo> matches = activity.getPackageManager().queryIntentActivities(intent, 0);
         for (ResolveInfo match : matches) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ShareButtonAdapter.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ShareButtonAdapter.java
@@ -1,6 +1,7 @@
 package com.automattic.simplenote.utils;
 
 import android.graphics.drawable.Drawable;
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -24,14 +25,15 @@ public class ShareButtonAdapter extends RecyclerView.Adapter<ShareButtonAdapter.
         mListener = listener;
     }
 
+    @NonNull
     @Override
-    public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         return new ViewHolder(LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.share_button_item, parent, false));
     }
 
     @Override
-    public void onBindViewHolder(ViewHolder holder, int position) {
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         holder.setData(mItems.get(position));
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -15,17 +15,16 @@ import java.util.List;
 public class ThemeUtils {
 
     // theme constants
-    public static final int THEME_LIGHT = 0;
-    public static final int THEME_DARK = 1;
+    private static final int THEME_LIGHT = 0;
+    private static final int THEME_DARK = 1;
     @SuppressWarnings("unused")
     public static final int THEME_AUTO = 2;
-    static public final String PREFERENCES_URI_AUTHORITY = "preferences";
-    static public final String URI_SEGMENT_THEME = "theme";
-    public static String THEME_CHANGED_EXTRA = "themeChanged";
+    private static final String PREFERENCES_URI_AUTHORITY = "preferences";
+    private static final String URI_SEGMENT_THEME = "theme";
+    private static String THEME_CHANGED_EXTRA = "themeChanged";
 
     public static void setTheme(Activity activity) {
-
-        // if we have a data uri that sets the theme let's do it here
+            // if we have a data uri that sets the theme let's do it here
         Uri data = activity.getIntent().getData();
         if (data != null) {
             if (data.getAuthority().equals(PREFERENCES_URI_AUTHORITY)) {

--- a/Simplenote/src/main/res/layout-v21/bottom_sheet_history.xml
+++ b/Simplenote/src/main/res/layout-v21/bottom_sheet_history.xml
@@ -43,20 +43,20 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="start"
-            android:paddingBottom="@dimen/padding_extra_large"
-            android:paddingEnd="@dimen/padding_large"
-            android:paddingLeft="@dimen/padding_large"
-            android:paddingRight="@dimen/padding_large"
             android:paddingStart="@dimen/padding_large"
+            android:paddingLeft="@dimen/padding_large"
             android:paddingTop="@dimen/padding_extra_large"
+            android:paddingEnd="@dimen/padding_large"
+            android:paddingRight="@dimen/padding_large"
+            android:paddingBottom="@dimen/padding_extra_large"
             android:textSize="14sp"
-            tools:text="March 1, 2016 13:30"/>
+            tools:text="March 1, 2016 13:30" />
 
         <View
             android:id="@+id/info_divider"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:background="@color/divider_grey"/>
+            android:background="@color/divider_grey" />
 
         <SeekBar
             android:id="@+id/seek_bar"
@@ -64,17 +64,18 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/padding_extra_small"
             android:layout_marginRight="@dimen/padding_extra_small"
+            android:paddingTop="@dimen/padding_extra_large"
             android:paddingBottom="@dimen/padding_small"
-            android:paddingTop="@dimen/padding_extra_large" />
+            android:thumbTint="@color/simplenote_blue" />
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
             android:orientation="horizontal"
-            android:paddingBottom="@dimen/padding_small"
             android:paddingLeft="@dimen/padding_large"
-            android:paddingRight="@dimen/padding_large">
+            android:paddingRight="@dimen/padding_large"
+            android:paddingBottom="@dimen/padding_small">
 
             <com.automattic.simplenote.widgets.RobotoMediumTextView
                 android:id="@+id/cancel_history_button"
@@ -102,7 +103,7 @@
                 android:textAllCaps="true"
                 android:textColor="@color/simplenote_blue"
                 android:textSize="14sp"
-                android:textStyle="bold"/>
+                android:textStyle="bold" />
         </LinearLayout>
 
     </LinearLayout>

--- a/Simplenote/src/main/res/layout-v21/bottom_sheet_history.xml
+++ b/Simplenote/src/main/res/layout-v21/bottom_sheet_history.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    style="@style/Theme.Simplestyle.BottomSheetDialogText">
+    android:theme="@style/Theme.Simplestyle.BottomSheetDialog">
 
     <LinearLayout
         android:id="@+id/history_loading_view"

--- a/Simplenote/src/main/res/layout/bottom_sheet_history.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_history.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    style="@style/Theme.Simplestyle.BottomSheetDialogText">
+    android:theme="@style/Theme.Simplestyle.BottomSheetDialog">
 
     <LinearLayout
         android:id="@+id/history_loading_view"

--- a/Simplenote/src/main/res/layout/bottom_sheet_info.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_info.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    style="@style/Theme.Simplestyle.BottomSheetDialogText">
+    android:theme="@style/Theme.Simplestyle.BottomSheetDialog">
 
     <LinearLayout
         android:id="@+id/linearDateWordCountInfo"

--- a/Simplenote/src/main/res/layout/bottom_sheet_info.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_info.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:theme="@style/Theme.Simplestyle">
+    style="@style/Theme.Simplestyle.BottomSheetDialogText">
 
     <LinearLayout
         android:id="@+id/linearDateWordCountInfo"
@@ -24,8 +24,7 @@
             android:paddingRight="@dimen/padding_large"
             android:paddingStart="@dimen/padding_large"
             android:paddingTop="@dimen/padding_extra_large"
-            android:textColor="@color/grey"
-            tools:text="Modified Jan 1, 20015, 8:00AM" />
+            tools:text="Modified Jan 1, 2015, 8:00AM" />
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
             android:id="@+id/info_words_text"
@@ -40,7 +39,6 @@
             android:paddingRight="@dimen/padding_large"
             android:paddingStart="@dimen/padding_large"
             android:paddingTop="@dimen/padding_extra_large"
-            android:textColor="@color/grey"
             tools:text="101 words\n1010 characters" />
     </LinearLayout>
     <View
@@ -61,8 +59,7 @@
         android:paddingRight="@dimen/padding_large"
         android:paddingStart="@dimen/padding_large"
         android:paddingTop="@dimen/padding_extra_large"
-        android:text="@string/pin_to_top"
-        android:textColor="@color/simplenote_dark_grey"/>
+        android:text="@string/pin_to_top" />
 
     <android.support.v7.widget.SwitchCompat
         android:id="@+id/info_markdown_switch"
@@ -75,65 +72,50 @@
         android:paddingRight="@dimen/padding_large"
         android:paddingStart="@dimen/padding_large"
         android:paddingTop="@dimen/padding_extra_large"
-        android:text="@string/enable_markdown"
-        android:textColor="@color/simplenote_dark_grey"/>
+        android:text="@string/enable_markdown" />
 
-    <RelativeLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/info_markdown_switch"
-        android:paddingLeft="@dimen/padding_large"
-        android:paddingStart="@dimen/padding_large">
+        android:paddingStart="@dimen/padding_large"
+        android:paddingEnd="@dimen/padding_large">
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:id="@+id/info_share_button"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:orientation="vertical"
             android:paddingBottom="@dimen/padding_extra_large"
-            android:paddingTop="@dimen/padding_extra_large">
+            android:paddingTop="@dimen/padding_extra_large"
+            style="@style/Theme.Simplestyle.BottomSheetDialogText">
 
             <com.automattic.simplenote.widgets.RobotoRegularTextView
                 android:id="@+id/info_public_link_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/public_link"
-                android:textColor="@color/simplenote_dark_grey"
-                />
+                style="@style/Theme.Simplestyle.BottomSheetDialogText"/>
 
             <com.automattic.simplenote.widgets.RobotoRegularTextView
                 android:id="@+id/info_public_link_url"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@color/grey"
                 tools:text="http://simp.ly/publish/fsfjksjd"
-                />
+                style="@style/Theme.Simplestyle.BottomSheetDialogText"/>
         </LinearLayout>
 
         <ImageButton
             android:id="@+id/info_copy_link_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"
+            android:layout_gravity="center|end"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/copy"
             android:padding="@dimen/padding_large"
-            android:tint="@color/grey"
-            app:srcCompat="@drawable/ic_content_copy_white_24dp"/>
+            app:srcCompat="@drawable/ic_content_copy_white_24dp" />
 
-        <ImageButton
-            android:id="@+id/info_share_button"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/copy"
-            android:padding="@dimen/padding_large"
-            android:tint="@color/grey"/>
-
-    </RelativeLayout>
+    </LinearLayout>
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/layout/bottom_sheet_share.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_share.xml
@@ -2,7 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    style="@style/Theme.Simplestyle">
+    android:theme="@style/Theme.Simplestyle.BottomSheetDialog">
 
     <LinearLayout
         android:id="@+id/share_custom_buttons"

--- a/Simplenote/src/main/res/layout/bottom_sheet_share.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_share.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    style="@style/Theme.Simplestyle">
 
     <LinearLayout
         android:id="@+id/share_custom_buttons"
@@ -23,7 +24,7 @@
             android:drawableTop="@drawable/ic_collaborate_selector"
             android:gravity="center_horizontal"
             android:text="@string/collaborate"
-            android:textColor="@color/simplenote_dark_grey"/>
+            style="@style/Theme.Simplestyle.BottomSheetDialogText"/>
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
             android:id="@+id/share_publish_button"
@@ -35,7 +36,7 @@
             android:drawableTop="@drawable/ic_publish_selector"
             android:gravity="center_horizontal"
             android:text="@string/publish"
-            android:textColor="@color/simplenote_dark_grey"/>
+            style="@style/Theme.Simplestyle.BottomSheetDialogText"/>
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
             android:id="@+id/share_unpublish_button"
@@ -47,7 +48,7 @@
             android:drawableTop="@drawable/ic_unpublish_selector"
             android:gravity="center_horizontal"
             android:text="@string/unpublish"
-            android:textColor="@color/simplenote_dark_grey"/>
+            style="@style/Theme.Simplestyle.BottomSheetDialogText"/>
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
             android:id="@+id/share_wp_post"
@@ -59,7 +60,7 @@
             android:drawableTop="@drawable/ic_wordpress_post_selector"
             android:gravity="center_horizontal"
             android:text="@string/wordpress_post"
-            android:textColor="@color/simplenote_dark_grey"/>
+            style="@style/Theme.Simplestyle.BottomSheetDialogText"/>
     </LinearLayout>
 
     <View
@@ -73,6 +74,7 @@
         android:id="@+id/share_button_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/info_divider"/>
+        android:layout_below="@id/info_divider"
+        style="@style/Theme.Simplestyle.BottomSheetDialogText"/>
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/layout/share_button_item.xml
+++ b/Simplenote/src/main/res/layout/share_button_item.xml
@@ -13,6 +13,6 @@
         android:drawablePadding="@dimen/padding_small"
         android:gravity="center_horizontal"
         android:padding="@dimen/padding_large"
-        android:textColor="@color/simplenote_dark_grey"/>
+        style="@style/Theme.Simplestyle.BottomSheetDialogText"/>
 
 </FrameLayout>

--- a/Simplenote/src/main/res/values-night/styles_simplestyle.xml
+++ b/Simplenote/src/main/res/values-night/styles_simplestyle.xml
@@ -11,8 +11,7 @@
         <item name="actionModeStyle">@style/ActionMode.Simplestyle</item>
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
 
-        <item name="android:actionBarItemBackground">@drawable/selectable_background_simplestyle
-        </item>
+        <item name="android:actionBarItemBackground">@drawable/selectable_background_simplestyle</item>
         <item name="android:popupMenuStyle">@style/PopupMenu.Simplestyle</item>
         <item name="android:dropDownListViewStyle">@style/DropDownListView.Simplestyle</item>
         <item name="android:actionBarTabStyle">@style/ActionBarTabStyle.Simplestyle</item>
@@ -61,7 +60,14 @@
 
     <style name="Theme.Simplestyle" parent="Base.Theme.Simplestyle"/>
 
-    <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.Design.BottomSheetDialog">
+    <style name="Theme.Simplestyle.BottomSheetDialog" parent="Theme.Design.BottomSheetDialog">
+        <item name="colorPrimary">@color/simplenote_toolbar_dark</item>
+        <item name="colorPrimaryDark">@color/black</item>
+        <item name="colorAccent">@color/simplenote_blue</item>
+        <item name="android:background">?attr/mainBackgroundColor</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.Simplestyle.BottomSheetDialog">
         <item name="android:textColor">@color/white</item>
     </style>
 

--- a/Simplenote/src/main/res/values-night/styles_simplestyle.xml
+++ b/Simplenote/src/main/res/values-night/styles_simplestyle.xml
@@ -54,9 +54,16 @@
         <item name="editorSearchHighlightBackgroundColor">#FFB9C5CE</item>
 
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+
+        <item name="bottomSheetDialogTheme">@style/Theme.Design.BottomSheetDialog</item>
+        <item name="isLightTheme">false</item>
     </style>
 
     <style name="Theme.Simplestyle" parent="Base.Theme.Simplestyle"/>
+
+    <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.Design.BottomSheetDialog">
+        <item name="android:textColor">@color/white</item>
+    </style>
 
     <style name="DrawerArrowStyle" parent="Widget.AppCompat.DrawerArrowToggle">
         <item name="spinBars">true</item>

--- a/Simplenote/src/main/res/values/styles_simplestyle.xml
+++ b/Simplenote/src/main/res/values/styles_simplestyle.xml
@@ -12,8 +12,7 @@
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
         <item name="actionModeCloseDrawable">@drawable/ic_arrow_back_24dp</item>
 
-        <item name="android:actionBarItemBackground">@drawable/selectable_background_simplestyle
-        </item>
+        <item name="android:actionBarItemBackground">@drawable/selectable_background_simplestyle</item>
         <item name="android:popupMenuStyle">@style/PopupMenu.Simplestyle</item>
         <item name="android:dropDownListViewStyle">@style/DropDownListView.Simplestyle</item>
         <item name="android:actionBarTabStyle">@style/ActionBarTabStyle.Simplestyle</item>
@@ -64,6 +63,13 @@
     </style>
 
     <style name="Theme.Simplestyle" parent="Base.Theme.Simplestyle"/>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog" parent="Theme.Design.Light.BottomSheetDialog">
+        <item name="colorPrimary">@color/simplenote_toolbar_light</item>
+        <item name="colorPrimaryDark">@color/lightgrey</item>
+        <item name="colorAccent">@color/simplenote_blue</item>
+        <item name="android:background">?attr/mainBackgroundColor</item>
+    </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.Design.Light.BottomSheetDialog">
         <item name="android:textColor">@color/simplenote_dark_grey</item>

--- a/Simplenote/src/main/res/values/styles_simplestyle.xml
+++ b/Simplenote/src/main/res/values/styles_simplestyle.xml
@@ -65,6 +65,10 @@
 
     <style name="Theme.Simplestyle" parent="Base.Theme.Simplestyle"/>
 
+    <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.Design.Light.BottomSheetDialog">
+        <item name="android:textColor">@color/simplenote_dark_grey</item>
+    </style>
+
     <style name="DrawerArrowStyle" parent="Widget.AppCompat.DrawerArrowToggle">
         <item name="spinBars">true</item>
         <item name="color">@color/simplenote_blue</item>


### PR DESCRIPTION
However, this does not fix #613 and the `RecyclerView` showing the sharing app buttons displays incorrect text colors THE FIRST TIME ONLY, which is caused by the same issue in #613. For some reason, when the `NoteEditorActivity` is opened the first time in since opening the app, the app suddenly switches from night mode to day mode. I spent the whole day looking for the cause with no success.

The theming however is fixed and I believe can be safely merged. The slight bug remaining is a result of #613. After a lot of testing, I am confident that fixing #613 will also fix it here. But that is another issue for another day/night.

Here are the results in dark theme:

**Info Bottom Sheet**
![1](https://user-images.githubusercontent.com/18679771/50922804-a5e71b80-144b-11e9-9fb4-8ff6fe031c45.png)

**Share Bottom Sheet**
![2](https://user-images.githubusercontent.com/18679771/50922805-a67fb200-144b-11e9-9e28-c053bab528c9.png)

**History Bottom Sheet**
![3](https://user-images.githubusercontent.com/18679771/50922808-a7b0df00-144b-11e9-9c19-c7984eaae69c.png)

@roundhill The pull request comes also with many minor code quality improvements.
Cheers!
