### PR TITLE
Fix bundle version and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,8 @@ fastlane/README.md
 fastlane/report.xml
 fastlane/.env
 
+# Configure
+*.bak
+
 # Eclipse
 .settings/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,4 +199,4 @@ DEPENDENCIES
   nokogiri!
 
 BUNDLED WITH
-   2.0.1
+   1.17.3


### PR DESCRIPTION
This PR adds two small fixes to the current configuration:
- adds `.bak` file to `.gitignore`. `.bak` files are generated by the Configure tool to backup the current `gradle.properties` when updating to a new version.
- switch to `bundle` 1.17 as this is the version we use in our other projects. 

# To Test
1. Add a .bak file in the same folder of `gradle.properties` and verify that it's ignored by git. 
2. Run `bundle install` and verify that it works without errors. 
3. Verify that the CI tests are good. 
