### PR TITLE
Checklist Cursor and Keyboard Adjustments

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -61,6 +61,8 @@ public class SimplenoteEditText extends AppCompatEditText {
 
     // Updates the ImageSpan drawable to the new checked state
     public void toggleCheckbox(final CheckableSpan checkableSpan) {
+        setCursorVisible(false);
+
         final Editable editable = getText();
 
         final int checkboxStart = editable.getSpanStart(checkableSpan);
@@ -92,6 +94,7 @@ public class SimplenoteEditText extends AppCompatEditText {
                             && selectionStart <= editable.length()
                             && selectionEnd <= editable.length()) {
                         setSelection(selectionStart, selectionEnd);
+                        setCursorVisible(true);
                     }
 
                     if (mOnCheckboxToggledListener != null) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -1,6 +1,7 @@
 package com.automattic.simplenote.widgets;
 
 import android.content.Context;
+import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.support.v7.widget.AppCompatEditText;
@@ -68,6 +69,15 @@ public class SimplenoteEditText extends AppCompatEditText {
         return super.dispatchKeyEvent(event);
     }
 
+    @Override
+    protected void onFocusChanged(boolean focused, int direction, Rect previouslyFocusedRect) {
+        if (focused) {
+            setCursorVisible(true);
+        }
+
+        super.onFocusChanged(focused, direction, previouslyFocusedRect);
+    }
+
     // Updates the ImageSpan drawable to the new checked state
     public void toggleCheckbox(final CheckableSpan checkableSpan) {
         setCursorVisible(false);
@@ -101,7 +111,7 @@ public class SimplenoteEditText extends AppCompatEditText {
                     // Restore the selection
                     if (selectionStart >= 0
                             && selectionStart <= editable.length()
-                            && selectionEnd <= editable.length()) {
+                            && selectionEnd <= editable.length() && hasFocus()) {
                         setSelection(selectionStart, selectionEnd);
                         setCursorVisible(true);
                     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -10,6 +10,7 @@ import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.style.ImageSpan;
 import android.util.AttributeSet;
+import android.view.KeyEvent;
 
 import com.automattic.simplenote.R;
 import com.automattic.simplenote.utils.ChecklistUtils;
@@ -57,6 +58,14 @@ public class SimplenoteEditText extends AppCompatEditText {
             for (OnSelectionChangedListener l : listeners)
                 l.onSelectionChanged(selStart, selEnd);
         }
+    }
+
+    @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        if (event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+            clearFocus();
+        }
+        return super.dispatchKeyEvent(event);
     }
 
     // Updates the ImageSpan drawable to the new checked state


### PR DESCRIPTION
Fixes #637 
- Hide cursor when toggling a checkbox until the selection position can be restored to prevent the jumping cursor effect.
- Clear editor focus when closing soft keyboard, this prevent the keyboard from showing up again when the user toggles another item.

**To Test**
- Open checklist note and toggle some items.
- Edit text in checklist note and toggle some items, the cursor should stay where it is.
- Close soft keyboard and toggle some items, the keyboard shouldn't show up.
- Edit text in checklist note, keyboard should show up again.