### PR TITLE
Add Hide Keyboard

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -1,7 +1,6 @@
 package com.automattic.simplenote;
 
 import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
@@ -14,7 +13,6 @@ import android.support.v4.view.PagerAdapter;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.utils.DisplayUtils;
@@ -94,11 +92,7 @@ public class NoteEditorActivity extends AppCompatActivity {
                         @Override
                         public void onPageSelected(int position) {
                             if (position == 1) {
-                                final InputMethodManager imm = (InputMethodManager) getSystemService(
-                                        Context.INPUT_METHOD_SERVICE);
-                                if (imm != null) {
-                                    imm.hideSoftInputFromWindow(mViewPager.getWindowToken(), 0);
-                                }
+                                DisplayUtils.hideKeyboard(mViewPager);
                             }
                         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -403,15 +403,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         }, 100);
     }
 
-    private void hideSoftKeyboard() {
-        if (getActivity() != null) {
-            InputMethodManager inputMethodManager = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
-            if (inputMethodManager != null) {
-                inputMethodManager.hideSoftInputFromWindow(mContentEditText.getWindowToken(), 0);
-            }
-        }
-    }
-
     @Override
     public void onPause() {
         super.onPause();  // Always call the superclass method first
@@ -420,7 +411,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mNotesBucket.stop();
 
         // Hide soft keyboard if it is showing...
-        hideSoftKeyboard();
+        DisplayUtils.hideKeyboard(mContentEditText);
 
         mTagView.setOnTagAddedListener(null);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DisplayUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DisplayUtils.java
@@ -81,8 +81,8 @@ public class DisplayUtils {
         return DisplayUtils.dpToPx(context, PrefUtils.getFontSize(context)) + DisplayUtils.dpToPx(context, 6);
     }
 
-  // Disable screenshots if app PIN lock is on
-  public static void disableScreenshotsIfLocked(Activity activity) {
+    // Disable screenshots if app PIN lock is on
+    public static void disableScreenshotsIfLocked(Activity activity) {
         if (AppLockManager.getInstance().getAppLock().isPasswordLocked()) {
             activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
         } else {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DisplayUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DisplayUtils.java
@@ -4,9 +4,12 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Point;
+import android.support.annotation.Nullable;
 import android.util.TypedValue;
 import android.view.Display;
+import android.view.View;
 import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
 
 import org.wordpress.passcodelock.AppLockManager;
 
@@ -84,6 +87,22 @@ public class DisplayUtils {
             activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
         } else {
             activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+        }
+    }
+
+    /**
+     * Hides the keyboard for the given {@link View}.  Since no {@link InputMethodManager} flag is
+     * used, the keyboard is forcibly hidden regardless of the circumstances.
+     */
+    public static void hideKeyboard(@Nullable final View view) {
+        if (view == null) {
+            return;
+        }
+
+        InputMethodManager inputMethodManager = (InputMethodManager) view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+
+        if (inputMethodManager != null) {
+            inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
         }
     }
 }


### PR DESCRIPTION
### Fix
Add a hide keyboard method to the `DisplayUtils` class in order to consolidate similar methods.

### Test
1. Go to ***All Notes***.
2. Open note with markdown enabled.
3. Tap note content.
4. Notice keyboard is shown.
5. Tap ***Preview*** tab.
6. Notice keyboard is hidden.
7. Tap ***Edit*** tab.
8. Tap note content.
9. Notice keyboard is shown.
10. Swipe to ***Preview*** tab.
11. Notice keyboard is hidden.
12. Swipe to ***Edit*** tab.
13. Tap note content.
14. Notice keyboard is shown.
15. Tap ***History***, ***Share***, or ***Info*** action.
16. Notice keyboard is hidden.

### Review
Only one developer is required to review these changes, but anyone can perform the review.