### PR TITLE
Add Travis CI build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Simplenote for Android
+[![Build Status](https://travis-ci.org/Automattic/simplenote-android.svg?branch=develop)](https://travis-ci.org/Automattic/simplenote-android)
 
 A Simplenote client for Android. Learn more about Simplenote at [Simplenote.com](https://simplenote.com).
 


### PR DESCRIPTION
Fixes #653 by adding Travis CI build status badge to README.
This offers a quick look at the build status to everyone.