### PR TITLE
Use Unicode No-Break Space to Prevent Checklist Span Break

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ChecklistUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ChecklistUtils.java
@@ -63,7 +63,7 @@ public class ChecklistUtils {
 
             CheckableSpan checkableSpan = new CheckableSpan();
             checkableSpan.setChecked(match.contains("x") || match.contains("X"));
-            editable.replace(start, end, " ");
+            editable.replace(start, end, "\u00A0");
 
             Drawable iconDrawable = context.getResources().getDrawable(
                     checkableSpan.isChecked()


### PR DESCRIPTION
Fixes #623 by using unicode no-break space character instead of regular space character to prevent checklist span break which was causing checkbox to disappear in the content preview.