### PR TITLE
Issue/update dependency tracks

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     }
     // Automattic and WordPress dependencies
     implementation 'com.simperium.android:simperium:0.7.1'
-    implementation 'com.automattic:tracks:1.1.4'
+    implementation 'com.automattic:tracks:1.1.6'
     implementation 'org.wordpress:passcodelock:1.5.1'
     // Google Support
     implementation "com.android.support:appcompat-v7:$googleVersion"


### PR DESCRIPTION
### Fix
Update the `com.automattic:tracks` library dependency from 1.1.4 to 1.1.6.

### Test
There are no manual test steps for these changes.  If the continuous integration environment build passes, the changes should be good to merge.

### Review
Only one developer is required to review these changes, but anyone can perform the review.