### PR TITLE
Add CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+orbs:
+  android: wordpress-mobile/android@0.0.25
+
+version: 2.1
+jobs:
+  Test:
+    executor: 
+      name: android/default
+      api-version: "27"
+    steps:
+      - checkout
+      - android/restore-gradle-cache
+      - run:
+          name: Build
+          command: ./gradlew --stacktrace assembleDebug assembleRelease
+      - run:
+          name: Test
+          command: ./gradlew --stacktrace testRelease
+      - android/save-gradle-cache
+      - android/save-test-results
+  Lint:
+    executor: 
+      name: android/default
+      api-version: "27"
+    steps:
+      - checkout
+      - android/restore-gradle-cache
+      - run:
+          name: Lint
+          command: ./gradlew --stacktrace lintRelease
+      - android/save-gradle-cache
+      - android/save-lint-results
+
+workflows:
+  simplenote-android:
+    jobs:
+      - Test
+      - Lint


### PR DESCRIPTION
This adds a CircleCI config to the repo as we have in all other projects. It runs these two jobs on each push:

- Test: Runs and caches these Gradle tasks: `assembleDebug assembleRelease testRelease`.
- Lint: Runs and caches `lintRelease`.

The total run time of the checks is about 1.5 minutes. When this lands, we can follow up by disabling Travis.

### Test

See that the CircleCI checks on this PR are green and that the tasks run successfully.
