### PR TITLE
Add Button Hint

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -21,6 +21,7 @@ import android.util.SparseBooleanArray;
 import android.util.TypedValue;
 import android.view.ActionMode;
 import android.view.Gravity;
+import android.view.HapticFeedbackConstants;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -34,6 +35,7 @@ import android.widget.CursorAdapter;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
+import android.widget.Toast;
 import android.widget.ToggleButton;
 
 import com.automattic.simplenote.analytics.AnalyticsTracker;
@@ -243,6 +245,17 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             @Override
             public void onClick(View v) {
                 createNewNote("action_bar_button");
+            }
+        });
+        mFloatingActionButton.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                if (v.isHapticFeedbackEnabled()) {
+                    v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+                }
+
+                Toast.makeText(getContext(), requireContext().getString(R.string.new_note), Toast.LENGTH_SHORT).show();
+                return true;
             }
         });
 


### PR DESCRIPTION
### Fix
Add a hint message when the floating action button is long-pressed.  The message shown is the same as the label for the app shortcut with the same icon.

### Test
1. Go to ***All Notes***, ***Trash***, or any tag notes list.
2. Long-press on floating action button.
3. Notice ***New note*** message is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.