### PR TITLE
Update Status Bar

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -12,7 +12,6 @@ import android.os.Handler;
 import android.support.design.widget.NavigationView;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
-import android.support.v4.content.ContextCompat;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
@@ -29,7 +28,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowInsets;
-import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.LinearLayout;
 import android.widget.ListView;
@@ -127,9 +125,6 @@ public class NotesActivity extends AppCompatActivity implements
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-        getWindow().setStatusBarColor(ContextCompat.getColor(this, android.R.color.transparent));
-
         ThemeUtils.setTheme(this);
         super.onCreate(savedInstanceState);
 

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -30,7 +30,7 @@
         <item name="actionModeTextColor">@color/white</item>
         <item name="colorAccent">@color/simplenote_blue</item>
         <item name="colorPrimary">@color/toolbar_light</item>
-        <item name="colorPrimaryDark">@color/gray_light</item>
+        <item name="colorPrimaryDark">@color/toolbar_light</item>
         <item name="dividerColor">@color/divider_list_light</item>
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
         <item name="editorSearchHighlightBackgroundColor">#FF4F91CC</item>


### PR DESCRIPTION
### Fix
Update the status bar color to mimic the changes in https://github.com/Automattic/simplenote-android/pull/695.  Two things were overlooked during a merge conflict resolution causing the status bar color to be darker than expected while using the ***Light*** theme.  See the screenshots below for illustration.

![status_light_merge](https://user-images.githubusercontent.com/3827611/60565823-3ed36100-9d22-11e9-9107-c7873fb908c1.png)

### Test
0. Set theme to ***Light***.
1. Go to notes list.
2. Notice status bar color is `#cccccc`.
3. Open navigation drawer.
4. Notice status bar color is `#cccccc`.
5. Tap ***Settings*** item.
6. Notice status bar color is `#cccccc`.

### Review
Only one developer is required to review these changes, but anyone can perform the review.