### PR TITLE
Remove Share Selector

### DIFF
--- a/Simplenote/src/main/res/drawable/ic_collaborate_selector.xml
+++ b/Simplenote/src/main/res/drawable/ic_collaborate_selector.xml
@@ -1,3 +1,0 @@
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@drawable/ic_collaborate_48dp" />
-</selector>

--- a/Simplenote/src/main/res/drawable/ic_publish_selector.xml
+++ b/Simplenote/src/main/res/drawable/ic_publish_selector.xml
@@ -1,3 +1,0 @@
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@drawable/ic_publish_48dp" />
-</selector>

--- a/Simplenote/src/main/res/drawable/ic_unpublish_selector.xml
+++ b/Simplenote/src/main/res/drawable/ic_unpublish_selector.xml
@@ -1,3 +1,0 @@
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@drawable/ic_unpublish_48dp" />
-</selector>

--- a/Simplenote/src/main/res/drawable/ic_wordpress_post_selector.xml
+++ b/Simplenote/src/main/res/drawable/ic_wordpress_post_selector.xml
@@ -1,3 +1,0 @@
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@drawable/ic_wordpress_post_48dp" />
-</selector>

--- a/Simplenote/src/main/res/layout/bottom_sheet_share.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_share.xml
@@ -33,7 +33,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:drawablePadding="@dimen/padding_small"
-            android:drawableTop="@drawable/ic_publish_selector"
+            android:drawableTop="@drawable/ic_publish_48dp"
             android:gravity="center_horizontal"
             android:text="@string/publish"
             style="@style/Theme.Simplestyle.BottomSheetDialogText"/>

--- a/Simplenote/src/main/res/layout/bottom_sheet_share.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_share.xml
@@ -21,7 +21,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:drawablePadding="@dimen/padding_small"
-            android:drawableTop="@drawable/ic_collaborate_selector"
+            android:drawableTop="@drawable/ic_collaborate_48dp"
             android:gravity="center_horizontal"
             android:text="@string/collaborate"
             style="@style/Theme.Simplestyle.BottomSheetDialogText"/>

--- a/Simplenote/src/main/res/layout/bottom_sheet_share.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_share.xml
@@ -57,7 +57,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:drawablePadding="@dimen/padding_small"
-            android:drawableTop="@drawable/ic_wordpress_post_selector"
+            android:drawableTop="@drawable/ic_wordpress_post_48dp"
             android:gravity="center_horizontal"
             android:text="@string/wordpress_post"
             style="@style/Theme.Simplestyle.BottomSheetDialogText"/>

--- a/Simplenote/src/main/res/layout/bottom_sheet_share.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_share.xml
@@ -45,7 +45,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:drawablePadding="@dimen/padding_small"
-            android:drawableTop="@drawable/ic_unpublish_selector"
+            android:drawableTop="@drawable/ic_unpublish_48dp"
             android:gravity="center_horizontal"
             android:text="@string/unpublish"
             style="@style/Theme.Simplestyle.BottomSheetDialogText"/>


### PR DESCRIPTION
### Fix
Remove the share selector drawable resources.  Since the selector only has one item, they are unnecessary and can be replaced by the one item.

### Test
1. Go to ***All Notes***.
2. Open unpublished note.
3. Tap ***Share*** action.
4. Notice ***Collaborate***, ***Publish***, and ***WordPress Post*** icons are shown.
5. Tap back arrow.
6. Open published note.
7. Tap ***Share*** action.
8. Notice ***Collaborate***, ***Unpublish***, and ***WordPress Post*** icons are shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

#### Note
Since these changes require a `minSdkVersion` value of `21` or higher, the pull request will be in draft status until https://github.com/Automattic/simplenote-android/pull/689 is merged.