### PR TITLE
Add codefreeze lane

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: ac95ea0ddab9ad287a455711f423b96cf37f3e8f
-  tag: 0.3.0
+  revision: 88ab0590095659574cbd46385f94b1ecd1bed14e
+  ref: 88ab0590095659574cbd46385f94b1ecd1bed14e
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.3.0)
+    fastlane-plugin-wpmreleasetoolkit (0.5.0)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
@@ -199,4 +199,4 @@ DEPENDENCIES
   nokogiri!
 
 BUNDLED WITH
-   2.0.1
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 08dde8b7c3d0a65811afed269052d1d985c56880
-  ref: 08dde8b7c3d0a65811afed269052d1d985c56880
+  revision: c555066402074a527a9853932790da8198eb7f21
+  tag: 0.6.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.5.0)
+    fastlane-plugin-wpmreleasetoolkit (0.6.0)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
@@ -13,7 +13,6 @@ GIT
       progress_bar (~> 1.3)
       rake (~> 12.3)
       rake-compiler (~> 1.0)
-      rmagick (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -132,7 +131,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.7.12)
+    oj (3.8.0)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)
@@ -150,7 +149,6 @@ GEM
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rmagick (3.2.0)
     rouge (2.0.7)
     rubyzip (1.2.3)
     sawyer (0.8.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 88ab0590095659574cbd46385f94b1ecd1bed14e
-  ref: 88ab0590095659574cbd46385f94b1ecd1bed14e
+  revision: 08dde8b7c3d0a65811afed269052d1d985c56880
+  ref: 08dde8b7c3d0a65811afed269052d1d985c56880
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.5.0)
       diffy (~> 3.3)

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -64,8 +64,6 @@ dependencies {
     wearApp project(':Wear')
 }
 
-version "1.8.1"
-
 android {
     testOptions {
         unitTests.returnDefaultValues = true
@@ -76,7 +74,7 @@ android {
 
     defaultConfig {
         applicationId "com.automattic.simplenote"
-        versionName project.version
+        versionName "1.8.1"
         versionCode 77
         minSdkVersion 23
         targetSdkVersion 28

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,7 +36,6 @@ ENV["PROJECT_NAME"]="Simplenote"
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
     
-    localize_libs()
     android_tag_build()
     get_prs_list(repository:GHHELPER_REPO, start_tag:"release/#{old_version}", report_path:"#{File.expand_path('~')}/simplenoteandroid_prs_list_#{old_version}_#{new_version}.txt")
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,16 +8,43 @@ platform :android do
 Dotenv.load('~/.simplenoteandroid-env.default')
 ENV[GHHELPER_REPO="automattic/simplenote-android"]
 ENV["PROJECT_ROOT_FOLDER"]="./"
+ENV["PROJECT_NAME"]="Simplenote"
 
 ########################################################################
 # Release Lanes
 ########################################################################  
-
+  #####################################################################################
+  # code_freeze
+  # -----------------------------------------------------------------------------------
+  # This lane executes the steps planned on code freeze
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane code_freeze [update_release_branch_version:<update flag>] [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane code_freeze 
+  # bundle exec fastlane code_freeze update_release_branch_version:false
+  # bundle exec fastlane code_freeze skip_confirm:true
+  #####################################################################################
+  desc "Creates a new release branch from the current develop"
+  lane :code_freeze do | options |
+    old_version = android_codefreeze_prechecks(options)
+   
+    android_bump_version_release()
+    new_version = android_get_app_version()
+    android_update_release_notes(new_version: new_version)
+    setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
+    setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
+    
+    localize_libs()
+    android_tag_build()
+    get_prs_list(repository:GHHELPER_REPO, start_tag:"release/#{old_version}", report_path:"#{File.expand_path('~')}/simplenoteandroid_prs_list_#{old_version}_#{new_version}.txt")
+  end
 ########################################################################
 # Helper Lanes
 ########################################################################  
   desc "Get a list of pull request from `start_tag` to the current state"
   lane :get_pullrequests_list do | options |
-    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{options[:start_tag]}", report_path:"#{File.expand_path('~')}/simplenote-android_prs_list.txt")
+    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{options[:start_tag]}", report_path:"#{File.expand_path('~')}/simplenoteandroid_prs_list.txt")
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,7 +37,7 @@ ENV["PROJECT_NAME"]="Simplenote"
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
     
     android_tag_build()
-    get_prs_list(repository:GHHELPER_REPO, start_tag:"release/#{old_version}", report_path:"#{File.expand_path('~')}/simplenoteandroid_prs_list_#{old_version}_#{new_version}.txt")
+    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/simplenoteandroid_prs_list_#{old_version}_#{new_version}.txt")
   end
 ########################################################################
 # Helper Lanes

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '08dde8b7c3d0a65811afed269052d1d985c56880'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.6.0'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.3.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '88ab0590095659574cbd46385f94b1ecd1bed14e'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '88ab0590095659574cbd46385f94b1ecd1bed14e'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '08dde8b7c3d0a65811afed269052d1d985c56880'


### PR DESCRIPTION
This PR adds a lane to automate some of the steps of the code freeze process. 
This PR builds on top of https://github.com/Automattic/simplenote-android/pull/744 and should be tested and merged after 744 is merged. 

# To Test
1. Run `bundle install`.
2. Run `bundle exec fastlane code_freeze`.
3. When prompted, verify that the versions are right and confirm. 
4. Verify that the script completes without errors.
5. Verify that a new branch has been created (currently it should be `release/1.9`) and pushed. 
6. Verify that the version has been updated (`1.9-rc-1`).
7. Verify that a new `1.9-rc-1` tag has been added and pushed. 
8. Verify that the snowflake tag has been added to the relevant milestone (currently `1.9`).
9. Verify that `simplenoteandroid_prs_list_1.8.1_1.9.txt` has been created in your home folder with the changelog. 

### Clean up
1. Remove the snowflake tag from the `1.9` milestone.
2. Remove the branch protection from `release/1.9`.
3. Delete the `release/1.9` branch from your local repository and from GitHub.
4. Delete the `1.9-rc-1` tag from your local repository and from GitHub.
