### PR TITLE
Add translations for release notes and metadata

### DIFF
--- a/Simplenote/metadata/PlayStoreStrings.pot
+++ b/Simplenote/metadata/PlayStoreStrings.pot
@@ -1,0 +1,42 @@
+# Translation of Release Notes & Play Store Descriptions in English (US)
+# This file is distributed under the same license as the Release Notes & Play Store Descriptions package.
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2019-06-19 11:49:24+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: VsCode\n"
+"Project-Id-Version: Release Notes & Play Store Descriptions\n"
+
+#. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_018"
+msgid ""
+"1.8:\n"
+"* Added a widget to view a note and open it in the app from the home screen.\n"
+"* Added hiding app content in the recent apps view when PIN lock is on.\n"
+"* Updated checkboxes to not show the keyboard when tapped.\n"
+"* Fixed multiple cursor bugs for notes with checklists.\n"
+msgstr ""
+
+#. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!
+msgctxt "play_store_promo"
+msgid "Simplenote is an easy way to keep notes, lists, ideas and more."
+msgstr ""
+
+#. translators: Multi-paragraph text used to display in the Play Store.
+msgctxt "play_store_desc"
+msgid ""
+"Simplenote is an easy way to keep notes, lists, ideas and more. Your notes stay in sync with all of your devices for free.\n"
+"\n"
+"The Simplenote experience is all about speed and efficiency. Open it, write some thoughts, and you're done. As your collection of notes grows, you can search them instantly and keep them organized with tags and pins\n"
+"\n"
+"The best way to learn about Simplenote is to try it. Once you're up and running, visit simplenote.com to download it on other devices and start accessing your notes everywhere.\n"
+msgstr ""
+
+#. translators: Title to be displayed in the Play Store. Limit to 50 characters including spaces and commas!
+msgctxt "play_store_app_title"
+msgid "Simplenote"
+msgstr ""
+

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -127,12 +127,6 @@
     <string name="ok">OK</string>
     <string name="no_account">Don\'t have an account yet?</string>
     <string name="have_account">Already have an account?</string>
-    <string name="app_description">The award-winning Simplenote is now available for Android. Simplenote is an easy way to keep notes, lists, ideas and more. Your notes stay in sync with all of your devices for free.
-
-        The Simplenote experience is all about speed and efficiency. Open it, write some thoughts, and you\'re done. As your collection of notes grows, you can search them instantly and keep them organized with tags and pins.
-
-        The best way to learn about Simplenote is to try it. Once you\'re up and running, visit simplenote.com to download it on other devices and start accessing your notes everywhere.</string>
-    <string name="app_description_short">Simplenote is an easy way to keep notes, lists, ideas and more.</string>
     <string name="wpcom_sign_in_error_generic">Couldn\'t sign in with WordPress.com. Please try again.</string>
     <string name="wpcom_sign_in_error_unverified">Activate your WordPress.com account via email and try again.</string>
 


### PR DESCRIPTION
This PR adds the `PlayStoreStrings.pot` file that contains the strings for the Play Store listing. 
The file is intended to be uploaded to GlotPress for translations.

Some listing related strings have been moved from `strings.xml` to `PlayStoreStrings.pot` so that they can uploaded to the proper GlotPress subproject.

# To Test
1. Verify that the removed strings are not used by the app itself.