### PR TITLE
Issue/731 remove simperium link

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/AboutFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AboutFragment.java
@@ -27,7 +27,6 @@ public class AboutFragment extends Fragment {
     private static final String SIMPLENOTE_HIRING_HANDLE = "https://automattic.com/work-with-us/";
     private static final String TWITTER_PROFILE_URL = "https://twitter.com/#!/";
     private static final String TWITTER_APP_URI = "twitter://user?screen_name=";
-    private static final String SIMPERIUM_URL = "https://simperium.com";
     private static final String PLAY_STORE_URL = "http://play.google.com/store/apps/details?id=";
     private static final String PLAY_STORE_URI = "market://details?id=";
 
@@ -42,7 +41,6 @@ public class AboutFragment extends Fragment {
         ImageView logoImageView = view.findViewById(R.id.about_logo);
         View blog = view.findViewById(R.id.about_blog);
         View twitter = view.findViewById(R.id.about_twitter);
-        View simperium = view.findViewById(R.id.about_simperium);
         View playStore = view.findViewById(R.id.about_play_store);
         View hiring = view.findViewById(R.id.about_hiring);
 
@@ -71,17 +69,6 @@ public class AboutFragment extends Fragment {
                     startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(TWITTER_APP_URI + SIMPLENOTE_TWITTER_HANDLE)));
                 } catch (Exception e) {
                     startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(TWITTER_PROFILE_URL + SIMPLENOTE_TWITTER_HANDLE)));
-                }
-            }
-        });
-
-        simperium.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                try {
-                    startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(SIMPERIUM_URL)));
-                } catch (Exception e) {
-                    Toast.makeText(getActivity(), R.string.no_browser_available, Toast.LENGTH_LONG).show();
                 }
             }
         });

--- a/Simplenote/src/main/res/layout/fragment_about.xml
+++ b/Simplenote/src/main/res/layout/fragment_about.xml
@@ -114,43 +114,6 @@
         </View>
 
         <LinearLayout
-            android:id="@+id/about_simperium"
-            android:background="?attr/selectableItemBackground"
-            android:clickable="true"
-            android:focusable="true"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"
-            android:orientation="vertical"
-            android:paddingBottom="@dimen/padding_medium"
-            android:paddingTop="@dimen/padding_medium">
-
-            <com.automattic.simplenote.widgets.RobotoLightTextView
-                android:layout_height="wrap_content"
-                android:layout_width="match_parent"
-                android:paddingEnd="@dimen/padding_large"
-                android:paddingStart="@dimen/padding_large"
-                android:text="@string/simperium"
-                android:textSize="22sp">
-            </com.automattic.simplenote.widgets.RobotoLightTextView>
-
-            <com.automattic.simplenote.widgets.RobotoLightTextView
-                android:layout_height="wrap_content"
-                android:layout_width="match_parent"
-                android:paddingEnd="@dimen/padding_large"
-                android:paddingStart="@dimen/padding_large"
-                android:text="@string/simperium_summary"
-                android:textSize="15sp">
-            </com.automattic.simplenote.widgets.RobotoLightTextView>
-
-        </LinearLayout>
-
-        <View
-            android:background="@android:color/white"
-            android:layout_height="1px"
-            android:layout_width="match_parent">
-        </View>
-
-        <LinearLayout
             android:id="@+id/about_play_store"
             android:background="?attr/selectableItemBackground"
             android:clickable="true"

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -161,8 +161,6 @@
     <string name="blog">Blog</string>
     <string name="no_browser_available">\"Unable to open website. No browser available.\"</string>
     <string name="simplenote_blog_url" translatable="false">simplenote.com/blog</string>
-    <string name="simperium">Simperium</string>
-    <string name="simperium_summary">Add data sync to your app</string>
 
     <!-- Unsynced note warnings -->
     <string name="unsynced_notes">Unsynced notes detected</string>


### PR DESCRIPTION
### Fix
Remove the ***Simperium*** item from the ***About*** screen to close #731.  See the screenshots below for illustration.

![731](https://user-images.githubusercontent.com/3827611/60775042-8bc88600-a0da-11e9-9bb0-6263f9a861d3.png)

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item.
3. Scroll to bottom.
4. Tap ***About Simplenote*** under ***More Information*** section.
5. Notice ***Simperium*** item is gone.

### Review
Only one developer is required to review these changes, but anyone can perform the review.