### PR TITLE
Update Integer Division

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
@@ -135,7 +135,7 @@ public class Note extends BucketObject {
             // Flick Note uses millisecond resolution timestamps Simplenote expects seconds
             // since we only deal with create and modify timestamps, they should all have occured
             // at the present time or in the past.
-            float now = date.getTimeInMillis() / 1000;
+            float now = (float) date.getTimeInMillis() / 1000;
             float magnitude = time.floatValue() / now;
             if (magnitude >= 2.f) time = time.longValue() / 1000;
             date.setTimeInMillis(time.longValue() * 1000);

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
@@ -133,7 +133,7 @@ public class Note extends BucketObject {
         Calendar date = Calendar.getInstance();
         if (time != null) {
             // Flick Note uses millisecond resolution timestamps Simplenote expects seconds
-            // since we only deal with create and modify timestamps, they should all have occured
+            // since we only deal with create and modify timestamps, they should all have occurred
             // at the present time or in the past.
             float now = (float) date.getTimeInMillis() / 1000;
             float magnitude = time.floatValue() / now;


### PR DESCRIPTION
### Fix
Update an instance of integer division in floating-point context and a typographical error in the `Note` class to eliminate two minor lint warnings.

### Test
There aren't any user-facing changes to test.  This pull request can be tested by modifying the `Note.numberToDate()` method with the following code and set a breakpoint after the `boolean equal = now == nowBefore;` statement to see if `equal` is `true` verifying the numbers are equivalent.

```java
    public static Calendar numberToDate(Number time) {
        Calendar date = Calendar.getInstance();
        if (time != null) {
            // Flick Note uses millisecond resolution timestamps Simplenote expects seconds
            // since we only deal with create and modify timestamps, they should all have occurred
            // at the present time or in the past.
            float nowBefore = date.getTimeInMillis() / 1000;
            float now = (float) date.getTimeInMillis() / 1000;
            boolean equal = now == nowBefore;
            float magnitude = time.floatValue() / now;
            if (magnitude >= 2.f) time = time.longValue() / 1000;
            date.setTimeInMillis(time.longValue() * 1000);
        }
        return date;
    }
```

### Review
Only one developer is required to review these changes, but anyone can perform the review.