### PR TITLE
Add Setting for Preview Mode First

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -17,6 +17,7 @@ import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 
 import com.automattic.simplenote.utils.DisplayUtils;
+import com.automattic.simplenote.utils.PrefUtils;
 import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.widgets.NoteEditorViewPager;
 
@@ -125,6 +126,9 @@ public class NoteEditorActivity extends AppCompatActivity {
 
         // Show tabs if markdown is enabled for the current note.
         if (isMarkdownEnabled) {
+            if(PrefUtils.getBoolPref(this, PrefUtils.PREF_PREVIEW_FIRST, false)) {
+                mViewPager.setCurrentItem(2);
+            }
             showTabs();
         }
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -35,6 +35,9 @@ public class PrefUtils {
     // boolean, determines linkifying content in the editor
     public static final String PREF_DETECT_LINKS = "pref_key_detect_links";
 
+    // boolean, determines if preview mode is showed first in markdown notes
+    public static final String PREF_PREVIEW_FIRST = "pref_key_preview_first";
+
     // boolean, set on first launch
     public static final String PREF_FIRST_LAUNCH = "pref_key_first_launch";
 

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="condensed_note_list">Condensed note list</string>
     <string name="sort_order">Sort order</string>
     <string name="detect_links">Detect links</string>
+    <string name="preview_first">Show markdown preview first</string>
     <string name="share_analytics">Share analytics</string>
     <string name="share_analytics_summary">Help us improve Simplenote by sharing usage data with our analytics tool. %1$sLearn more%2$s</string>
 

--- a/Simplenote/src/main/res/xml/preferences.xml
+++ b/Simplenote/src/main/res/xml/preferences.xml
@@ -53,6 +53,10 @@
             android:defaultValue="true"
             android:key="pref_key_detect_links"
             android:title="@string/detect_links"/>
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_key_preview_first"
+            android:title="@string/preview_first"/>
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Fixes #434 and #446 by adding a preference to show preview mode as default on markdown notes.
If this setting is enabled, markdown notes will be loaded in 'preview' tab as default.