### PR TITLE
Note counts for tags with uppercase letters are now shown correctly

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
@@ -291,7 +291,7 @@ public class TagsListFragment extends ListFragment implements AdapterView.OnItem
             TextView tagTitle = convertView.findViewById(R.id.tag_name);
             TextView tagCountTextView = convertView.findViewById(R.id.tag_count);
             tagTitle.setText(tag.getName());
-            final int tagCount = mNotesBucket.query().where("tags", Query.ComparisonType.EQUAL_TO, tag.getSimperiumKey()).count();
+            final int tagCount = mNotesBucket.query().where("tags", Query.ComparisonType.EQUAL_TO, tag.getName()).count();
             if (tagCount > 0) {
                 tagCountTextView.setText(String.valueOf(tagCount));
             } else {

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
@@ -262,12 +262,12 @@ public class TagsListFragment extends ListFragment implements AdapterView.OnItem
 
         private Bucket.ObjectCursor<Tag> mCursor;
 
-        public TagsAdapter(Context context, Bucket.ObjectCursor<Tag> c, int flags) {
+        TagsAdapter(Context context, Bucket.ObjectCursor<Tag> c, int flags) {
             super(context, c, flags);
             mCursor = c;
         }
 
-        public void changeCursor(Bucket.ObjectCursor<Tag> cursor) {
+        void changeCursor(Bucket.ObjectCursor<Tag> cursor) {
             super.changeCursor(cursor);
             mCursor = cursor;
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
@@ -162,13 +162,11 @@ public class TagsListFragment extends ListFragment implements AdapterView.OnItem
 
     @Override
     public boolean onActionItemClicked(ActionMode actionMode, MenuItem menuItem) {
-        switch (menuItem.getItemId()) {
-            case R.id.menu_delete:
-                actionMode.finish(); // Action picked, so close the CAB
-                return true;
-            default:
-                return false;
+        if (menuItem.getItemId() == R.id.menu_delete) {
+            actionMode.finish(); // Action picked, so close the CAB
+            return true;
         }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
### Fix
This fixes bug #709 concerning note counts not being shown for tags with capital letters in their names. The problem was that the count was being queried from database using `tag.getSimperiumKey()` which is always a lower case representation of the tag name instead of `tag.getName()` which is the exact name of the tag, including upper case letters. This resulted in always finding zero count for tags containing upper case letters and thus displaying a blank instead of the actual count.

I assume that you want to keep the ability of having tags with upper case letters and hence this fix.

### Test
1. Add a tag with a capital letter in its name to a note.
2. Go tags editing screen
3. See that now even tags

### Review
Same as **Test** really.

### Screenshot
![Screenshot](https://user-images.githubusercontent.com/18679771/59976966-5e9cb380-95c3-11e9-8b26-372c906fa256.png)

