### PR TITLE
Issue/772 navigation drawer unlocked

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -88,6 +88,14 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
      */
     private static Callbacks sCallbacks = new Callbacks() {
         @Override
+        public void onActionModeCreated() {
+        }
+
+        @Override
+        public void onActionModeDestroyed() {
+        }
+
+        @Override
         public void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled, boolean isPreviewEnabled) {
         }
     };
@@ -137,6 +145,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
     @Override
     public boolean onCreateActionMode(ActionMode actionMode, Menu menu) {
+        mCallbacks.onActionModeCreated();
         MenuInflater inflater = actionMode.getMenuInflater();
         inflater.inflate(R.menu.bulk_edit, menu);
         DrawableUtils.tintMenuWithAttribute(getActivity(), menu, R.attr.actionModeTextColor);
@@ -167,6 +176,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
     @Override
     public void onDestroyActionMode(ActionMode mode) {
+        mCallbacks.onActionModeDestroyed();
         mActionMode = null;
         new Handler().post(new Runnable() {
             @Override
@@ -528,6 +538,14 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
      * selections.
      */
     public interface Callbacks {
+        /**
+         * Callback for when action mode is created.
+         */
+        void onActionModeCreated();
+        /**
+         * Callback for when action mode is destroyed.
+         */
+        void onActionModeDestroyed();
         /**
          * Callback for when a note has been selected.
          */

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -287,10 +287,12 @@ public class NotesActivity extends AppCompatActivity implements
 
     @Override
     public void onActionModeCreated() {
+        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
     }
 
     @Override
     public void onActionModeDestroyed() {
+        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
     }
 
     private void setTitleWithCustomFont(CharSequence title) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -285,6 +285,14 @@ public class NotesActivity extends AppCompatActivity implements
         }
     }
 
+    @Override
+    public void onActionModeCreated() {
+    }
+
+    @Override
+    public void onActionModeDestroyed() {
+    }
+
     private void setTitleWithCustomFont(CharSequence title) {
         if (getSupportActionBar() == null) {
             return;


### PR DESCRIPTION
### Fix
Update the navigation drawer to be locked and unlocked when the contextual action bar is shown and hidden, respectively, to close #772.

### Test
1. Swipe from left/start of list.
2. Notice navigation drawer is shown.
3. Swipe from right/end of navigation drawer.
4. Notice navigation drawer is hidden.
5. Long-press any note in list.
6. Notice contextual action bar is shown.
7. Swipe from left/start of list.
8. Notice navigation drawer is not shown.
9. Tap back arrow in top app bar.
10. Notice contextual action bar is hidden.
11. Swipe from left/start of list.
12. Notice navigation drawer is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.