### PR TITLE
Update Keyboard Super

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -66,7 +66,8 @@ public class SimplenoteEditText extends AppCompatEditText {
         if (event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
             clearFocus();
         }
-        return super.dispatchKeyEvent(event);
+
+        return super.onKeyPreIme(keyCode, event);
     }
 
     @Override


### PR DESCRIPTION
### Fix
Update the returned `super` method for the keyboard pre-input method editor override from `dispatchKeyEvent(event)` to `onKeyPreIme(keyCode, event)` to fix issues with Japanese and Korean keyboard input.

### Test
1. Tap any note in list.
2. Set software keyboard to Japanese.
3. Type on hardware keyboard.
4. Notice characters are Japanese.
5. Set software keyboard to Korean.
6. Type on hardware keyboard.
7. Notice characters are Korean.
8. Set software keyboard to English.
9. Type on hardware keyboard.
10. Notice characters are English.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

#### Note
@loremattei, this bug was introduced with the 1.8.0 changes and requires a hotfix.