### PR TITLE
Fixes crash when tapping on a very specific point next to a checkbox.

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -88,7 +88,9 @@ public class SimplenoteEditText extends AppCompatEditText {
                     fixLineSpacing();
 
                     // Restore the selection
-                    if (selectionStart <= editable.length() && selectionEnd <= editable.length()) {
+                    if (selectionStart >= 0
+                            && selectionStart <= editable.length()
+                            && selectionEnd <= editable.length()) {
                         setSelection(selectionStart, selectionEnd);
                     }
 


### PR DESCRIPTION
Fixes #638. The selection appeared to be resetting to `-1` for some reason when clicking on a very specific point next to a checkbox.

**To Test**
* Insert a checklist item, add some text next to the checkbox
* Try to click in the space between the checkbox and the text, keep moving a pixel or two over and keep clicking. 
* No crash should occur 👍 