### PR TITLE
Issue/721 add open preview

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 1.9.0
 -----
 * Added an option to the Theme setting to follow the system day/night mode
+* Added showing the last viewed tab when opening a note
 
 1.8.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 1.9.0
 -----
+* Added an option to the Theme setting to follow the system day/night mode
 
 1.8.0
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
@@ -59,7 +59,9 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
         mInfoMarkdownSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                if (!mFragment.isAdded()) return;
+                if (!mFragment.isAdded()){
+                    return;
+                }
 
                 infoSheetListener.onInfoMarkdownSwitchChanged(isChecked);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -15,10 +15,13 @@ import androidx.fragment.app.FragmentPagerAdapter;
 import androidx.viewpager.widget.PagerAdapter;
 
 import com.automattic.simplenote.analytics.AnalyticsTracker;
+import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.widgets.NoteEditorViewPager;
 import com.google.android.material.tabs.TabLayout;
+import com.simperium.client.Bucket;
+import com.simperium.client.BucketObjectMissingException;
 
 import org.wordpress.passcodelock.AppLockManager;
 
@@ -31,9 +34,11 @@ import static com.automattic.simplenote.utils.DisplayUtils.disableScreenshotsIfL
 
 public class NoteEditorActivity extends AppCompatActivity {
     private TabLayout mTabLayout;
+    private Note mNote;
     private NoteEditorFragmentPagerAdapter mNoteEditorFragmentPagerAdapter;
     private NoteEditorViewPager mViewPager;
     private boolean isMarkdownEnabled;
+    private boolean isPreviewEnabled;
     private String mNoteId;
 
     @Override
@@ -62,6 +67,14 @@ public class NoteEditorActivity extends AppCompatActivity {
 
         Intent intent = getIntent();
         mNoteId = intent.getStringExtra(NoteEditorFragment.ARG_ITEM_ID);
+
+        try {
+            Simplenote application = (Simplenote) getApplication();
+            Bucket<Note> notesBucket = application.getNotesBucket();
+            mNote = notesBucket.get(mNoteId);
+        } catch (BucketObjectMissingException exception) {
+            exception.printStackTrace();
+        }
 
         if (savedInstanceState == null) {
             // Create the note editor fragment
@@ -92,8 +105,13 @@ public class NoteEditorActivity extends AppCompatActivity {
                     new NoteEditorViewPager.OnPageChangeListener() {
                         @Override
                         public void onPageSelected(int position) {
-                            if (position == 1) {
+                            if (position == 1) {  // Preview is position 1
                                 DisplayUtils.hideKeyboard(mViewPager);
+                            }
+
+                            if (mNote != null) {
+                                mNote.setPreviewEnabled(position == 1);  // Preview is position 1
+                                mNote.save();
                             }
                         }
 
@@ -108,6 +126,7 @@ public class NoteEditorActivity extends AppCompatActivity {
             );
 
             isMarkdownEnabled = intent.getBooleanExtra(NoteEditorFragment.ARG_MARKDOWN_ENABLED, false);
+            isPreviewEnabled = intent.getBooleanExtra(NoteEditorFragment.ARG_PREVIEW_ENABLED, false);
         } else {
             mNoteEditorFragmentPagerAdapter.addFragment(
                     getSupportFragmentManager().getFragment(savedInstanceState, getString(R.string.tab_edit)),
@@ -119,6 +138,7 @@ public class NoteEditorActivity extends AppCompatActivity {
             );
 
             isMarkdownEnabled = savedInstanceState.getBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED);
+            isPreviewEnabled = savedInstanceState.getBoolean(NoteEditorFragment.ARG_PREVIEW_ENABLED);
         }
 
         mViewPager.setAdapter(mNoteEditorFragmentPagerAdapter);
@@ -127,6 +147,10 @@ public class NoteEditorActivity extends AppCompatActivity {
         // Show tabs if markdown is enabled for the current note.
         if (isMarkdownEnabled) {
             showTabs();
+
+            if (isPreviewEnabled) {
+                mViewPager.setCurrentItem(mNoteEditorFragmentPagerAdapter.getCount() - 1);
+            }
         }
 
         if (intent.hasExtra(KEY_WIDGET_CLICK) && intent.getExtras() != null &&
@@ -154,7 +178,7 @@ public class NoteEditorActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onSaveInstanceState(Bundle outState) {
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
         if (mNoteEditorFragmentPagerAdapter.getCount() > 0 && mNoteEditorFragmentPagerAdapter.getItem(0).isAdded()) {
             getSupportFragmentManager()
                     .putFragment(outState, getString(R.string.tab_edit), mNoteEditorFragmentPagerAdapter.getItem(0));
@@ -164,11 +188,12 @@ public class NoteEditorActivity extends AppCompatActivity {
                     .putFragment(outState, getString(R.string.tab_preview), mNoteEditorFragmentPagerAdapter.getItem(1));
         }
         outState.putBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED, isMarkdownEnabled);
+        outState.putBoolean(NoteEditorFragment.ARG_PREVIEW_ENABLED, isPreviewEnabled);
         super.onSaveInstanceState(outState);
     }
 
     @Override
-    public void onConfigurationChanged(Configuration newConfig) {
+    public void onConfigurationChanged(@NonNull Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
 
         // If changing to large screen landscape, we finish the activity to go back to
@@ -210,6 +235,7 @@ public class NoteEditorActivity extends AppCompatActivity {
             return mFragments.size();
         }
 
+        @NonNull
         @Override
         public Fragment getItem(int position) {
             return mFragments.get(position);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -88,7 +88,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
      */
     private static Callbacks sCallbacks = new Callbacks() {
         @Override
-        public void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled) {
+        public void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled, boolean isPreviewEnabled) {
         }
     };
     protected NotesCursorAdapter mNotesAdapter;
@@ -275,7 +275,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     }
 
     @Override
-    public void onAttach(Context activity) {
+    public void onAttach(@NonNull Context activity) {
         super.onAttach(activity);
 
         // Activities containing this fragment must implement its callbacks.
@@ -308,14 +308,16 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     }
 
     @Override
-    public void onListItemClick(ListView listView, View view, int position, long id) {
+    public void onListItemClick(@NonNull ListView listView, @NonNull View view, int position, long id) {
         if (!isAdded()) return;
         super.onListItemClick(listView, view, position, id);
 
         NoteViewHolder holder = (NoteViewHolder) view.getTag();
         String noteID = holder.getNoteId();
+
         if (noteID != null) {
-            mCallbacks.onNoteSelected(noteID, position, holder.matchOffsets, mNotesAdapter.getItem(position).isMarkdownEnabled());
+            Note note = mNotesAdapter.getItem(position);
+            mCallbacks.onNoteSelected(noteID, position, holder.matchOffsets, note.isMarkdownEnabled(), note.isPreviewEnabled());
         }
 
         mActivatedPosition = position;
@@ -327,7 +329,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     public void selectFirstNote() {
         if (mNotesAdapter.getCount() > 0) {
             Note selectedNote = mNotesAdapter.getItem(0);
-            mCallbacks.onNoteSelected(selectedNote.getSimperiumKey(), 0, null, selectedNote.isMarkdownEnabled());
+            mCallbacks.onNoteSelected(selectedNote.getSimperiumKey(), 0, null, selectedNote.isMarkdownEnabled(), selectedNote.isPreviewEnabled());
         }
     }
 
@@ -464,7 +466,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             new Handler().postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    mCallbacks.onNoteSelected(note.getSimperiumKey(), 0, null, note.isMarkdownEnabled());
+                    mCallbacks.onNoteSelected(note.getSimperiumKey(), 0, null, note.isMarkdownEnabled(), note.isPreviewEnabled());
                 }
             }, 50);
         } else {
@@ -472,6 +474,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             arguments.putString(NoteEditorFragment.ARG_ITEM_ID, note.getSimperiumKey());
             arguments.putBoolean(NoteEditorFragment.ARG_NEW_NOTE, true);
             arguments.putBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED, note.isMarkdownEnabled());
+            arguments.putBoolean(NoteEditorFragment.ARG_PREVIEW_ENABLED, note.isPreviewEnabled());
             Intent editNoteIntent = new Intent(getActivity(), NoteEditorActivity.class);
             editNoteIntent.putExtras(arguments);
 
@@ -528,7 +531,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         /**
          * Callback for when a note has been selected.
          */
-        void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled);
+        void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled, boolean isPreviewEnabled);
     }
 
     // view holder for NotesCursorAdapter

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -56,7 +56,6 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.simperium.client.Bucket;
 import com.simperium.client.Bucket.ObjectCursor;
 import com.simperium.client.Query;
-import com.simperium.client.Query.SortType;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -423,9 +422,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         }
 
         query.include(Note.PINNED_INDEX_NAME);
-
-        sortNoteQuery(query);
-
+        PrefUtils.sortNoteQuery(query, requireContext());
         return query.execute();
     }
 
@@ -520,31 +517,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
     public boolean hasSearchQuery() {
         return mSearchString != null && !mSearchString.equals("");
-    }
-
-    public void sortNoteQuery(Query<Note> noteQuery) {
-        noteQuery.order("pinned", SortType.DESCENDING);
-        int sortPref = PrefUtils.getIntPref(getActivity(), PrefUtils.PREF_SORT_ORDER);
-        switch (sortPref) {
-            case 0:
-                noteQuery.order(Note.MODIFIED_INDEX_NAME, SortType.DESCENDING);
-                break;
-            case 1:
-                noteQuery.order(Note.MODIFIED_INDEX_NAME, SortType.ASCENDING);
-                break;
-            case 2:
-                noteQuery.order(Note.CREATED_INDEX_NAME, SortType.DESCENDING);
-                break;
-            case 3:
-                noteQuery.order(Note.CREATED_INDEX_NAME, SortType.ASCENDING);
-                break;
-            case 4:
-                noteQuery.order(Note.CONTENT_PROPERTY, SortType.ASCENDING);
-                break;
-            case 5:
-                noteQuery.order(Note.CONTENT_PROPERTY, SortType.DESCENDING);
-                break;
-        }
     }
 
     /**

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidget.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidget.java
@@ -107,6 +107,7 @@ public class NoteWidget extends AppWidgetProvider {
                     Bundle arguments = new Bundle();
                     arguments.putString(NoteEditorFragment.ARG_ITEM_ID, updatedNote.getSimperiumKey());
                     arguments.putBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED, updatedNote.isMarkdownEnabled());
+                    arguments.putBoolean(NoteEditorFragment.ARG_PREVIEW_ENABLED, updatedNote.isPreviewEnabled());
 
                     // Create intent to navigate to selected note on widget click
                     Intent intent = new Intent(context, NoteEditorActivity.class);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetConfigureActivity.java
@@ -99,6 +99,7 @@ public class NoteWidgetConfigureActivity extends AppCompatActivity {
         Bucket<Note> mNotesBucket = mApplication.getNotesBucket();
         Query<Note> query = Note.all(mNotesBucket);
         query.include(Note.TITLE_INDEX_NAME, Note.CONTENT_PREVIEW_INDEX_NAME);
+        PrefUtils.sortNoteQuery(query, NoteWidgetConfigureActivity.this);
         ObjectCursor<Note> cursor = query.execute();
 
         Context context = new ContextThemeWrapper(NoteWidgetConfigureActivity.this, R.style.Theme_Transparent);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1,7 +1,6 @@
 package com.automattic.simplenote;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -24,6 +23,7 @@ import android.widget.ProgressBar;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.ActionBarDrawerToggle;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -21,6 +21,7 @@ import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.ProgressBar;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
@@ -232,7 +233,7 @@ public class NotesActivity extends AppCompatActivity implements
         setSelectedTagActive();
 
         if (mCurrentNote != null && mShouldSelectNewNote) {
-            onNoteSelected(mCurrentNote.getSimperiumKey(), 0, null, mCurrentNote.isMarkdownEnabled());
+            onNoteSelected(mCurrentNote.getSimperiumKey(), 0, null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
             mShouldSelectNewNote = false;
         }
 
@@ -787,12 +788,13 @@ public class NotesActivity extends AppCompatActivity implements
      * the item with the given ID was selected. Used for tablets only.
      */
     @Override
-    public void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled) {
+    public void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled, boolean isPreviewEnabled) {
         if (!DisplayUtils.isLargeScreenLandscape(this)) {
             // Launch the editor activity
             Bundle arguments = new Bundle();
             arguments.putString(NoteEditorFragment.ARG_ITEM_ID, noteID);
             arguments.putBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED, isMarkdownEnabled);
+            arguments.putBoolean(NoteEditorFragment.ARG_PREVIEW_ENABLED, isPreviewEnabled);
 
             if (matchOffsets != null) {
                 arguments.putString(NoteEditorFragment.ARG_MATCH_OFFSETS, matchOffsets);
@@ -993,7 +995,7 @@ public class NotesActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onConfigurationChanged(Configuration newConfig) {
+    public void onConfigurationChanged(@NonNull Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
 
         mDrawerToggle.onConfigurationChanged(newConfig);
@@ -1008,25 +1010,24 @@ public class NotesActivity extends AppCompatActivity implements
                 } else if (DisplayUtils.isLandscape(this)) {
                     addEditorFragment();
                 }
+
                 if (mNoteListFragment != null) {
                     mNoteListFragment.setActivateOnItemClick(true);
                     mNoteListFragment.setDividerVisible(true);
                 }
+
                 // Select the current note on a tablet
                 if (mCurrentNote != null) {
-                    onNoteSelected(mCurrentNote.getSimperiumKey(), 0, null, mCurrentNote.isMarkdownEnabled());
+                    onNoteSelected(mCurrentNote.getSimperiumKey(), 0, null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
                 } else {
                     mNoteEditorFragment.setPlaceholderVisible(true);
                     mNoteListFragment.getListView().clearChoices();
                 }
+
                 invalidateOptionsMenu();
-            } else {
-                if (mNoteListFragment.isHidden()) {
-                    // Go to NoteEditorActivity if the note editing was fullscreen and orientation was switched to portrait
-                    if (mCurrentNote != null) {
-                        onNoteSelected(mCurrentNote.getSimperiumKey(), 0, null, mCurrentNote.isMarkdownEnabled());
-                    }
-                }
+            // Go to NoteEditorActivity if note editing was fullscreen and orientation was switched to portrait
+            } else if (mNoteListFragment.isHidden() && mCurrentNote != null) {
+                onNoteSelected(mCurrentNote.getSimperiumKey(), 0, null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
@@ -26,6 +26,7 @@ public class Note extends BucketObject {
     public static final String BUCKET_NAME = "note";
     public static final String MARKDOWN_TAG = "markdown";
     public static final String PINNED_TAG = "pinned";
+    public static final String PREVIEW_TAG = "preview";
     public static final String PUBLISHED_TAG = "published";
     public static final String NEW_LINE = "\n";
     public static final String CONTENT_PROPERTY = "content";
@@ -367,6 +368,18 @@ public class Note extends BucketObject {
         }
     }
 
+    public boolean isPreviewEnabled() {
+        return hasSystemTag(PREVIEW_TAG);
+    }
+
+    public void setPreviewEnabled(boolean isPreviewEnabled) {
+        if (isPreviewEnabled) {
+            addSystemTag(PREVIEW_TAG);
+        } else {
+            removeSystemTag(PREVIEW_TAG);
+        }
+    }
+
     public boolean isPublished() {
         return hasSystemTag(PUBLISHED_TAG) && !TextUtils.isEmpty(getPublishedUrl());
     }
@@ -433,13 +446,15 @@ public class Note extends BucketObject {
      * @param tagString         space separated tags
      * @param isPinned          note is pinned
      * @param isMarkdownEnabled note has markdown enabled
+     * @param isPreviewEnabled  note has preview enabled
      * @return true if note has changes, false if it is unchanged.
      */
-    public boolean hasChanges(String content, String tagString, boolean isPinned, boolean isMarkdownEnabled) {
+    public boolean hasChanges(String content, String tagString, boolean isPinned, boolean isMarkdownEnabled, boolean isPreviewEnabled) {
         return !content.equals(this.getContent())
                 || !tagString.equals(this.getTagString().toString())
                 || this.isPinned() != isPinned
-                || this.isMarkdownEnabled() != isMarkdownEnabled;
+                || this.isMarkdownEnabled() != isMarkdownEnabled
+                || this.isPreviewEnabled() != isPreviewEnabled;
     }
 
     public static class Schema extends BucketSchema<Note> {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -11,6 +11,10 @@ import android.preference.PreferenceManager;
 
 import com.automattic.simplenote.BuildConfig;
 import com.automattic.simplenote.R;
+import com.automattic.simplenote.models.Note;
+import com.simperium.client.Query;
+
+import static com.automattic.simplenote.models.Note.PINNED_INDEX_NAME;
 
 @SuppressWarnings("unused")
 public class PrefUtils {
@@ -128,4 +132,29 @@ public class PrefUtils {
         return getIntPref(context, PREF_FONT_SIZE, defaultFontSize);
     }
 
+    public static void sortNoteQuery(Query<Note> query, Context context) {
+        query.order(PINNED_INDEX_NAME, Query.SortType.DESCENDING);
+        int sortOrder = PrefUtils.getIntPref(context, PrefUtils.PREF_SORT_ORDER);
+
+        switch (sortOrder) {
+            case 0:
+                query.order(Note.MODIFIED_INDEX_NAME, Query.SortType.DESCENDING);
+                break;
+            case 1:
+                query.order(Note.MODIFIED_INDEX_NAME, Query.SortType.ASCENDING);
+                break;
+            case 2:
+                query.order(Note.CREATED_INDEX_NAME, Query.SortType.DESCENDING);
+                break;
+            case 3:
+                query.order(Note.CREATED_INDEX_NAME, Query.SortType.ASCENDING);
+                break;
+            case 4:
+                query.order(Note.CONTENT_PROPERTY, Query.SortType.ASCENDING);
+                break;
+            case 5:
+                query.order(Note.CONTENT_PROPERTY, Query.SortType.DESCENDING);
+                break;
+        }
+    }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -21,8 +21,8 @@ public class ThemeUtils {
     // theme constants
     private static final int THEME_LIGHT = 0;
     private static final int THEME_DARK = 1;
-    @SuppressWarnings("unused")
     public static final int THEME_AUTO = 2;
+    private static final int THEME_SYSTEM = 3;
     private static final String PREFERENCES_URI_AUTHORITY = "preferences";
     private static final String URI_SEGMENT_THEME = "theme";
     private static String THEME_CHANGED_EXTRA = "themeChanged";
@@ -47,13 +47,20 @@ public class ThemeUtils {
             }
         }
 
-        int theme = PrefUtils.getIntPref(activity, PrefUtils.PREF_THEME, THEME_LIGHT);
-        if (theme == THEME_LIGHT)
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
-        else if (theme == THEME_DARK)
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
-        else
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
+        switch (PrefUtils.getIntPref(activity, PrefUtils.PREF_THEME, THEME_SYSTEM)) {
+            case THEME_AUTO:
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
+                break;
+            case THEME_DARK:
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+                break;
+            case THEME_LIGHT:
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+                break;
+            case THEME_SYSTEM:
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
+                break;
+        }
     }
 
     public static boolean isLightTheme(Context context) {

--- a/Simplenote/src/main/res/layout/bottom_sheet_history.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_history.xml
@@ -82,35 +82,21 @@
             android:paddingEnd="@dimen/padding_large"
             android:paddingStart="@dimen/padding_large">
 
-            <com.automattic.simplenote.widgets.RobotoMediumTextView
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/cancel_history_button"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:clickable="true"
-                android:focusable="true"
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
-                android:padding="@dimen/padding_small"
                 android:text="@string/cancel"
-                android:textAllCaps="true"
-                android:textColor="@color/simplenote_blue"
-                android:textSize="14sp"
-                android:textStyle="bold">
-            </com.automattic.simplenote.widgets.RobotoMediumTextView>
+                style="@style/Button.Flat">
+            </com.google.android.material.button.MaterialButton>
 
-            <com.automattic.simplenote.widgets.RobotoMediumTextView
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/restore_history_button"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:clickable="true"
-                android:focusable="true"
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
-                android:padding="@dimen/padding_small"
                 android:text="@string/restore"
-                android:textAllCaps="true"
-                android:textColor="@color/simplenote_blue"
-                android:textSize="14sp"
-                android:textStyle="bold">
-            </com.automattic.simplenote.widgets.RobotoMediumTextView>
+                style="@style/Button.Flat">
+            </com.google.android.material.button.MaterialButton>
 
         </LinearLayout>
 

--- a/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
+++ b/Simplenote/src/main/res/layout/dialog_wordpress_post.xml
@@ -3,6 +3,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
     android:orientation="vertical">
@@ -103,29 +104,25 @@
             android:textSize="16sp">
         </TextView>
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/wp_dialog_share"
-            android:drawablePadding="@dimen/padding_extra_small"
-            android:drawableStart="@drawable/ic_share_24dp"
-            android:drawableTint="@color/simplenote_blue"
             android:layout_below="@id/wp_dialog_success_summary"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"
             android:text="@string/share"
-            android:theme="@style/FlatButton.Simplestyle">
-        </androidx.appcompat.widget.AppCompatButton>
+            app:icon="@drawable/ic_share_24dp"
+            style="@style/Button.Flat.Icon">
+        </com.google.android.material.button.MaterialButton>
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/wp_dialog_copy_url"
-            android:drawablePadding="@dimen/padding_extra_small"
-            android:drawableStart="@drawable/ic_content_copy_white_24dp"
-            android:drawableTint="@color/simplenote_blue"
             android:layout_below="@id/wp_dialog_share"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"
             android:text="@string/copy"
-            android:theme="@style/FlatButton.Simplestyle">
-        </androidx.appcompat.widget.AppCompatButton>
+            app:icon="@drawable/ic_content_copy_white_24dp"
+            style="@style/Button.Flat.Icon">
+        </com.google.android.material.button.MaterialButton>
 
     </RelativeLayout>
 

--- a/Simplenote/src/main/res/layout/fragment_notes_list.xml
+++ b/Simplenote/src/main/res/layout/fragment_notes_list.xml
@@ -58,11 +58,11 @@
         android:layout_marginEnd="@dimen/padding_large"
         android:layout_width="wrap_content"
         android:src="@drawable/ic_create_24dp"
-        android:tint="?attr/fabIconColor"
         app:backgroundTint="?attr/fabColor"
         app:borderWidth="0dp"
         app:elevation="8dp"
-        app:pressedTranslationZ="12dp">
+        app:pressedTranslationZ="12dp"
+        app:tint="?attr/fabIconColor">
     </com.google.android.material.floatingactionbutton.FloatingActionButton>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -2,7 +2,7 @@
 
 <resources>
 
-    <style name="Base.Theme.Simplestyle" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="Base.Theme.Simplestyle" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="android:actionBarTabStyle">@style/ActionBarTabStyle.Simplestyle</item>
         <item name="android:popupMenuStyle">@style/PopupMenu.Simplestyle</item>
         <item name="android:spinnerDropDownItemStyle">@style/SpinnerDropDownItem.Simplestyle</item>
@@ -10,9 +10,9 @@
         <item name="android:windowBackground">@color/background_dark</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="actionModeStyle">@style/ActionMode.Simplestyle</item>
-        <item name="bottomSheetDialogTheme">@style/Theme.Design.BottomSheetDialog</item>
+        <item name="bottomSheetDialogTheme">@style/Theme.MaterialComponents.BottomSheetDialog</item>
         <item name="colorAccent">@color/simplenote_blue</item>
-        <item name="colorPrimary">@color/toolbar_dark</item>
+        <item name="colorPrimary">@color/simplenote_blue</item>
         <item name="colorPrimaryDark">@color/toolbar_dark</item>
         <item name="dividerColor">@color/divider_list_dark</item>
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
@@ -43,7 +43,7 @@
         <item name="actionBarTextColor">@color/simplenote_blue</item>
         <item name="actionModeTextColor">@color/simplenote_blue</item>
         <item name="actionModeBackgroundColor">@color/row_selected_dark</item>
-        <item name="toolbarPopupTheme">@style/ThemeOverlay.AppCompat</item>
+        <item name="toolbarPopupTheme">@style/ThemeOverlay.MaterialComponents</item>
         <item name="windowActionModeOverlay">true</item>
     </style>
 
@@ -61,18 +61,18 @@
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
     </style>
 
-    <style name="Theme.Simplestyle.BottomSheetDialog" parent="Theme.Design.BottomSheetDialog">
+    <style name="Theme.Simplestyle.BottomSheetDialog" parent="Theme.MaterialComponents.BottomSheetDialog">
         <item name="android:background">?attr/mainBackgroundColor</item>
-        <item name="colorAccent">@color/simplenote_blue</item>
-        <item name="colorPrimary">@color/toolbar_dark</item>
-        <item name="colorPrimaryDark">@android:color/black</item>
+        <item name="colorAccent">@color/simplenote_blue_accent</item>
+        <item name="colorPrimary">@color/simplenote_blue</item>
+        <item name="colorPrimaryDark">@color/simplenote_blue_dark</item>
     </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.Simplestyle.BottomSheetDialog">
         <item name="android:textColor">@android:color/white</item>
     </style>
 
-    <style name="ToolbarTheme" parent="@style/ThemeOverlay.AppCompat">
+    <style name="ToolbarTheme" parent="@style/ThemeOverlay.MaterialComponents">
         <item name="android:textColorPrimary">?attr/actionBarTextColor</item>
         <item name="android:textColorSecondary">?attr/actionBarTextColor</item>
     </style>

--- a/Simplenote/src/main/res/values-v29/arrays.xml
+++ b/Simplenote/src/main/res/values-v29/arrays.xml
@@ -25,12 +25,14 @@
         <item>@string/theme_light</item>
         <item>@string/theme_dark</item>
         <item>@string/theme_auto</item>
+        <item>@string/theme_system</item>
     </string-array>
 
     <string-array name="array_theme_values" translatable="false" tools:ignore="InconsistentArrays">
         <item>0</item>
         <item>1</item>
         <item>2</item>
+        <item>3</item>
     </string-array>
 
     <string-array name="array_font_size">

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -149,6 +149,7 @@
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
     <string name="theme_auto">Dark at night only</string>
+    <string name="theme_system">System default</string>
     <string name="theme">Theme</string>
     <string name="version">Version</string>
 

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -12,7 +12,7 @@
         <item name="titleTextStyle">@style/Simplestyle.ActionModeTitleTextStyle</item>
     </style>
 
-    <style name="Base.Theme.Simplestyle" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="Base.Theme.Simplestyle" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="android:actionBarTabStyle">@style/ActionBarTabStyle.Simplestyle</item>
         <item name="android:actionModeCopyDrawable">@drawable/ic_content_copy_white_24dp</item>
         <item name="android:actionModeCutDrawable">@drawable/ic_content_cut_white_24dp</item>
@@ -29,7 +29,7 @@
         <item name="actionModeStyle">@style/ActionMode.Simplestyle</item>
         <item name="actionModeTextColor">@color/white</item>
         <item name="colorAccent">@color/simplenote_blue</item>
-        <item name="colorPrimary">@color/toolbar_light</item>
+        <item name="colorPrimary">@color/simplenote_blue</item>
         <item name="colorPrimaryDark">@color/toolbar_light</item>
         <item name="dividerColor">@color/divider_list_light</item>
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
@@ -56,7 +56,7 @@
         <item name="tagChipShadowColor">@color/white</item>
         <item name="tagChipTextColor">@color/text_tag_chip</item>
         <item name="toolbarColor">@color/white</item>
-        <item name="toolbarPopupTheme">@style/ThemeOverlay.AppCompat.Light</item>
+        <item name="toolbarPopupTheme">@style/ThemeOverlay.MaterialComponents.Light</item>
         <item name="windowActionModeOverlay">true</item>
     </style>
 
@@ -70,10 +70,13 @@
         <item name="android:textSize">16sp</item>
     </style>
 
-    <style name="FlatButton.Simplestyle" parent="Theme.AppCompat.Light">
-        <item name="android:buttonStyle">@style/Widget.AppCompat.Button.Borderless.Colored</item>
-        <item name="colorAccent">@color/simplenote_blue</item>
-        <item name="colorControlHighlight">@color/simplenote_blue_accent</item>
+    <style name="Button.Flat" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textColor">@color/simplenote_blue</item>
+    </style>
+
+    <style name="Button.Flat.Icon" parent="Widget.MaterialComponents.Button.TextButton.Icon">
+        <item name="android:textColor">@color/simplenote_blue</item>
+        <item name="iconTint">@color/simplenote_blue</item>
     </style>
 
     <style name="PopupMenu.Simplestyle" parent="@android:style/Widget.Material.Light.ListPopupWindow">
@@ -89,14 +92,14 @@
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
     </style>
 
-    <style name="Theme.Simplestyle.BottomSheetDialog" parent="Theme.Design.Light.BottomSheetDialog">
-        <item name="colorPrimary">@color/toolbar_light</item>
-        <item name="colorPrimaryDark">@color/gray_light</item>
-        <item name="colorAccent">@color/simplenote_blue</item>
+    <style name="Theme.Simplestyle.BottomSheetDialog" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
         <item name="android:background">?attr/mainBackgroundColor</item>
+        <item name="colorAccent">@color/simplenote_blue_accent</item>
+        <item name="colorPrimary">@color/simplenote_blue</item>
+        <item name="colorPrimaryDark">@color/simplenote_blue_dark</item>
     </style>
 
-    <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.Design.Light.BottomSheetDialog">
+    <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
         <item name="android:textColor">@color/gray_dark</item>
     </style>
 
@@ -104,7 +107,7 @@
         <item name="android:windowBackground">?attr/mainBackgroundColor</item>
     </style>
 
-    <style name="ToolbarTheme" parent="@style/ThemeOverlay.AppCompat.Light">
+    <style name="ToolbarTheme" parent="@style/ThemeOverlay.MaterialComponents.Light">
         <item name="android:textColorPrimary">?attr/actionBarTextColor</item>
         <item name="android:textColorSecondary">?attr/actionBarTextColor</item>
     </style>
@@ -148,7 +151,7 @@
         <item name="toolbarColor">@color/simplenote_blue</item>
     </style>
 
-    <style name="Theme.Simplestyle.Passcode" parent="@style/Theme.AppCompat.Light.NoActionBar">
+    <style name="Theme.Simplestyle.Passcode" parent="@style/Theme.MaterialComponents.Light.NoActionBar">
         <item name="android:statusBarColor">@color/passcodelock_background</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
     </style>
@@ -172,7 +175,7 @@
         <item name="android:textStyle">italic</item>
     </style>
 
-    <style name="PasscodeKeyboardButtonStyle" parent="Widget.AppCompat.Button">
+    <style name="PasscodeKeyboardButtonStyle" parent="Widget.MaterialComponents.Button">
         <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
         <item name="android:clickable">true</item>
         <item name="android:focusable">true</item>


### PR DESCRIPTION
### Fix
Add opening notes on the last-viewed tab (i.e. ***Edit*** or ***Preview***) to close #721.  The property is set on a per-note basis.  The option was originally added as a manual switch on the note info sheet, but the switch was removed in favor of automatically detecting the last-viewed tab to minimize the required interaction for the user.  Notes will open in the ***Edit*** tab by default unless the note is exited while the ***Preview*** tab is shown.  See the animation below for illustration.

<img src="https://user-images.githubusercontent.com/3827611/62569635-09072800-b84c-11e9-8e52-1c469a2058cb.gif" width="320">

### Test
1. Tap note in list with markdown on.
2. Notice ***Edit*** tab is shown.
3. Tap ***Preview*** tab.
4. Tap back arrow in app bar.
5. Tap note in list from Step 1.
6. Notice ***Preview*** tab is shown.
7. Tap ***Edit*** tab.
8. Tap back arrow in app bar.
9. Tap note in list from Step 1.
10. Notice ***Edit*** tab is shown.
11. Tap ***Info*** action in app bar.
12. Tap ***Enable markdown*** switch.
13. Notice ***Enable markdown*** switch is off.
14. Notice ***Edit*** and ***Preview*** tabs are not shown.
15. Tap back arrow in navigation bar.
16. Tap back arrow in app bar.
17. Tap note in list from Step 1.
18. Notice ***Edit*** and ***Preview*** tabs are not shown.
19. Notice note is in edit mode.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in b9689a2 with:
> Added showing the last viewed tab when opening a note