### PR TITLE
Implement CommonMark parsing and rendering

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -52,7 +52,9 @@ dependencies {
     // Third Party
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation 'com.takisoft.fix:preference-v7:27.1.1.1'
-    implementation 'com.commonsware.cwac:anddown:0.4.0'
+    implementation 'com.atlassian.commonmark:commonmark:0.12.1'
+    implementation 'com.atlassian.commonmark:commonmark-ext-gfm-tables:0.12.1'
+    implementation 'com.atlassian.commonmark:commonmark-ext-gfm-strikethrough:0.12.1'
     implementation 'net.openid:appauth:0.7.0'
     implementation('com.crashlytics.sdk.android:crashlytics:2.9.5@aar') {
         transitive = true

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -17,9 +17,18 @@ import com.automattic.simplenote.utils.ContextUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.NoteUtils;
 import com.automattic.simplenote.utils.ThemeUtils;
-import com.commonsware.cwac.anddown.AndDown;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObjectMissingException;
+
+import org.commonmark.Extension;
+import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension;
+import org.commonmark.ext.gfm.tables.TablesExtension;
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class NoteMarkdownFragment extends Fragment {
     public static final String ARG_ITEM_ID = "item_id";
@@ -110,12 +119,13 @@ public class NoteMarkdownFragment extends Fragment {
                 "<link href=\"https://fonts.googleapis.com/css?family=Noto+Serif\" rel=\"stylesheet\">" +
                 cssContent + "</head><body>";
 
-        String parsedMarkdown = new AndDown().markdownToHtml(
-                sourceContent,
-                AndDown.HOEDOWN_EXT_STRIKETHROUGH | AndDown.HOEDOWN_EXT_FENCED_CODE |
-                        AndDown.HOEDOWN_EXT_QUOTE | AndDown.HOEDOWN_EXT_TABLES,
-                AndDown.HOEDOWN_HTML_ESCAPE
-        );
+        List<Extension> extensions = new ArrayList<>();
+        extensions.add(TablesExtension.create());
+        extensions.add(StrikethroughExtension.create());
+        Parser parser = Parser.builder().extensions(extensions).build();
+        Node document = parser.parse(sourceContent);
+        HtmlRenderer renderer = HtmlRenderer.builder().extensions(extensions).escapeHtml(true).build();
+        String parsedMarkdown = renderer.render(document);
 
         return header + "<div class=\"note-detail-markdown\">" + parsedMarkdown +
                 "</div></body></html>";


### PR DESCRIPTION
There seems to be some bugs and inconsistencies with Markdown rendering across Simplenote apps.

Implement [commonmark-java](https://github.com/atlassian/commonmark-java) for parsing and rendering Markdown enabled notes based on the [CommonMark](https://commonmark.org/) spec.

Enable tables and strikethrough extensions since this functionality is already enabled across Simplenote apps. These extensions are part of [GitHub Flavored Markdown spec](https://github.github.com/gfm/) which is also based on the CommonMark spec and used by [simplenote-electron](https://github.com/Automattic/simplenote-electron).

This fixes some of the existing Markdown issues and it can serve as a standard specification for Simplenote apps.

Fixes #494 #447 #411 
Related #499 #477 #392 

*apk is now 136 KB smaller. :)