### PR TITLE
Fix arrow key navigation in note editor

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     wearApp project(':Wear')
 }
 
-version "1.6.8"
+version "1.6.9"
 
 android {
     testOptions {
@@ -75,7 +75,7 @@ android {
     defaultConfig {
         applicationId "com.automattic.simplenote"
         versionName project.version
-        versionCode 71
+        versionCode 72
         minSdkVersion 16
         targetSdkVersion 27
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -72,7 +72,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         SimplenoteEditText.OnSelectionChangedListener,
         ShareBottomSheetDialog.ShareSheetListener,
         HistoryBottomSheetDialog.HistorySheetListener,
-        InfoBottomSheetDialog.InfoSheetListener {
+        InfoBottomSheetDialog.InfoSheetListener,
+        SimplenoteEditText.OnCheckboxToggledListener {
 
     public static final String ARG_ITEM_ID = "item_id";
     public static final String ARG_NEW_NOTE = "new_note";
@@ -292,6 +293,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mRootView = inflater.inflate(R.layout.fragment_note_editor, container, false);
         mContentEditText = mRootView.findViewById(R.id.note_content);
         mContentEditText.addOnSelectionChangedListener(this);
+        mContentEditText.setOnCheckboxToggledListener(this);
         mContentEditText.setMovementMethod(SimplenoteMovementMethod.getInstance());
         mTagView = mRootView.findViewById(R.id.tag_view);
         mTagView.setTokenizer(new SpaceTokenizer());
@@ -482,6 +484,15 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 AnalyticsTracker.CATEGORY_NOTE,
                 "toolbar_button"
         );
+    }
+
+    @Override
+    public void onCheckboxToggled() {
+        // Save note (using delay) after toggling a checkbox
+        if (mAutoSaveHandler != null) {
+            mAutoSaveHandler.removeCallbacks(mAutoSaveRunnable);
+            mAutoSaveHandler.postDelayed(mAutoSaveRunnable, AUTOSAVE_DELAY_MILLIS);
+        }
     }
 
     private void deleteNote() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -616,6 +616,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         // 4. Text was removed before the cursor ==> location retreats
         // 5. Text was added/removed on both sides of the cursor ==> not handled
 
+        cursorLocation = Math.max(cursorLocation, 0);
+
         int newCursorLocation = cursorLocation;
 
         int deltaLength = newText.length() - oldText.length();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -672,16 +672,10 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     @Override
-    public void afterTextChanged(Editable editable) {
+    public void afterTextChanged(final Editable editable) {
         attemptAutoList(editable);
         setTitleSpan(editable);
-
-        // Prevents line heights from compacting
-        // https://issuetracker.google.com/issues/37009353
-        float lineSpacingExtra = mContentEditText.getLineSpacingExtra();
-        float lineSpacingMultiplier = mContentEditText.getLineSpacingMultiplier();
-        mContentEditText.setLineSpacing(0.0f, 1.0f);
-        mContentEditText.setLineSpacing(lineSpacingExtra, lineSpacingMultiplier);
+        mContentEditText.fixLineSpacing();
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -672,7 +672,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     @Override
-    public void afterTextChanged(final Editable editable) {
+    public void afterTextChanged(Editable editable) {
         attemptAutoList(editable);
         setTitleSpan(editable);
         mContentEditText.fixLineSpacing();

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SimplenoteMovementMethod.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SimplenoteMovementMethod.java
@@ -1,29 +1,23 @@
 package com.automattic.simplenote.utils;
 
 import android.text.Layout;
-import android.text.NoCopySpan;
 import android.text.Selection;
 import android.text.Spannable;
 import android.text.method.ArrowKeyMovementMethod;
 import android.view.MotionEvent;
-import android.view.View;
 import android.widget.TextView;
 
 import com.automattic.simplenote.widgets.CheckableSpan;
 
 // Only allows onClick events for CheckableSpans
 public class SimplenoteMovementMethod extends ArrowKeyMovementMethod {
+
     private static SimplenoteMovementMethod mInstance;
 
     public static SimplenoteMovementMethod getInstance() {
         if (mInstance == null)
             mInstance = new SimplenoteMovementMethod();
         return mInstance;
-    }
-
-    @Override
-    public boolean canSelectArbitrarily() {
-        return true;
     }
 
     @Override
@@ -63,22 +57,4 @@ public class SimplenoteMovementMethod extends ArrowKeyMovementMethod {
 
         return false;
     }
-
-    // Borrowed from LinkMovementMethod
-    @Override
-    public void initialize(TextView widget, Spannable text) {
-        Selection.removeSelection(text);
-        text.removeSpan(FROM_BELOW);
-    }
-    @Override
-    public void onTakeFocus(TextView view, Spannable text, int dir) {
-        Selection.removeSelection(text);
-        if ((dir & View.FOCUS_BACKWARD) != 0) {
-            text.setSpan(FROM_BELOW, 0, 0, Spannable.SPAN_POINT_POINT);
-        } else {
-            text.removeSpan(FROM_BELOW);
-        }
-    }
-
-    private static Object FROM_BELOW = new NoCopySpan.Concrete();
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SimplenoteMovementMethod.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SimplenoteMovementMethod.java
@@ -3,14 +3,14 @@ package com.automattic.simplenote.utils;
 import android.text.Layout;
 import android.text.Selection;
 import android.text.Spannable;
-import android.text.method.LinkMovementMethod;
+import android.text.method.ArrowKeyMovementMethod;
 import android.view.MotionEvent;
 import android.widget.TextView;
 
 import com.automattic.simplenote.widgets.CheckableSpan;
 
 // Only allows onClick events for CheckableSpans
-public class SimplenoteMovementMethod extends LinkMovementMethod {
+public class SimplenoteMovementMethod extends ArrowKeyMovementMethod {
 
     private static SimplenoteMovementMethod mInstance;
 
@@ -19,7 +19,7 @@ public class SimplenoteMovementMethod extends LinkMovementMethod {
             mInstance = new SimplenoteMovementMethod();
         return mInstance;
     }
-    
+
     @Override
     public boolean onTouchEvent(TextView textView, Spannable buffer, MotionEvent event) {
         int action = event.getAction();

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SimplenoteMovementMethod.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SimplenoteMovementMethod.java
@@ -1,23 +1,29 @@
 package com.automattic.simplenote.utils;
 
 import android.text.Layout;
+import android.text.NoCopySpan;
 import android.text.Selection;
 import android.text.Spannable;
 import android.text.method.ArrowKeyMovementMethod;
 import android.view.MotionEvent;
+import android.view.View;
 import android.widget.TextView;
 
 import com.automattic.simplenote.widgets.CheckableSpan;
 
 // Only allows onClick events for CheckableSpans
 public class SimplenoteMovementMethod extends ArrowKeyMovementMethod {
-
     private static SimplenoteMovementMethod mInstance;
 
     public static SimplenoteMovementMethod getInstance() {
         if (mInstance == null)
             mInstance = new SimplenoteMovementMethod();
         return mInstance;
+    }
+
+    @Override
+    public boolean canSelectArbitrarily() {
+        return true;
     }
 
     @Override
@@ -57,4 +63,22 @@ public class SimplenoteMovementMethod extends ArrowKeyMovementMethod {
 
         return false;
     }
+
+    // Borrowed from LinkMovementMethod
+    @Override
+    public void initialize(TextView widget, Spannable text) {
+        Selection.removeSelection(text);
+        text.removeSpan(FROM_BELOW);
+    }
+    @Override
+    public void onTakeFocus(TextView view, Spannable text, int dir) {
+        Selection.removeSelection(text);
+        if ((dir & View.FOCUS_BACKWARD) != 0) {
+            text.setSpan(FROM_BELOW, 0, 0, Spannable.SPAN_POINT_POINT);
+        } else {
+            text.removeSpan(FROM_BELOW);
+        }
+    }
+
+    private static Object FROM_BELOW = new NoCopySpan.Concrete();
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SimplenoteMovementMethod.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SimplenoteMovementMethod.java
@@ -22,37 +22,44 @@ public class SimplenoteMovementMethod extends ArrowKeyMovementMethod {
 
     @Override
     public boolean onTouchEvent(TextView textView, Spannable buffer, MotionEvent event) {
-        int action = event.getAction();
+        int x = (int) event.getX();
+        int y = (int) event.getY();
 
-        if (action == MotionEvent.ACTION_UP) {
-            int x = (int) event.getX();
-            int y = (int) event.getY();
+        x -= textView.getTotalPaddingLeft();
+        y -= textView.getTotalPaddingTop();
 
-            x -= textView.getTotalPaddingLeft();
-            y -= textView.getTotalPaddingTop();
+        x += textView.getScrollX();
+        y += textView.getScrollY();
 
-            x += textView.getScrollX();
-            y += textView.getScrollY();
+        Layout layout = textView.getLayout();
+        int line = layout.getLineForVertical(y);
+        int off = layout.getOffsetForHorizontal(line, x);
+        int lineStart = layout.getLineStart(line);
 
-            Layout layout = textView.getLayout();
-            int line = layout.getLineForVertical(y);
-            int off = layout.getOffsetForHorizontal(line, x);
-            int lineStart = layout.getLineStart(line);
+        // Also toggle the checkbox if the user tapped the space next to the checkbox
+        if (off == lineStart + 1) {
+            off = lineStart;
+        }
 
-            // Also toggle the checkbox if the user tapped the space next to the checkbox
-            if (off == lineStart + 1) {
-                off = lineStart;
+        CheckableSpan[] checkableSpans = buffer.getSpans(off, off + 1, CheckableSpan.class);
+
+        if (checkableSpans.length != 0) {
+            switch (event.getAction()) {
+                case MotionEvent.ACTION_DOWN:
+                    if (!textView.hasFocus()) {
+                        textView.setFocusableInTouchMode(false);
+                    }
+
+                    break;
+                case MotionEvent.ACTION_UP:
+                    checkableSpans[0].onClick(textView);
+                    textView.setFocusableInTouchMode(true);
+                    break;
             }
 
-            CheckableSpan[] checkableSpans = buffer.getSpans(off, off + 1, CheckableSpan.class);
-
-            if (checkableSpans.length != 0) {
-                checkableSpans[0].onClick(textView);
-
-                return true;
-            } else {
-                Selection.removeSelection(buffer);
-            }
+            return true;
+        } else {
+            Selection.removeSelection(buffer);
         }
 
         return false;

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -1,5 +1,6 @@
 package com.automattic.simplenote.widgets;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
@@ -10,6 +11,7 @@ import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.style.ImageSpan;
 import android.util.AttributeSet;
+import android.view.inputmethod.InputMethodManager;
 
 import com.automattic.simplenote.R;
 import com.automattic.simplenote.utils.ChecklistUtils;
@@ -56,11 +58,13 @@ public class SimplenoteEditText extends AppCompatEditText {
 
     // Updates the ImageSpan drawable to the new checked state
     public void toggleCheckbox(final CheckableSpan checkableSpan) {
-        final Editable editable = getText();
+        if (getContext() == null) {
+            return;
+        }
 
+        final Editable editable = getText();
         final int checkboxStart = editable.getSpanStart(checkableSpan);
         final int checkboxEnd = editable.getSpanEnd(checkableSpan);
-
         final int selectionStart = getSelectionStart();
         final int selectionEnd = getSelectionEnd();
 
@@ -82,8 +86,15 @@ public class SimplenoteEditText extends AppCompatEditText {
                     editable.removeSpan(imageSpans[0]);
                     fixLineSpacing();
 
-                    // Restore the selection
-                    if (selectionStart <= editable.length() && selectionEnd <= editable.length()) {
+                    if (selectionStart < 0) {
+                        // Dismiss keyboard and focus if user tapped on checkbox before keyboard was shown.
+                        clearFocus();
+                        InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
+                        if (imm != null) {
+                            imm.hideSoftInputFromWindow(getWindowToken(), 0);
+                        }
+                    } else if (selectionStart <= editable.length() && selectionEnd <= editable.length()) {
+                        // Restore the selection
                         setSelection(selectionStart, selectionEnd);
                     }
                 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -1,6 +1,5 @@
 package com.automattic.simplenote.widgets;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
@@ -11,7 +10,6 @@ import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.style.ImageSpan;
 import android.util.AttributeSet;
-import android.view.inputmethod.InputMethodManager;
 
 import com.automattic.simplenote.R;
 import com.automattic.simplenote.utils.ChecklistUtils;
@@ -63,13 +61,11 @@ public class SimplenoteEditText extends AppCompatEditText {
 
     // Updates the ImageSpan drawable to the new checked state
     public void toggleCheckbox(final CheckableSpan checkableSpan) {
-        if (getContext() == null) {
-            return;
-        }
-
         final Editable editable = getText();
+
         final int checkboxStart = editable.getSpanStart(checkableSpan);
         final int checkboxEnd = editable.getSpanEnd(checkableSpan);
+
         final int selectionStart = getSelectionStart();
         final int selectionEnd = getSelectionEnd();
 
@@ -91,15 +87,8 @@ public class SimplenoteEditText extends AppCompatEditText {
                     editable.removeSpan(imageSpans[0]);
                     fixLineSpacing();
 
-                    if (selectionStart < 0) {
-                        // Dismiss keyboard and focus if user tapped on checkbox before keyboard was shown.
-                        clearFocus();
-                        InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
-                        if (imm != null) {
-                            imm.hideSoftInputFromWindow(getWindowToken(), 0);
-                        }
-                    } else if (selectionStart <= editable.length() && selectionEnd <= editable.length()) {
-                        // Restore the selection
+                    // Restore the selection
+                    if (selectionStart <= editable.length() && selectionEnd <= editable.length()) {
                         setSelection(selectionStart, selectionEnd);
                     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -23,7 +23,12 @@ import java.util.List;
 
 public class SimplenoteEditText extends AppCompatEditText {
     private List<OnSelectionChangedListener> listeners;
+    private OnCheckboxToggledListener mOnCheckboxToggledListener;
     private final int CHECKBOX_LENGTH = 2; // One CheckableSpan + a space character
+
+    public interface OnCheckboxToggledListener {
+        void onCheckboxToggled();
+    }
 
     public SimplenoteEditText(Context context) {
         super(context);
@@ -96,6 +101,10 @@ public class SimplenoteEditText extends AppCompatEditText {
                     } else if (selectionStart <= editable.length() && selectionEnd <= editable.length()) {
                         // Restore the selection
                         setSelection(selectionStart, selectionEnd);
+                    }
+
+                    if (mOnCheckboxToggledListener != null) {
+                        mOnCheckboxToggledListener.onCheckboxToggled();
                     }
                 }
             });
@@ -241,5 +250,9 @@ public class SimplenoteEditText extends AppCompatEditText {
                 getText(),
                 ChecklistUtils.CHECKLIST_REGEX_LINES,
                 R.color.simplenote_text_preview);
+    }
+
+    public void setOnCheckboxToggledListener(OnCheckboxToggledListener listener) {
+        mOnCheckboxToggledListener = listener;
     }
 }

--- a/Simplenote/src/main/res/layout/activity_note_editor.xml
+++ b/Simplenote/src/main/res/layout/activity_note_editor.xml
@@ -40,6 +40,8 @@
         android:id="@+id/main_parent_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
         android:foreground="@drawable/header_shadow"
         android:orientation="vertical"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">

--- a/Simplenote/src/main/res/layout/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_editor.xml
@@ -14,8 +14,6 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:focusable="true"
-            android:focusableInTouchMode="true"
             android:orientation="vertical"
             android:paddingLeft="@dimen/padding_large"
             android:paddingRight="@dimen/padding_large">


### PR DESCRIPTION
For the Checklists feature I added a `SimplenoteMovementMethod` class in order to detect taps on Checkboxes. This caused an issue with using the arrow keys to navigate around the editor, which is a pain on devices like Chromebooks. Using the arrow keys would highlight the checkboxes instead of moving the text cursor.

The fix is to use a subclass of `ArrowKeyMovementMethod` instead of `LinkMovementMethod`. Changing this required a change to run the checklist `onClick` code on the main ui thread as well in order to prevent an exception.

I've also bumped the version number in this PR so we can release an update (current rollout is at 5%).

There's a bug with this that I'm struggling to fix. If you tap on a checklist after opening a note, it shows the soft keyboard. Suggestions welcome :)

**To Test**
* Open a note, and use the arrow keys on your keyboard to navigate the cursor around. It should work as expected.
* Create a checklist, tapping on the checklists should toggle them as expected.
* Placing a cursor within a URL or phone number should still show the context menu.