### PR TITLE
Fix Correctness>Messages warnings

### DIFF
--- a/Simplenote/src/main/res/values-iw/strings.xml
+++ b/Simplenote/src/main/res/values-iw/strings.xml
@@ -17,7 +17,6 @@
     <string name="automattic_copyright">‎©2016 Automattic, Inc.‎</string>
     <string name="rate_us">נשמח לקבל ממך דירוג</string>
     <string name="twitter">טוויטר</string>
-    <string name="about_twitter_handle">‎@simplenoteapp</string>
     <string name="about_play_store">חנות Google Play</string>
     <string name="about_hiring">Simplenote נוצר באהבה על ידי אנשי Automattic. האם יש לך ניסיון בפיתוח? נשמח לקבל אותך.</string>
     <string name="about">אודות Simplenote</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name" translatable="false">Simplenote</string>
     <string name="app_launcher_name" translatable="false">@string/app_name</string>
@@ -142,6 +142,7 @@
     <string name="passcode_turn_off">Turn PIN lock off</string>
     <string name="passcode_turn_on">Turn PIN lock on</string>
     <string name="passcode_summary">Screenshots are disabled while PIN lock is on</string>
+    <string name="description_fingerprint_supported">Fingerprint Supported</string>
 
     <!-- Themes -->
     <string name="theme_light">Light</string>
@@ -160,8 +161,6 @@
     <string name="blog">Blog</string>
     <string name="no_browser_available">\"Unable to open website. No browser available.\"</string>
     <string name="simplenote_blog_url" translatable="false">simplenote.com/blog</string>
-    <string name="simperium">Simperium</string>
-    <string name="simperium_summary">Add data sync to your app</string>
 
     <!-- Unsynced note warnings -->
     <string name="unsynced_notes">Unsynced notes detected</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
     <string name="app_name" translatable="false">Simplenote</string>
     <string name="app_launcher_name" translatable="false">@string/app_name</string>
@@ -36,8 +36,8 @@
     <string name="website">Visit simplenote.com</string>
     <string name="more_info">More Information</string>
     <string name="note_pinned">Note pinned.</string>
-    <string name="note_selected" tools:ignore="PluralsCandidate">%d note selected</string>
-    <string name="notes_selected" tools:ignore="PluralsCandidate">%d notes selected</string>
+    <string name="note_selected">%d note selected</string>
+    <string name="notes_selected">%d notes selected</string>
     <string name="note_added">Note added</string>
     <string name="search">Search notes</string>
     <string name="notes">Notes</string>
@@ -142,7 +142,6 @@
     <string name="passcode_turn_off">Turn PIN lock off</string>
     <string name="passcode_turn_on">Turn PIN lock on</string>
     <string name="passcode_summary">Screenshots are disabled while PIN lock is on</string>
-    <string name="description_fingerprint_supported">Fingerprint Supported</string>
 
     <!-- Themes -->
     <string name="theme_light">Light</string>
@@ -161,6 +160,8 @@
     <string name="blog">Blog</string>
     <string name="no_browser_available">\"Unable to open website. No browser available.\"</string>
     <string name="simplenote_blog_url" translatable="false">simplenote.com/blog</string>
+    <string name="simperium">Simperium</string>
+    <string name="simperium_summary">Add data sync to your app</string>
 
     <!-- Unsynced note warnings -->
     <string name="unsynced_notes">Unsynced notes detected</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name" translatable="false">Simplenote</string>
     <string name="app_launcher_name" translatable="false">@string/app_name</string>
@@ -36,8 +36,8 @@
     <string name="website">Visit simplenote.com</string>
     <string name="more_info">More Information</string>
     <string name="note_pinned">Note pinned.</string>
-    <string name="note_selected">%d note selected</string>
-    <string name="notes_selected">%d notes selected</string>
+    <string name="note_selected" tools:ignore="PluralsCandidate">%d note selected</string>
+    <string name="notes_selected" tools:ignore="PluralsCandidate">%d notes selected</string>
     <string name="note_added">Note added</string>
     <string name="search">Search notes</string>
     <string name="notes">Notes</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
     <string name="app_name" translatable="false">Simplenote</string>
     <string name="app_launcher_name" translatable="false">@string/app_name</string>


### PR DESCRIPTION
### Fix
This is a partial code cleanup. #564 #255
Fix Correctness>Messages warnings:
* ~~Ignore `Potential Plurals` warnings for `note_selected` and `notes_selected` strings since they are used by the plural already defined in `plurals.xml`.~~
* Remove untranslatable string `about_twitter_handle` from `strings.xml(iw)`.

### Test
* Verify `gradlew lintRelease` report doesn't contain Correctness>Messages warnings.
* Verify continuous integration build succeeds.
* Verify app builds and runs without error.

### Review
Only one developer is required to review these changes, but anyone can perform the review.