### PR TITLE
Update Readme 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Simplenote for Android
-[![Version](https://img.shields.io/badge/version-1.7.0-blue.svg)](https://github.com/Automattic/simplenote-android/releases/tag/1.7.0) [![CircleCI](https://img.shields.io/circleci/build/gh/Automattic/simplenote-android.svg?label=circleci)](https://circleci.com/gh/Automattic/simplenote-android) [![Travis CI](https://img.shields.io/travis/Automattic/simplenote-android/develop.svg?label=travisci)](https://travis-ci.org/Automattic/simplenote-android)
+[![Version](https://img.shields.io/badge/version-1.8.0-blue.svg)](https://github.com/Automattic/simplenote-android/releases/tag/1.8.0) [![CircleCI](https://img.shields.io/circleci/build/gh/Automattic/simplenote-android.svg?label=circleci)](https://circleci.com/gh/Automattic/simplenote-android) [![Travis CI](https://img.shields.io/travis/Automattic/simplenote-android/develop.svg?label=travisci)](https://travis-ci.org/Automattic/simplenote-android)
 
 Simplenote for Android. Learn more at [Simplenote.com](https://simplenote.com).
 


### PR DESCRIPTION
### Fix
Update the version shield to `1.8.0` and link it to [Release 1.8.0](https://github.com/Automattic/simplenote-android/releases/tag/1.8.0) in the `README.md` file.

### Test
1. Open [`README.md`](https://github.com/Automattic/simplenote-android/blob/188b8c1a8f57c405a3b3b44b76b8af7012081788/README.md) file.
2. Notice version shield shows `1.8.0`.
3. Click version shield.
4. Notice [Release 1.8.0](https://github.com/Automattic/simplenote-android/releases/tag/1.8.0) is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.