### PR TITLE
Fix SimplenoteMovementMethod from clearing the selection

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SimplenoteMovementMethod.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SimplenoteMovementMethod.java
@@ -58,8 +58,6 @@ public class SimplenoteMovementMethod extends ArrowKeyMovementMethod {
             }
 
             return true;
-        } else {
-            Selection.removeSelection(buffer);
         }
 
         return false;


### PR DESCRIPTION
I noticed that the cursor would jump to the start when you click around the editor:

![feb-07-2019 09-03-50](https://user-images.githubusercontent.com/789137/52428878-bf659c80-2ab7-11e9-8b03-01da3c6ffdf8.gif)

Tracked it down to some code that was left over from when I subclassed `SimplenoteMovementMethod` from `LinkMovementMethod`. Since we are subclassing `ArrowKeyMovementMethod`, we shouldn't be clearing the selection after a click.

**To Test**
* Change the cursor position in the editor, it should behave normally. Clicking checklists and links should also still work as expected.