### PR TITLE
Bugfix: Correct "Restore note" icon is now being shown in markdown preview of deleted notes

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -39,13 +39,16 @@ public class NoteMarkdownFragment extends Fragment {
             viewPublishedNoteItem.setVisible(true);
 
             MenuItem trashItem = menu.findItem(R.id.menu_delete).setTitle(R.string.undelete);
-            DrawableUtils.tintMenuItemWithAttribute(getActivity(), trashItem, R.attr.actionBarTextColor);
 
             if (mNote.isDeleted()) {
                 trashItem.setTitle(R.string.undelete);
+                trashItem.setIcon(R.drawable.ic_trash_restore_24dp);
             } else {
                 trashItem.setTitle(R.string.delete);
+                trashItem.setIcon(R.drawable.ic_trash_24dp);
             }
+
+            DrawableUtils.tintMenuItemWithAttribute(getActivity(), trashItem, R.attr.actionBarTextColor);
         }
 
         super.onCreateOptionsMenu(menu, inflater);


### PR DESCRIPTION
### Fix
Fixes incorrect "Restore note" icon in markdown preview for deleted notes #739.

### Test
1. Create a new note.
2. Enable markdown support for that note.
3. Delete that note.
4. Go to Trash and open the note you just deleted.
5. Observe correct note restoration icons between note editing and note preview screens like in the demo below.

### Demo
Before|After
-|-
![Before](https://user-images.githubusercontent.com/18679771/60976959-85c6e500-a326-11e9-9a7c-678dee2dd37a.gif)|![After](https://user-images.githubusercontent.com/18679771/60977197-f1a94d80-a326-11e9-8700-3ec665398411.gif)|

### Review
Only one developer is required to review these changes.

### Release
Fixed incorrect "Restore note" icon in markdown preview of icons in trash.
