### PR TITLE
Issue/642 resize share icons

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/ShareBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/ShareBottomSheetDialog.java
@@ -14,6 +14,7 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.automattic.simplenote.models.Note;
+import com.automattic.simplenote.utils.IconResizer;
 import com.automattic.simplenote.utils.ShareButtonAdapter;
 
 import java.util.ArrayList;
@@ -121,7 +122,8 @@ public class ShareBottomSheetDialog extends BottomSheetDialogBase {
         List<ShareButtonAdapter.ShareButtonItem> shareButtons = new ArrayList<>();
         final List<ResolveInfo> matches = activity.getPackageManager().queryIntentActivities(intent, 0);
         for (ResolveInfo match : matches) {
-            final Drawable icon = match.loadIcon(activity.getPackageManager());
+            IconResizer iconResizer = new IconResizer(getContext());
+            final Drawable icon = iconResizer.createIconThumbnail(match.loadIcon(activity.getPackageManager()));
             final CharSequence label = match.loadLabel(activity.getPackageManager());
             shareButtons.add(new ShareButtonAdapter.ShareButtonItem(icon, label,
                     match.activityInfo.packageName, match.activityInfo.name));

--- a/Simplenote/src/main/java/com/automattic/simplenote/ShareBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/ShareBottomSheetDialog.java
@@ -121,8 +121,8 @@ public class ShareBottomSheetDialog extends BottomSheetDialogBase {
     private List<ShareButtonAdapter.ShareButtonItem> getShareButtons(Activity activity, Intent intent) {
         List<ShareButtonAdapter.ShareButtonItem> shareButtons = new ArrayList<>();
         final List<ResolveInfo> matches = activity.getPackageManager().queryIntentActivities(intent, 0);
+        IconResizer iconResizer = new IconResizer(getContext());
         for (ResolveInfo match : matches) {
-            IconResizer iconResizer = new IconResizer(getContext());
             final Drawable icon = iconResizer.createIconThumbnail(match.loadIcon(activity.getPackageManager()));
             final CharSequence label = match.loadLabel(activity.getPackageManager());
             shareButtons.add(new ShareButtonAdapter.ShareButtonItem(icon, label,

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/IconResizer.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/IconResizer.java
@@ -1,0 +1,101 @@
+package com.automattic.simplenote.utils;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.PaintFlagsDrawFilter;
+import android.graphics.PixelFormat;
+import android.graphics.Rect;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.PaintDrawable;
+
+/**
+ * Utility class to resize icons to match default icon size.
+ */
+public class IconResizer {
+
+    // Code is borrowed from com.android.launcher.Utilities.
+    private int mIconWidth = -1;
+    private int mIconHeight = -1;
+    private final Rect mOldBounds = new Rect();
+    private Canvas mCanvas = new Canvas();
+    private Context context;
+
+    public IconResizer(Context context) {
+        this.context = context;
+        mCanvas.setDrawFilter(new PaintFlagsDrawFilter(Paint.DITHER_FLAG,
+                Paint.FILTER_BITMAP_FLAG));
+
+        final Resources resources = context.getResources();
+        mIconWidth = mIconHeight = (int) resources.getDimension(
+                android.R.dimen.app_icon_size);
+    }
+
+    /**
+     * Returns a Drawable representing the thumbnail of the specified Drawable.
+     * The size of the thumbnail is defined by the dimension
+     * android.R.dimen.launcher_application_icon_size.
+     * <p>
+     * This method is not thread-safe and should be invoked on the UI thread only.
+     *
+     * @param icon The icon to get a thumbnail of.
+     * @return A thumbnail for the specified icon or the icon itself if the
+     * thumbnail could not be created.
+     */
+    public Drawable createIconThumbnail(Drawable icon) {
+        int width = mIconWidth;
+        int height = mIconHeight;
+        final int iconWidth = icon.getIntrinsicWidth();
+        final int iconHeight = icon.getIntrinsicHeight();
+        if (icon instanceof PaintDrawable) {
+            PaintDrawable painter = (PaintDrawable) icon;
+            painter.setIntrinsicWidth(width);
+            painter.setIntrinsicHeight(height);
+        }
+        if (width > 0 && height > 0) {
+            if (width < iconWidth || height < iconHeight) {
+                final float ratio = (float) iconWidth / iconHeight;
+                if (iconWidth > iconHeight) {
+                    height = (int) (width / ratio);
+                } else if (iconHeight > iconWidth) {
+                    width = (int) (height * ratio);
+                }
+                final Bitmap.Config c = icon.getOpacity() != PixelFormat.OPAQUE ?
+                        Bitmap.Config.ARGB_8888 : Bitmap.Config.RGB_565;
+                final Bitmap thumb = Bitmap.createBitmap(mIconWidth, mIconHeight, c);
+                final Canvas canvas = mCanvas;
+                canvas.setBitmap(thumb);
+                // Copy the old bounds to restore them later
+                // If we were to do oldBounds = icon.getBounds(),
+                // the call to setBounds() that follows would
+                // change the same instance and we would lose the
+                // old bounds
+                mOldBounds.set(icon.getBounds());
+                final int x = (mIconWidth - width) / 2;
+                final int y = (mIconHeight - height) / 2;
+                icon.setBounds(x, y, x + width, y + height);
+                icon.draw(canvas);
+                icon.setBounds(mOldBounds);
+                icon = new BitmapDrawable(context.getResources(), thumb);
+                canvas.setBitmap(null);
+            } else if (iconWidth < width && iconHeight < height) {
+                final Bitmap.Config c = Bitmap.Config.ARGB_8888;
+                final Bitmap thumb = Bitmap.createBitmap(mIconWidth, mIconHeight, c);
+                final Canvas canvas = mCanvas;
+                canvas.setBitmap(thumb);
+                mOldBounds.set(icon.getBounds());
+                final int x = (width - iconWidth) / 2;
+                final int y = (height - iconHeight) / 2;
+                icon.setBounds(x, y, x + iconWidth, y + iconHeight);
+                icon.draw(canvas);
+                icon.setBounds(mOldBounds);
+                icon = new BitmapDrawable(context.getResources(), thumb);
+                canvas.setBitmap(null);
+            }
+        }
+        return icon;
+    }
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/IconResizer.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/IconResizer.java
@@ -12,6 +12,8 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.PaintDrawable;
 
+import com.automattic.simplenote.R;
+
 /**
  * Utility class to resize icons to match default icon size.
  */
@@ -30,8 +32,7 @@ public class IconResizer {
                 Paint.FILTER_BITMAP_FLAG));
 
         final Resources resources = context.getResources();
-        mIconWidth = mIconHeight = (int) resources.getDimension(
-                android.R.dimen.app_icon_size);
+        mIconWidth = mIconHeight = (int) resources.getDimension(R.dimen.share_icon_size);
     }
 
     /**

--- a/Simplenote/src/main/res/drawable/ic_collaborate_48dp.xml
+++ b/Simplenote/src/main/res/drawable/ic_collaborate_48dp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="48dp"
-    android:height="48dp"
+    android:width="@dimen/share_icon_size"
+    android:height="@dimen/share_icon_size"
     android:viewportHeight="120"
     android:viewportWidth="120">
 

--- a/Simplenote/src/main/res/drawable/ic_publish_48dp.xml
+++ b/Simplenote/src/main/res/drawable/ic_publish_48dp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="48dp"
-    android:height="48dp"
+    android:width="@dimen/share_icon_size"
+    android:height="@dimen/share_icon_size"
     android:viewportHeight="120"
     android:viewportWidth="120">
 

--- a/Simplenote/src/main/res/drawable/ic_unpublish_48dp.xml
+++ b/Simplenote/src/main/res/drawable/ic_unpublish_48dp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="48dp"
-    android:height="48dp"
+    android:width="@dimen/share_icon_size"
+    android:height="@dimen/share_icon_size"
     android:viewportHeight="120"
     android:viewportWidth="120">
 

--- a/Simplenote/src/main/res/drawable/ic_wordpress_post_48dp.xml
+++ b/Simplenote/src/main/res/drawable/ic_wordpress_post_48dp.xml
@@ -1,5 +1,5 @@
-<vector android:height="48dp" android:viewportHeight="120"
-    android:viewportWidth="120" android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+<vector android:height="@dimen/share_icon_size" android:viewportHeight="120"
+    android:viewportWidth="120" android:width="@dimen/share_icon_size" xmlns:android="http://schemas.android.com/apk/res/android">
     <group>
         <clip-path android:pathData="M0,0h120v120h-120z M 0,0"/>
         <path android:fillColor="#4895D9" android:pathData=" M 60 0 C 93.137 0 120 26.863 120 60 C 120 93.137 93.137 120 60 120 C 26.863 120 0 93.137 0 60 C 0 26.863 26.863 0 60 0 Z "/>

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -28,6 +28,9 @@
 
     <dimen name="bottom_sheet_dialog_width">0dp</dimen>
 
+    <!-- https://support.google.com/accessibility/android/answer/7101858 -->
+    <dimen name="share_icon_size">48dp</dimen>
+
     <!--
 Refer to App Widget Documentation for margin information
 http://developer.android.com/guide/topics/appwidgets/index.html#CreatingLayout


### PR DESCRIPTION
### Fix
Fixes #642 app icons have different icon sizes when sharing from note. 

Before (different sizes)          |  After (same default icon size)
:-------------------------:|:-------------------------:
![1557820114324](https://user-images.githubusercontent.com/15052571/57683960-6d479080-763d-11e9-94d7-01f526100866.JPEG)   | ![1557824384716](https://user-images.githubusercontent.com/15052571/57685023-a4b73c80-763f-11e9-9356-393a3d24dee5.JPEG)

### To Test
> 1. Open a note
> 2. Tab the share icon

### Review
> Only one developer and one designer are required to review these changes, but anyone can perform the review.
