### PR TITLE
Fix accessibility warnings

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
@@ -32,7 +32,7 @@ public class NoteEditorViewPager extends ViewPager {
 
     @Override
     public boolean performClick() {
-        return super.performClick();
+        return this.mIsEnabled && super.performClick();
     }
 
     public void setPagingEnabled(boolean enabled) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
@@ -19,10 +19,20 @@ public class NoteEditorViewPager extends ViewPager {
         return this.mIsEnabled && super.onInterceptTouchEvent(event);
     }
 
-    @SuppressLint("ClickableViewAccessibility")
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        return this.mIsEnabled && super.onTouchEvent(event);
+        if(mIsEnabled) {
+            if(event.getAction() == MotionEvent.ACTION_UP) {
+                performClick();
+            }
+            return super.onTouchEvent(event);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean performClick() {
+        return super.performClick();
     }
 
     public void setPagingEnabled(boolean enabled) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
@@ -1,6 +1,5 @@
 package com.automattic.simplenote.widgets;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
@@ -1,5 +1,6 @@
 package com.automattic.simplenote.widgets;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
@@ -18,6 +19,7 @@ public class NoteEditorViewPager extends ViewPager {
         return this.mIsEnabled && super.onInterceptTouchEvent(event);
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         return this.mIsEnabled && super.onTouchEvent(event);

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
@@ -20,13 +20,15 @@ public class NoteEditorViewPager extends ViewPager {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        if(mIsEnabled) {
-            if(event.getAction() == MotionEvent.ACTION_UP) {
-                performClick();
-            }
-            return super.onTouchEvent(event);
+        if (!mIsEnabled) {
+            return false;
         }
-        return false;
+
+        if(event.getAction() == MotionEvent.ACTION_UP) {
+            performClick();
+        }
+
+        return super.onTouchEvent(event);
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
@@ -24,7 +24,7 @@ public class NoteEditorViewPager extends ViewPager {
             return false;
         }
 
-        if(event.getAction() == MotionEvent.ACTION_UP) {
+        if (event.getAction() == MotionEvent.ACTION_UP) {
             performClick();
         }
 

--- a/Simplenote/src/main/res/layout/nav_drawer_footer.xml
+++ b/Simplenote/src/main/res/layout/nav_drawer_footer.xml
@@ -11,7 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="1px"
         android:layout_marginBottom="@dimen/padding_small"
-        android:background="?attr/dividerColor"/>
+        android:background="?attr/dividerColor" />
 
     <LinearLayout
         android:id="@+id/nav_settings"
@@ -19,6 +19,7 @@
         android:layout_height="wrap_content"
         android:background="@drawable/selectable_background_simplestyle"
         android:clickable="true"
+        android:focusable="true"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:paddingLeft="@dimen/list_padding_left"
@@ -32,7 +33,7 @@
             android:contentDescription="@string/settings"
             android:scaleType="center"
             android:tint="?attr/noteTitleColor"
-            app:srcCompat="@drawable/ic_settings_24dp"/>
+            app:srcCompat="@drawable/ic_settings_24dp" />
 
         <com.automattic.simplenote.widgets.RobotoMediumTextView
             android:layout_width="match_parent"
@@ -41,7 +42,7 @@
             android:minHeight="@dimen/nav_row_height"
             android:text="@string/settings"
             android:textColor="?attr/noteTitleColor"
-            android:textSize="@dimen/nav_drawer_item_text_size"/>
+            android:textSize="@dimen/nav_drawer_item_text_size" />
 
     </LinearLayout>
 </LinearLayout>

--- a/Simplenote/src/main/res/layout/nav_drawer_footer.xml
+++ b/Simplenote/src/main/res/layout/nav_drawer_footer.xml
@@ -11,7 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="1px"
         android:layout_marginBottom="@dimen/padding_small"
-        android:background="?attr/dividerColor" />
+        android:background="?attr/dividerColor"/>
 
     <LinearLayout
         android:id="@+id/nav_settings"
@@ -33,7 +33,7 @@
             android:contentDescription="@string/settings"
             android:scaleType="center"
             android:tint="?attr/noteTitleColor"
-            app:srcCompat="@drawable/ic_settings_24dp" />
+            app:srcCompat="@drawable/ic_settings_24dp"/>
 
         <com.automattic.simplenote.widgets.RobotoMediumTextView
             android:layout_width="match_parent"
@@ -42,7 +42,7 @@
             android:minHeight="@dimen/nav_row_height"
             android:text="@string/settings"
             android:textColor="?attr/noteTitleColor"
-            android:textSize="@dimen/nav_drawer_item_text_size" />
+            android:textSize="@dimen/nav_drawer_item_text_size"/>
 
     </LinearLayout>
 </LinearLayout>

--- a/Simplenote/src/main/res/layout/nav_drawer_row.xml
+++ b/Simplenote/src/main/res/layout/nav_drawer_row.xml
@@ -11,12 +11,12 @@
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:paddingStart="@dimen/list_padding_left"
-        android:paddingLeft="@dimen/list_padding_left"
-        android:paddingTop="@dimen/padding_small"
-        android:paddingEnd="@dimen/padding_large"
-        android:paddingRight="@dimen/padding_large"
         android:paddingBottom="@dimen/padding_small"
+        android:paddingEnd="@dimen/padding_large"
+        android:paddingLeft="@dimen/list_padding_left"
+        android:paddingRight="@dimen/padding_large"
+        android:paddingStart="@dimen/list_padding_left"
+        android:paddingTop="@dimen/padding_small"
         android:visibility="gone"
         tools:visibility="visible">
 
@@ -24,11 +24,11 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:paddingTop="@dimen/padding_extra_small"
             android:paddingBottom="@dimen/padding_extra_small"
+            android:paddingTop="@dimen/padding_extra_small"
             android:text="@string/tags"
             android:textColor="?attr/notePreviewColor"
-            android:textSize="@dimen/nav_drawer_item_text_size" />
+            android:textSize="@dimen/nav_drawer_item_text_size"/>
 
         <com.automattic.simplenote.widgets.RobotoMediumTextView
             android:id="@+id/edit_tags"
@@ -43,7 +43,7 @@
             android:textColor="@color/simplenote_blue"
             android:textSize="@dimen/nav_drawer_item_text_size"
             android:textStyle="bold"
-            tools:text="Edit" />
+            tools:text="Edit"/>
 
     </LinearLayout>
 
@@ -51,10 +51,10 @@
         android:id="@+id/top_section_divider"
         android:layout_width="match_parent"
         android:layout_height="1px"
-        android:layout_marginTop="0dp"
         android:layout_marginBottom="0dp"
+        android:layout_marginTop="0dp"
         android:background="?attr/dividerColor"
-        android:visibility="gone" />
+        android:visibility="gone"/>
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -63,12 +63,12 @@
         android:gravity="center_vertical"
         android:minHeight="@dimen/nav_row_height"
         android:orientation="horizontal"
-        android:paddingStart="@dimen/list_padding_left"
-        android:paddingLeft="@dimen/list_padding_left"
-        android:paddingTop="@dimen/padding_large"
+        android:paddingBottom="@dimen/padding_large"
         android:paddingEnd="@dimen/padding_large"
+        android:paddingLeft="@dimen/list_padding_left"
         android:paddingRight="@dimen/padding_large"
-        android:paddingBottom="@dimen/padding_large">
+        android:paddingStart="@dimen/list_padding_left"
+        android:paddingTop="@dimen/padding_large">
 
         <com.automattic.simplenote.widgets.RobotoMediumTextView
             android:id="@+id/drawer_item_name"
@@ -79,7 +79,7 @@
             android:gravity="center_vertical"
             android:textColor="?attr/noteTitleColor"
             android:textSize="@dimen/nav_drawer_item_text_size"
-            tools:text="Item 1" />
+            tools:text="Item 1"/>
 
     </LinearLayout>
 
@@ -87,9 +87,9 @@
         android:id="@+id/section_divider"
         android:layout_width="match_parent"
         android:layout_height="1px"
-        android:layout_marginTop="0dp"
         android:layout_marginBottom="0dp"
+        android:layout_marginTop="0dp"
         android:background="?attr/dividerColor"
-        android:visibility="gone" />
+        android:visibility="gone"/>
 
 </LinearLayout>

--- a/Simplenote/src/main/res/layout/nav_drawer_row.xml
+++ b/Simplenote/src/main/res/layout/nav_drawer_row.xml
@@ -11,12 +11,12 @@
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:paddingBottom="@dimen/padding_small"
-        android:paddingEnd="@dimen/padding_large"
-        android:paddingLeft="@dimen/list_padding_left"
-        android:paddingRight="@dimen/padding_large"
         android:paddingStart="@dimen/list_padding_left"
+        android:paddingLeft="@dimen/list_padding_left"
         android:paddingTop="@dimen/padding_small"
+        android:paddingEnd="@dimen/padding_large"
+        android:paddingRight="@dimen/padding_large"
+        android:paddingBottom="@dimen/padding_small"
         android:visibility="gone"
         tools:visibility="visible">
 
@@ -24,11 +24,11 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:paddingBottom="@dimen/padding_extra_small"
             android:paddingTop="@dimen/padding_extra_small"
+            android:paddingBottom="@dimen/padding_extra_small"
             android:text="@string/tags"
             android:textColor="?attr/notePreviewColor"
-            android:textSize="@dimen/nav_drawer_item_text_size"/>
+            android:textSize="@dimen/nav_drawer_item_text_size" />
 
         <com.automattic.simplenote.widgets.RobotoMediumTextView
             android:id="@+id/edit_tags"
@@ -36,13 +36,14 @@
             android:layout_height="wrap_content"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
+            android:focusable="true"
             android:padding="@dimen/padding_extra_small"
             android:text="@string/edit"
             android:textAllCaps="true"
             android:textColor="@color/simplenote_blue"
             android:textSize="@dimen/nav_drawer_item_text_size"
             android:textStyle="bold"
-            tools:text="Edit"/>
+            tools:text="Edit" />
 
     </LinearLayout>
 
@@ -50,10 +51,10 @@
         android:id="@+id/top_section_divider"
         android:layout_width="match_parent"
         android:layout_height="1px"
-        android:layout_marginBottom="0dp"
         android:layout_marginTop="0dp"
+        android:layout_marginBottom="0dp"
         android:background="?attr/dividerColor"
-        android:visibility="gone"/>
+        android:visibility="gone" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -62,12 +63,12 @@
         android:gravity="center_vertical"
         android:minHeight="@dimen/nav_row_height"
         android:orientation="horizontal"
-        android:paddingBottom="@dimen/padding_large"
-        android:paddingEnd="@dimen/padding_large"
-        android:paddingLeft="@dimen/list_padding_left"
-        android:paddingRight="@dimen/padding_large"
         android:paddingStart="@dimen/list_padding_left"
-        android:paddingTop="@dimen/padding_large">
+        android:paddingLeft="@dimen/list_padding_left"
+        android:paddingTop="@dimen/padding_large"
+        android:paddingEnd="@dimen/padding_large"
+        android:paddingRight="@dimen/padding_large"
+        android:paddingBottom="@dimen/padding_large">
 
         <com.automattic.simplenote.widgets.RobotoMediumTextView
             android:id="@+id/drawer_item_name"
@@ -78,7 +79,7 @@
             android:gravity="center_vertical"
             android:textColor="?attr/noteTitleColor"
             android:textSize="@dimen/nav_drawer_item_text_size"
-            tools:text="Item 1"/>
+            tools:text="Item 1" />
 
     </LinearLayout>
 
@@ -86,9 +87,9 @@
         android:id="@+id/section_divider"
         android:layout_width="match_parent"
         android:layout_height="1px"
-        android:layout_marginBottom="0dp"
         android:layout_marginTop="0dp"
+        android:layout_marginBottom="0dp"
         android:background="?attr/dividerColor"
-        android:visibility="gone"/>
+        android:visibility="gone" />
 
 </LinearLayout>


### PR DESCRIPTION
### Fix
This is a partial code cleanup. #564 #255
Fix accessibility warnings:
* Add missing `focusable` attributes.
* Implement `performClick` on `NoteEditorViewPagerJava` for accessibility.

### Test
* Verify `gradlew lintRelease` report doesn't containt accessibility warnings.
* Verify continuous integration build succeeds.
* Verify app builds and runs without error.
* Verify note editor pager is responding as expected on markdown enabled notes or disabled otherwise.

### Review
Only one developer is required to review these changes, but anyone can perform the review.