### PR TITLE
Add tagged version of sentry

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -14,7 +14,6 @@ apply plugin: 'io.sentry.android.gradle'
 repositories {
     maven { url "https://s3.amazonaws.com/repo.commonsware.com" }
     maven { url "https://maven.google.com" }
-    maven { url "https://jitpack.io" }
     jcenter()
 }
 
@@ -38,7 +37,7 @@ dependencies {
     }
     // Automattic and WordPress dependencies
     implementation 'com.simperium.android:simperium:0.7.1'
-    implementation 'com.github.Automattic:Automattic-Tracks-Android:52d3e23406'
+    implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:1.6.0'
 
     // Google Support


### PR DESCRIPTION
### Fix
Reference a tagged version of Sentry rather than a commit hash.

### Test
This code is identical to the prior version of the app. If it compiles and runs, it means that you're using the same version of the Tracks library.

### Release
This change is not user-facing and doesn't require a release notes update.