### PR TITLE
Issue/732 crash bullet list

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/AutoBullet.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/AutoBullet.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 
 public class AutoBullet {
 
-    private static final String PATTERN_BULLET = "^([\\s]*)[-*+][\\s]+(.*)$";
+    private static final String PATTERN_BULLET = "^([\\s]*)([-*+])[\\s]+(.*)$";
     private static final String STR_LINE_BREAK = System.getProperty("line.separator");
     private static final String STR_SPACE = " ";
 


### PR DESCRIPTION
### Fix
Update the regular expression pattern used to detect when a bullet list is being edited and automatically insert a bullet (i.e. dash) to close #732.

### Test
1. Create note with the following content.
```
List

- 1
- 2
- 3
- 4
```
2. Place cursor at end of any line in list.
3. Tap ***Enter***/***Return*** key.
4. Notice app doesn't crash.
5. Notice <code>- </code> is inserted on new line.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

#### Note
@loremattei, this bug was introduced with the 1.8.0 changes and requires a hotfix.