### PR TITLE
Issue/build gradle properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ A Simplenote client for Android. Learn more about Simplenote at [Simplenote.com]
 git clone https://github.com/Automattic/simplenote-android.git
 cd simplenote-android
 ```
-* Copy `gradle.properties-example` to `gradle.properties`.
-```shell
-cp Simplenote/gradle.properties-example Simplenote/gradle.properties
-```
 
 * Import into Android Studio using the Gradle build option. You may need to create a `local.properties` file with the absolute path to the Android SDK. Sample `local.properties`:
 ```

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -137,7 +137,7 @@ task generateCrashlyticsConfig(group: "generate", description: "Generate Crashly
     def outputFile = new File("${rootDir}/Simplenote/crashlytics.properties")
     def inputFile = file("${rootDir}/Simplenote/gradle.properties")
     if (!inputFile.exists()) {
-        throw new StopActionException("Build configuration file " + inputFile + " doesn't exist")
+        tasks.copyGradlePropertiesExampleFile.execute()
     }
     outputs.file outputFile
     inputs.file inputFile
@@ -167,7 +167,6 @@ static String toSnakeCase( String text ) {
 }
 
 android.applicationVariants.all { variant ->
-    tasks.copyGradlePropertiesExampleFile.execute()
     variant.generateBuildConfig.dependsOn(generateCrashlyticsConfig)
     def inputFile = file("${rootDir}/Simplenote/gradle.properties")
     def properties = loadPropertiesFromFile(inputFile)

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -123,6 +123,16 @@ if(["storeFile", "storePassword", "keyAlias", "keyPassword"].count { !project.ha
     android.buildTypes.release.signingConfig = android.signingConfigs.release
 }
 
+task copyGradlePropertiesExampleFile(type: Copy) {
+    def inputFile = file("${rootDir}/Simplenote/gradle.properties")
+    if (!inputFile.exists()) {
+        from("${rootDir}/Simplenote")
+        into("${rootDir}/Simplenote")
+        include('gradle.properties-example')
+        rename('gradle.properties-example', 'gradle.properties')
+    }
+}
+
 task generateCrashlyticsConfig(group: "generate", description: "Generate Crashlytics config") {
     def outputFile = new File("${rootDir}/Simplenote/crashlytics.properties")
     def inputFile = file("${rootDir}/Simplenote/gradle.properties")
@@ -158,6 +168,7 @@ static String toSnakeCase( String text ) {
 }
 
 android.applicationVariants.all { variant ->
+    tasks.copyGradlePropertiesExampleFile.execute()
     variant.generateBuildConfig.dependsOn(generateCrashlyticsConfig)
     def inputFile = file("${rootDir}/Simplenote/gradle.properties")
     def properties = loadPropertiesFromFile(inputFile)

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -82,13 +82,6 @@ android {
         vectorDrawables.useSupportLibrary = true
 
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
-
-        buildConfigField "String", "SIMPERIUM_APP_ID", "\"${project.simperiumAppId}\""
-        buildConfigField "String", "SIMPERIUM_APP_KEY", "\"${project.simperiumAppKey}\""
-        buildConfigField "String", "GOOGLE_ANALYTICS_ID", "\"${project.googleAnalyticsId}\""
-        buildConfigField "String", "WPCOM_CLIENT_ID", "\"${project.wpcomClientId}\""
-        buildConfigField "String", "BUILD", "\"${gitDescribe()}\""
-        buildConfigField "String", "BUILD_HASH", "\"${gitHash()}\""
      }
 
     buildTypes {
@@ -152,7 +145,31 @@ apiKey=${crashlyticsApiKey}""")
     }
 }
 
-// Add generateCrashlyticsConfig to all generateBuildConfig tasks (all variants)
+static def loadPropertiesFromFile(inputFile) {
+    def properties = new Properties()
+    inputFile.withInputStream { stream ->
+        properties.load(stream)
+    }
+    return properties
+}
+
+static String toSnakeCase( String text ) {
+    text.replaceAll( /([A-Z])/, /_$1/ ).replaceAll( /^_/, '' )
+}
+
 android.applicationVariants.all { variant ->
     variant.generateBuildConfig.dependsOn(generateCrashlyticsConfig)
+    def inputFile = file("${rootDir}/Simplenote/gradle.properties")
+    def properties = loadPropertiesFromFile(inputFile)
+    properties.any { property ->
+        def key = toSnakeCase(property.key).toUpperCase()
+        if (key == "SIMPERIUM_APP_ID" ||
+            key == "SIMPERIUM_APP_KEY" ||
+            key == "GOOGLE_ANALYTICS_ID" ||
+            key == "WPCOM_CLIENT_ID") {
+            buildConfigField "String", key, "\"${property.value}\""
+        }
+    }
+    buildConfigField "String", "BUILD", "\"${gitDescribe()}\""
+    buildConfigField "String", "BUILD_HASH", "\"${gitHash()}\""
 }

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -137,8 +137,7 @@ task generateCrashlyticsConfig(group: "generate", description: "Generate Crashly
     def outputFile = new File("${rootDir}/Simplenote/crashlytics.properties")
     def inputFile = file("${rootDir}/Simplenote/gradle.properties")
     if (!inputFile.exists()) {
-        throw new StopActionException("Build configuration file:" + inputFile
-                + " doesn't exist, follow README instructions")
+        throw new StopActionException("Build configuration file " + inputFile + " doesn't exist")
     }
     outputs.file outputFile
     inputs.file inputFile


### PR DESCRIPTION
### Fix
Update the `Simplenote/build.gradle` script to eliminate a step from the ***How to Configure*** section of the `README.md` file.  Since the `Simplenote/gradle.properties-example` file does not need to be changed after copying it to `Simplenote/gradle.properties`, we can do that step automatically if the `Simplenote/gradle.properties` file doesn't already exist.  Also, this avoids the following build error, which is shown when the `Simplenote/gradle.properties` file does not exist.

```
FAILURE: Build failed with an exception.

* Where:
Build file '../simplenote-android/Simplenote/build.gradle' line: 86

* What went wrong:
A problem occurred evaluating project ':Simplenote'.
> Could not get unknown property 'simperiumAppId' for project ':Simplenote' of type org.gradle.api.Project.
```

The error below was intended to be shown when the `Simplenote/gradle.properties` file does not exist, but the error above occurs before the file check is performed on a clean build.

```
Build configuration file:/simplenote-android/Simplenote/gradle.properties doesn't exist, follow README instructions
```

### Test
1. Delete `Simplenote/gradle.properties` file.
2. Clean project.
3. Notice no error is shown.
4. Notice `Simplenote/gradle.properties` file exists with default values.
5. Notice default values shown in `BulidConfig.java`.
6. Update `Simplenote/gradle.properties` file with new values.
7. Clean project.
8. Notice no error is shown.
9. Notice `Simplenote/gradle.properties` file exists with new values.
10. Notice new values shown in `BulidConfig.java`.

### Review
@daniloercoli, @maxme, and @nbradbury, I requested you as reviewer since you have contributed to Simplenote in the past.  @bummytime, I requested you as a reviewer to keep you informed of Simplenote changes.  Only one developer is required to review these changes, but anyone can perform the review.