### PR TITLE
Update Readme 1.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Simplenote for Android
-[![Version](https://img.shields.io/badge/version-1.8.0-blue.svg)](https://github.com/Automattic/simplenote-android/releases/tag/1.8.0) [![CircleCI](https://img.shields.io/circleci/build/gh/Automattic/simplenote-android.svg?label=circleci)](https://circleci.com/gh/Automattic/simplenote-android) [![Travis CI](https://img.shields.io/travis/Automattic/simplenote-android/develop.svg?label=travisci)](https://travis-ci.org/Automattic/simplenote-android)
+[![Version](https://img.shields.io/badge/version-1.8.2-blue.svg)](https://github.com/Automattic/simplenote-android/releases/tag/1.8.2) [![CircleCI](https://img.shields.io/circleci/build/gh/Automattic/simplenote-android.svg?label=circleci)](https://circleci.com/gh/Automattic/simplenote-android) [![Travis CI](https://img.shields.io/travis/Automattic/simplenote-android/develop.svg?label=travisci)](https://travis-ci.org/Automattic/simplenote-android)
 
 Simplenote for Android. Learn more at [Simplenote.com](https://simplenote.com).
 


### PR DESCRIPTION
### Fix
Update the version shield to `1.8.2` and link it to [Release 1.8.2](https://github.com/Automattic/simplenote-android/releases/tag/1.8.2) in the `README.md` file.

### Test
1. Open [`README.md`](https://github.com/Automattic/simplenote-android/blob/5c56d06b6a3f40cbd3eda89fe558ac46d5b1862a/README.md) file.
2. Notice version shield shows `1.8.2`.
3. Click version shield.
4. Notice [Release 1.8.2](https://github.com/Automattic/simplenote-android/releases/tag/1.8.2) is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.