### PR TITLE
Update fastlane

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org" do
-  gem 'fastlane'
+  gem 'fastlane', "2.127.2"
   gem 'nokogiri'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,11 +31,11 @@ GEM
     declarative-option (0.1.0)
     diffy (3.3.0)
     digest-crc (0.4.1)
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.7.2)
+    dotenv (2.7.4)
     emoji_regex (1.0.1)
-    excon (0.64.0)
+    excon (0.65.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -44,7 +44,7 @@ GEM
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.5)
-    fastlane (2.125.2)
+    fastlane (2.127.2)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -64,7 +64,7 @@ GEM
       highline (>= 1.7.2, < 2.0.0)
       json (< 3.0.0)
       jwt (~> 2.1.0)
-      mini_magick (~> 4.5.1)
+      mini_magick (>= 4.9.4, < 5.0.0)
       multi_xml (~> 0.5)
       multipart-post (~> 2.0.0)
       plist (>= 3.1.0, < 4.0.0)
@@ -93,7 +93,7 @@ GEM
       signet (~> 0.9)
     google-cloud-core (1.3.0)
       google-cloud-env (~> 1.0)
-    google-cloud-env (1.1.0)
+    google-cloud-env (1.2.0)
       faraday (~> 0.11)
     google-cloud-storage (1.16.0)
       digest-crc (~> 0.4)
@@ -120,7 +120,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
-    mini_magick (4.5.1)
+    mini_magick (4.9.5)
     mini_portile2 (2.4.0)
     multi_json (1.13.1)
     multi_xml (0.6.0)
@@ -177,7 +177,7 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     word_wrap (1.0.0)
-    xcodeproj (1.10.0)
+    xcodeproj (1.11.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -192,7 +192,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane!
+  fastlane (= 2.127.2)!
   fastlane-plugin-wpmreleasetoolkit!
   nokogiri!
 


### PR DESCRIPTION
This PR updates `Fastlane` to get rid of the `mini_magic` security alert.

To test:

1. Run `bundle install`.
2. Run one of the release lanes (for example: build_release) and verify that it works.