### PR TITLE
Issue/ignore gradle properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,9 @@ config.properties
 *.iws
 .idea/
 
-.idea/
+# Gradle
 .gradle/
+Simplenote/gradle.properties
 
 *.keystore
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ before_install:
   # TODO: Remove the following line when Travis' platform-tools are updated to v25+
   - echo yes | android update sdk -a --filter platform-tools --no-ui --force
 
+install:
+  - cp Simplenote/gradle.properties-example Simplenote/gradle.properties
+
 script:
   - ./gradlew assembleDebug assembleRelease
   - ./gradlew lint || (grep -A20 -B2 'severity="Error"' */build/outputs/*.xml; exit 1)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ A Simplenote client for Android. Learn more about Simplenote at [Simplenote.com]
 git clone https://github.com/Automattic/simplenote-android.git
 cd simplenote-android
 ```
+* Copy `gradle.properties-example` to `gradle.properties`.
+```shell
+cp Simplenote/gradle.properties-example Simplenote/gradle.properties
+```
 
 * Import into Android Studio using the "Gradle" build option. You may need to create a `local.properties` file with the absolute path to the Android SDK:
 Sample `local.properties`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Simplenote client for Android. Learn more about Simplenote at [Simplenote.com]
 
 ## How to Configure
 
-* Clone repo
+* Clone repository.
 ```shell
 git clone https://github.com/Automattic/simplenote-android.git
 cd simplenote-android
@@ -15,18 +15,17 @@ cd simplenote-android
 cp Simplenote/gradle.properties-example Simplenote/gradle.properties
 ```
 
-* Import into Android Studio using the "Gradle" build option. You may need to create a `local.properties` file with the absolute path to the Android SDK:
-Sample `local.properties`
+* Import into Android Studio using the Gradle build option. You may need to create a `local.properties` file with the absolute path to the Android SDK. Sample `local.properties`:
 ```
 sdk.dir=/Applications/Android Studio.app/sdk
 ```
 
-* Install debug build with Android Studio or:
+* Install debug build with Android Studio or command line with:
 ```shell
 ./gradlew installDebug
 ```
 
-* Create a new account in order to use a dev build. Signing in with an existing Simplenote account won't work. Use the account for **testing purposes only** as all note data will be periodically cleared out on the server.
+* Create a new account in order to use a development build. Signing in with an existing Simplenote account won't work. Use the account for **testing purposes only** as all note data will be periodically cleared out on the server.
 
 _Note: Simplenote API features such as sharing and publishing will not work with development builds._
 

--- a/Simplenote/gradle.properties
+++ b/Simplenote/gradle.properties
@@ -1,5 +1,0 @@
-simperiumAppId=history-analyst-dad
-simperiumAppKey=dccacc59bbef4982a15abaeafaf7bc8a
-googleAnalyticsId=
-crashlyticsApiKey=0
-wpcomClientId=

--- a/Simplenote/gradle.properties-example
+++ b/Simplenote/gradle.properties-example
@@ -1,0 +1,5 @@
+simperiumAppId = history-analyst-dad
+simperiumAppKey = dccacc59bbef4982a15abaeafaf7bc8a
+crashlyticsApiKey = 0
+googleAnalyticsId =
+wpcomClientId =


### PR DESCRIPTION
### Fix
Add the `Simplenote/gradle.properties` file to the `.gitignore` list and deleted the existing file to ensure developer-specific configuration values are not accidentally pushed to the repository.  In it's place, a `Simplenote/gradle.properties-example` file was created with the same content and instructions for copying the `Simplenote/gradle.properties-example` file to `Simplenote/gradle.properties` were added to the ***How to Configure*** section of the `README.md` file.

### Test
There are automated and manual tests for these changes.
#### Automated
The continuous integration environment passes with new `Simplenote/gradle.properties-example` statement shown [here](https://travis-ci.org/Automattic/simplenote-android/builds/526628191#L1967).
#### Manual
1. Checkout `issue/ignore-gradle-properties` branch.
2. Clean/Build project.
3. Notice build error below is shown.
```
Build configuration file:/simplenote-android/Simplenote/gradle.properties doesn't exist, follow README instructions
```
4. Copy `Simplenote/gradle.properties-example` to `Simplenote/gradle.properties`.
5. Clean/Build project.
6. Notice build error isn't shown.

### Review
@daniloercoli, @maxme, and @nbradbury, I requested you as reviewer since you have contributed to Simplenote in the past.  @bummytime, I requested you as a reviewer to keep you informed of Simplenote changes.  Only one developer is required to review these changes, but anyone can perform the review.