### PR TITLE
Update to targetSdkVersion 28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     - platform-tools
     - tools
     - build-tools-28.0.3
-    - android-27
+    - android-28
 
 env:
   global:

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -68,7 +68,7 @@ android {
         unitTests.returnDefaultValues = true
     }
 
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {
@@ -76,7 +76,7 @@ android {
         versionName project.version
         versionCode 76
         minSdkVersion 23
-        targetSdkVersion 27
+        targetSdkVersion 28
 
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
      }
@@ -96,8 +96,6 @@ android {
 	lintOptions {
 	    checkReleaseBuilds false
 	}
-
-    useLibrary 'org.apache.http.legacy'
 }
 
 if(["storeFile", "storePassword", "keyAlias", "keyPassword"].count { !project.hasProperty(it) } == 0 ){

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    googleVersion = '27.1.1'
+    googleVersion = '28.0.0'
 }
 
 dependencies {
@@ -47,7 +47,11 @@ dependencies {
     implementation "com.android.support:preference-v7:$googleVersion"
     implementation "com.android.support:preference-v14:$googleVersion"
     // Google Play Services
-    implementation 'com.google.android.gms:play-services-wearable:15.0.1'
+    implementation ('com.google.android.gms:play-services-wearable:16.0.1') {
+        // Necessary to avoid version conflicts
+        exclude group: 'com.android.support', module: 'support-media-compat'
+        exclude group: 'com.android.support', module: 'support-v4'
+    }
     // Third Party
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation 'com.takisoft.fix:preference-v7:27.1.1.1'

--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -81,6 +81,8 @@
             android:name="com.sec.android.app.multiwindow"
             android:required="false" />
 
+        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
+
         <meta-data
             android:name="com.sec.android.support.multiwindow"
             android:value="true" />

--- a/Wear/build.gradle
+++ b/Wear/build.gradle
@@ -12,13 +12,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "com.automattic.simplenote"
         minSdkVersion 20
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -35,7 +35,7 @@ dependencies {
     compileOnly 'com.google.android.wearable:wearable:2.3.0'
 
     implementation 'com.google.android.support:wearable:2.3.0'
-    implementation ('com.google.android.gms:play-services-wearable:15.0.1'){
+    implementation ('com.google.android.gms:play-services-wearable:16.0.1'){
         exclude group: 'com.android.support', module: 'support-v4'
     }
 }


### PR DESCRIPTION
## Migration documentation

I read the [migration](https://developer.android.com/about/versions/pie/android-9.0-migration) and the [what changed in Android 9](https://developer.android.com/about/versions/pie/android-9.0-changes-28) documentation. I identified only one task for Simplenote:


> To continue using the Apache HTTP client, apps that target Android 9 and above can add the following to their AndroidManifest.xml:

Done in a092c02

Note: We can't bump `com.google.android.gms:play-services-wearable` version to version 17 yet. It requires Android X.
