### PR TITLE
Update Markdown Parser to Support Checklists

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -112,8 +112,10 @@ android {
 
 	lintOptions {
 	    checkReleaseBuilds false
+        
         // Flexmark library includes some Java packages that aren't in Android
         disable 'InvalidPackage'
+        disable 'DuplicatePlatformClasses'
 	}
 
     useLibrary 'org.apache.http.legacy'

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -108,9 +108,8 @@ android {
     }
 
     packagingOptions {
-        exclude 'META-INF/LICENSE-LGPL-3.txt'
-        exclude 'META-INF/DEPENDENCIES'
         exclude 'META-INF/LICENSE-LGPL-2.1.txt'
+        exclude 'META-INF/LICENSE-LGPL-3.txt'
         exclude 'META-INF/LICENSE-W3C-TEST'
     }
 

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -52,7 +52,11 @@ dependencies {
     // Third Party
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation 'com.takisoft.fix:preference-v7:27.1.1.1'
-    implementation 'com.vladsch.flexmark:flexmark-all:0.40.16'
+    implementation 'com.vladsch.flexmark:flexmark:0.40.16'
+    implementation 'com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:0.40.16'
+    implementation 'com.vladsch.flexmark:flexmark-ext-tables:0.40.16'
+    implementation 'com.vladsch.flexmark:flexmark-ext-gfm-tasklist:0.40.16'
+
     implementation 'net.openid:appauth:0.7.0'
     implementation('com.crashlytics.sdk.android:crashlytics:2.9.5@aar') {
         transitive = true

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -112,6 +112,8 @@ android {
 
 	lintOptions {
 	    checkReleaseBuilds false
+        // Flexmark library includes some Java packages that aren't in Android
+        disable 'InvalidPackage'
 	}
 
     useLibrary 'org.apache.http.legacy'

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     // Third Party
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation 'com.takisoft.fix:preference-v7:27.1.1.1'
-    implementation 'com.commonsware.cwac:anddown:0.4.0'
+    implementation 'com.vladsch.flexmark:flexmark-all:0.40.16'
     implementation 'net.openid:appauth:0.7.0'
     implementation('com.crashlytics.sdk.android:crashlytics:2.9.5@aar') {
         transitive = true
@@ -101,6 +101,13 @@ android {
         debug {
             applicationIdSuffix '.debug'
         }
+    }
+
+    packagingOptions {
+        exclude 'META-INF/LICENSE-LGPL-3.txt'
+        exclude 'META-INF/DEPENDENCIES'
+        exclude 'META-INF/LICENSE-LGPL-2.1.txt'
+        exclude 'META-INF/LICENSE-W3C-TEST'
     }
 
 	lintOptions {

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -112,10 +112,9 @@ android {
 
 	lintOptions {
 	    checkReleaseBuilds false
-        
+
         // Flexmark library includes some Java packages that aren't in Android
-        disable 'InvalidPackage'
-        disable 'DuplicatePlatformClasses'
+        disable 'InvalidPackage', 'DuplicatePlatformClasses'
 	}
 
     useLibrary 'org.apache.http.legacy'

--- a/Simplenote/proguard-rules.pro
+++ b/Simplenote/proguard-rules.pro
@@ -32,3 +32,8 @@
 
 # OkHttp platform used only on JVM and when Conscrypt dependency is available.
 -dontwarn okhttp3.internal.platform.ConscryptPlatform
+
+# Flexmark related classes
+-dontwarn java.awt.**
+-dontwarn javax.swing.**
+-dontwarn javax.imageio.**

--- a/Simplenote/proguard-rules.pro
+++ b/Simplenote/proguard-rules.pro
@@ -37,3 +37,4 @@
 -dontwarn java.awt.**
 -dontwarn javax.swing.**
 -dontwarn javax.imageio.**
+-dontwarn sun.misc.**

--- a/Simplenote/src/main/assets/dark.css
+++ b/Simplenote/src/main/assets/dark.css
@@ -174,6 +174,13 @@ html {
     font-weight: 600;
 }
 
+.note-detail-markdown li.task-list-item {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    margin-left: -2em;
+}
+
 @media only screen and (max-width: 480px) {
     .note-detail-markdown {
         font-size: 16px;

--- a/Simplenote/src/main/assets/light.css
+++ b/Simplenote/src/main/assets/light.css
@@ -174,6 +174,13 @@ html {
     font-weight: 600;
 }
 
+.note-detail-markdown li.task-list-item {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    margin-left: -2em;
+}
+
 @media only screen and (max-width: 480px) {
     .note-detail-markdown {
         font-size: 16px;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -17,9 +17,17 @@ import com.automattic.simplenote.utils.ContextUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.NoteUtils;
 import com.automattic.simplenote.utils.ThemeUtils;
-import com.commonsware.cwac.anddown.AndDown;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObjectMissingException;
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;
+import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.ast.Node;
+import com.vladsch.flexmark.util.options.MutableDataSet;
+
+import java.util.Arrays;
 
 public class NoteMarkdownFragment extends Fragment {
     public static final String ARG_ITEM_ID = "item_id";
@@ -110,14 +118,22 @@ public class NoteMarkdownFragment extends Fragment {
                 "<link href=\"https://fonts.googleapis.com/css?family=Noto+Serif\" rel=\"stylesheet\">" +
                 cssContent + "</head><body>";
 
-        String parsedMarkdown = new AndDown().markdownToHtml(
-                sourceContent,
-                AndDown.HOEDOWN_EXT_STRIKETHROUGH | AndDown.HOEDOWN_EXT_FENCED_CODE |
-                        AndDown.HOEDOWN_EXT_QUOTE | AndDown.HOEDOWN_EXT_TABLES,
-                AndDown.HOEDOWN_HTML_ESCAPE
-        );
+        MutableDataSet options = new MutableDataSet();
+        options.set(Parser.EXTENSIONS, Arrays.asList(
+                StrikethroughExtension.create(),
+                TablesExtension.create(),
+                TaskListExtension.create()
+        ));
 
-        return header + "<div class=\"note-detail-markdown\">" + parsedMarkdown +
+        Parser parser = Parser.builder(options).build();
+        HtmlRenderer renderer = HtmlRenderer.builder(options).escapeHtml(true).build();
+
+        Node document = parser.parse(sourceContent);
+        String parsedMarkdown = renderer.render(document);
+
+        return header +
+                "<div class=\"note-detail-markdown\">" +
+                parsedMarkdown +
                 "</div></body></html>";
     }
 


### PR DESCRIPTION
This PR fixes the issue described in #608 where checklists would not render properly in the Markdown preview:

<img width="113" alt="screen shot 2019-01-29 at 4 06 39 pm" src="https://user-images.githubusercontent.com/789137/51949365-2365d200-23e1-11e9-8369-19b0c6fe5e1f.png">

I achieved this by replacing the `AndDown` library we were previously using to parse markdown with [Flexmark](https://github.com/vsch/flexmark-java), which supports many more markdown formatting options, including task lists.

Unfortunately it doesn't seem to support rendering nested checklists, because indented text gets placed in code blocks:

<img width="297" alt="screen shot 2019-01-29 at 4 10 41 pm" src="https://user-images.githubusercontent.com/789137/51949421-5a3be800-23e1-11e9-8660-3c7498a08e2e.png">

**To Test**
* Create a Markdown formatted note that includes checklists. They should render in the markdown preview as disabled checkboxes.
* Ensure that the Markdown preview still works as it did previously (tables, quotes, etc).
* HTML added to a note should be escaped in the markdown preview (like `<input type="text" />`)
* Javascript `<script>` tags should also be escaped.