### PR TITLE
Issue/708 first tag focus

### DIFF
--- a/Simplenote/src/main/res/layout/nav_drawer_row.xml
+++ b/Simplenote/src/main/res/layout/nav_drawer_row.xml
@@ -42,7 +42,8 @@
             android:textColor="@color/simplenote_blue"
             android:textSize="@dimen/nav_drawer_item_text_size"
             android:textStyle="bold"
-            tools:text="Edit"/>
+            tools:ignore="KeyboardInaccessibleWidget"
+            tools:text="Edit" />
 
     </LinearLayout>
 

--- a/Simplenote/src/main/res/layout/nav_drawer_row.xml
+++ b/Simplenote/src/main/res/layout/nav_drawer_row.xml
@@ -36,7 +36,6 @@
             android:layout_height="wrap_content"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
-            android:focusable="true"
             android:padding="@dimen/padding_extra_small"
             android:text="@string/edit"
             android:textAllCaps="true"


### PR DESCRIPTION
### Fix
Remove the `android:focusable="true"` attribute from the ***Edit*** view in the tags header group of the navigation drawer item layout in order to close https://github.com/Automattic/simplenote-android/issues/708.  The `android:focusable="true"` attribute makes the first tag view unable to be tapped/clicked.  Removing the attribute allows the tag view to be tapped/clicked.  The attribute was added to remove the lint warning stating when a view is `clickable` and not `focusable`, it cannot be accessed by the keyboard.  The `tools:ignore="KeyboardInaccessibleWidget"` attribute was added to suppress the lint warning.  Even though adding the `android:focusable="true"` attribute removed the lint warning and the ***Edit*** view was able to be focused using a keyboard, the view was not able to be clicked by the keyboard due to the custom navigation drawer layout.  Therefore, removing the `android:focusable="true"` attribute and adding the `tools:ignore="KeyboardInaccessibleWidget"` attribute does not change the ability to click the ***Edit*** view using a keyboard, removes the lint warning, and resolves the first tag view issue.

### Test
0. Use account with at least one tag.
1. Open navigation drawer.
2. Tap first tag in list.
3. Notice tag is selected as expected.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

#### Note
@loremattei, this bug was introduced with the 1.8.0 changes and requires a hotfix.