### PR TITLE
Change versioning in build.gradle

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -64,8 +64,6 @@ dependencies {
     wearApp project(':Wear')
 }
 
-version "1.8.1"
-
 android {
     testOptions {
         unitTests.returnDefaultValues = true
@@ -76,7 +74,7 @@ android {
 
     defaultConfig {
         applicationId "com.automattic.simplenote"
-        versionName project.version
+        versionName "1.8.1"
         versionCode 77
         minSdkVersion 23
         targetSdkVersion 28


### PR DESCRIPTION
This PR changes the way the version is set in `build.gradle` in order to make it compatible with our release tools.

# To Test
1. Run `./gradlew clean` and `./gradlew assembleRelease`.
2. Verify that the build finishes without errors.
3. Run the app and verify that the version in the About box is correct.

