### PR TITLE
Add Sentry (and the secret store)

### DIFF
--- a/.configure
+++ b/.configure
@@ -1,6 +1,6 @@
 {
   "branch": "master",
-  "pinned_hash": "7900133aac3761caf323024ca63f0104b22fbc5e",
+  "pinned_hash": "438df3c6206e9d31adc712ecef5825cab64bdeb0",
   "files_to_copy": [
     {
       "file": "android/simplenote/gradle.properties",
@@ -9,6 +9,10 @@
     {
       "file": "android/simplenote/Simplenote/gradle.properties",
       "destination": "Simplenote/gradle.properties"
+    },
+    {
+      "file": "android/simplenote/sentry.properties",
+      "destination": "sentry.properties"
     }
   ],
   "file_dependencies": [

--- a/.configure
+++ b/.configure
@@ -1,0 +1,17 @@
+{
+  "branch": "master",
+  "pinned_hash": "7900133aac3761caf323024ca63f0104b22fbc5e",
+  "files_to_copy": [
+    {
+      "file": "android/simplenote/gradle.properties",
+      "destination": "gradle.properties"
+    },
+    {
+      "file": "android/simplenote/Simplenote/gradle.properties",
+      "destination": "Simplenote/gradle.properties"
+    }
+  ],
+  "file_dependencies": [
+
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 bin/
 gen/
 build/
+vendor/
 
 # Local configuration file (sdk path, etc)
 local.properties
@@ -31,6 +32,7 @@ config.properties
 # Gradle
 .gradle/
 gradle.properties
+sentry.properties
 Simplenote/gradle.properties
 
 *.keystore
@@ -46,8 +48,5 @@ fastlane/README.md
 fastlane/report.xml
 fastlane/.env
 
-# Ruby Dependencies
-/vendor
-
-# Eclypse
+# Eclipse
 .settings/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,19 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 6586eba8ca98279e4f4196bd0a579d1d4d8d3210
-  tag: 0.2.2
+  revision: ac95ea0ddab9ad287a455711f423b96cf37f3e8f
+  tag: 0.3.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.2.2)
-      diffy
-      git
-      nokogiri
-      octokit
+    fastlane-plugin-wpmreleasetoolkit (0.3.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      jsonlint
+      nokogiri (= 1.10.1)
+      octokit (~> 4.13)
+      parallel (~> 1.14)
+      progress_bar (~> 1.3)
+      rake (~> 12.3)
+      rake-compiler (~> 1.0)
+      rmagick (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -107,6 +113,9 @@ GEM
       domain_name (~> 0.5)
     httpclient (2.8.3)
     json (2.2.0)
+    jsonlint (0.3.0)
+      oj (~> 3)
+      optimist (~> 3)
     jwt (2.1.0)
     memoist (0.16.0)
     mime-types (3.2.2)
@@ -119,18 +128,29 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.2.6)
     naturally (2.2.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
+    oj (3.7.12)
+    optimist (3.0.0)
+    options (2.3.2)
     os (1.0.1)
+    parallel (1.17.0)
     plist (3.5.0)
+    progress_bar (1.3.0)
+      highline (>= 1.6, < 3)
+      options (~> 2.3.0)
     public_suffix (2.0.5)
+    rake (12.3.2)
+    rake-compiler (1.0.7)
+      rake
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
+    rmagick (3.2.0)
     rouge (2.0.7)
     rubyzip (1.2.3)
     sawyer (0.8.2)

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -1,21 +1,20 @@
 buildscript {
     repositories {
         google()
-        maven { url 'https://maven.fabric.io/public' }
         jcenter()
     }
     dependencies {
-        classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.16'
     }
 }
 
 apply plugin: 'com.android.application'
-apply plugin: "io.fabric"
+apply plugin: 'io.sentry.android.gradle'
 
 repositories {
     maven { url "https://s3.amazonaws.com/repo.commonsware.com" }
-    maven { url 'https://maven.fabric.io/public' }
     maven { url "https://maven.google.com" }
+    maven { url "https://jitpack.io" }
     jcenter()
 }
 
@@ -39,8 +38,9 @@ dependencies {
     }
     // Automattic and WordPress dependencies
     implementation 'com.simperium.android:simperium:0.7.1'
-    implementation 'com.automattic:tracks:1.1.6'
+    implementation 'com.github.Automattic:Automattic-Tracks-Android:52d3e23406'
     implementation 'org.wordpress:passcodelock:1.6.0'
+
     // Google Support
     implementation "com.android.support:appcompat-v7:$googleVersion"
     implementation "com.android.support:design:$googleVersion"
@@ -112,7 +112,7 @@ if(["storeFile", "storePassword", "keyAlias", "keyPassword"].count { !project.ha
               keyPassword = project.keyPassword
           }
           debug {
-              storeFile = file(project.storeFile)
+              storeFile = file(project.storeFile.replaceFirst("^~", System.getProperty("user.home")))
               storePassword = project.storePassword
               keyAlias = project.keyAlias
               keyPassword = project.keyPassword
@@ -171,6 +171,7 @@ android.applicationVariants.all { variant ->
         if (key == "SIMPERIUM_APP_ID" ||
             key == "SIMPERIUM_APP_KEY" ||
             key == "GOOGLE_ANALYTICS_ID" ||
+            key == "SENTRY_DSN" ||
             key == "WPCOM_CLIENT_ID") {
             buildConfigField "String", key, "\"${property.value}\""
         }

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -106,7 +106,7 @@ if(["storeFile", "storePassword", "keyAlias", "keyPassword"].count { !project.ha
     android {
       signingConfigs {
           release {
-              storeFile = file(project.storeFile)
+              storeFile = file(project.storeFile.replaceFirst("^~", System.getProperty("user.home")))
               storePassword = project.storePassword
               keyAlias = project.keyAlias
               keyPassword = project.keyPassword

--- a/Simplenote/gradle.properties-example
+++ b/Simplenote/gradle.properties-example
@@ -3,3 +3,4 @@ simperiumAppKey = dccacc59bbef4982a15abaeafaf7bc8a
 crashlyticsApiKey = 0
 googleAnalyticsId =
 wpcomClientId =
+sentryDsn=https://00000000000000000000000000000000@sentry.io/00000000

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -36,6 +36,7 @@ import android.widget.ProgressBar;
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
+import com.automattic.simplenote.utils.CrashUtils;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
@@ -910,6 +911,7 @@ public class NotesActivity extends AppCompatActivity implements
 
                 Simplenote app = (Simplenote) getApplication();
                 AnalyticsTracker.refreshMetadata(app.getSimperium().getUser().getEmail());
+                CrashUtils.setCurrentUser(app.getSimperium().getUser());
 
                 AnalyticsTracker.track(
                         AnalyticsTracker.Stat.USER_SIGNED_IN,

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -19,6 +19,7 @@ import android.widget.Toast;
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Preferences;
+import com.automattic.simplenote.utils.CrashUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.automattic.simplenote.utils.ThemeUtils;
@@ -291,6 +292,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
 
         // Resets analytics user back to 'anon' type
         AnalyticsTracker.refreshMetadata(null);
+        CrashUtils.clearCurrentUser();
 
         // Remove wp.com token
         SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(getActivity()).edit();
@@ -318,6 +320,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
 
             Simplenote app = (Simplenote) getActivity().getApplication();
             AnalyticsTracker.refreshMetadata(app.getSimperium().getUser().getEmail());
+            CrashUtils.setCurrentUser(app.getSimperium().getUser());
 
             AnalyticsTracker.track(
                     AnalyticsTracker.Stat.USER_SIGNED_IN,

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -15,8 +15,8 @@ import com.automattic.simplenote.models.NoteCountIndexer;
 import com.automattic.simplenote.models.NoteTagger;
 import com.automattic.simplenote.models.Preferences;
 import com.automattic.simplenote.models.Tag;
+import com.automattic.simplenote.utils.CrashUtils;
 import com.automattic.simplenote.utils.PrefUtils;
-import com.crashlytics.android.Crashlytics;
 import com.simperium.Simperium;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketNameInvalid;
@@ -24,7 +24,6 @@ import com.simperium.client.BucketObjectMissingException;
 
 import org.wordpress.passcodelock.AppLockManager;
 
-import io.fabric.sdk.android.Fabric;
 
 import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
 
@@ -49,9 +48,7 @@ public class Simplenote extends Application {
     public void onCreate() {
         super.onCreate();
 
-        if (!BuildConfig.DEBUG) {
-            Fabric.with(this, new Crashlytics());
-        }
+        CrashUtils.initWithContext(this);
 
         AppLockManager.getInstance().enableDefaultAppLockIfAvailable(this);
 
@@ -85,6 +82,7 @@ public class Simplenote extends Application {
 
         AnalyticsTracker.registerTracker(new AnalyticsTrackerNosara(this));
         AnalyticsTracker.refreshMetadata(mSimperium.getUser().getEmail());
+        CrashUtils.setCurrentUser(mSimperium.getUser());
     }
 
     @SuppressWarnings("unused")

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/CrashUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/CrashUtils.java
@@ -1,0 +1,114 @@
+package com.automattic.simplenote.utils;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.automattic.android.tracks.CrashLogging.CrashLogging;
+import com.automattic.android.tracks.CrashLogging.CrashLoggingDataProvider;
+import com.automattic.android.tracks.TracksUser;
+import com.automattic.simplenote.BuildConfig;
+import com.automattic.simplenote.Simplenote;
+import com.simperium.client.User;
+
+import java.util.Locale;
+import java.util.Map;
+
+public class CrashUtils implements CrashLoggingDataProvider {
+
+    private User currentUser;
+    private Locale locale;
+
+    private static CrashUtils sharedInstance;
+
+    public static void initWithContext(Context context) {
+
+        if (sharedInstance != null) {
+            return;
+        }
+
+        sharedInstance = new CrashUtils();
+        sharedInstance.locale = localeForContext(context);
+
+        CrashLogging.start(context, sharedInstance);
+    }
+
+    public static void setCurrentUser(User user) {
+        sharedInstance.currentUser = user;
+        CrashLogging.setNeedsDataRefresh();
+    }
+
+    public static void clearCurrentUser() {
+        sharedInstance.currentUser = null;
+        CrashLogging.setNeedsDataRefresh();
+    }
+
+    @Override
+    public String sentryDSN() {
+        return BuildConfig.SENTRY_DSN;
+    }
+
+    @Override
+    public boolean getUserHasOptedOut() {
+        return !Simplenote.analyticsIsEnabled();
+    }
+
+    @NonNull
+    @Override
+    public String buildType() {
+        return BuildConfig.BUILD_TYPE;
+    }
+
+    @NonNull
+    @Override
+    public String releaseName() {
+        return BuildConfig.VERSION_NAME;
+    }
+
+    @Nullable
+    @Override
+    public TracksUser currentUser() {
+
+        if (sharedInstance.currentUser == null) {
+            return null;
+        }
+
+        String userID = sharedInstance.currentUser.getUserId();
+        String email =  sharedInstance.currentUser.getEmail();
+
+        return new TracksUser(userID, email, "");
+    }
+
+    @NonNull
+    @Override
+    public Map<String, Object> applicationContext() {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Map<String, Object> userContext() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Locale locale() {
+        return sharedInstance.locale;
+    }
+
+    @SuppressWarnings( "deprecation" )
+    private static Locale localeForContext(Context context) {
+
+        Resources resources = context.getResources();
+
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
+            return resources.getConfiguration().getLocales().get(0);
+        }
+        else {
+            return resources.getConfiguration().locale;
+        }
+    }
+}

--- a/Wear/build.gradle
+++ b/Wear/build.gradle
@@ -44,13 +44,13 @@ if(["storeFile", "storePassword", "keyAlias", "keyPassword"].count { !project.ha
     android {
         signingConfigs {
             release {
-                storeFile = file(project.storeFile)
+                storeFile = file(project.storeFile.replaceFirst("^~", System.getProperty("user.home")))
                 storePassword = project.storePassword
                 keyAlias = project.keyAlias
                 keyPassword = project.keyPassword
             }
             debug {
-                storeFile = file(project.storeFile)
+                storeFile = file(project.storeFile.replaceFirst("^~", System.getProperty("user.home")))
                 storePassword = project.storePassword
                 keyAlias = project.keyAlias
                 keyPassword = project.keyPassword

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.2.2'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.3.0'


### PR DESCRIPTION
### Fix
Adds Sentry crash logging (and as a side-effect, support for the secret store).

### Test
> 1. Check out this branch. Once it's checked out, run `bundle install` and `bundle exec fastlane run configure_apply`.
> 2. Add a crash in the application code. I'd recommend adding `CrashLogging.crash();` to your local copy of the code in [this location](https://github.com/Automattic/simplenote-android/blob/cf5fd707739a33226f58c3edccbc6a2df8bd8c0c/Simplenote/src/main/java/com/automattic/simplenote/AboutActivity.java#L17).
> 3. Run `./gradlew assembleRelease`, and install the `Simplenote/build/outputs/release/Simplenote-release.apk` executable on a physical device. 
> 4. Trigger your crash and relaunch the app.
> 5. Note that the crash shows up in Sentry, along with the relevant user data.

### Release
These changes are not user-facing, and don't require a release notes update.