### PR TITLE
Update Password Length

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -63,7 +63,7 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Automattic and WordPress dependencies
-    implementation 'com.simperium.android:simperium:0.8.0'
+    implementation 'com.simperium.android:simperium:0.9.0'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:1.7.0'
 

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -241,6 +241,7 @@
     <string name="simperium_button_signup">Sign Up</string>
     <string name="simperium_dialog_message_login">Could not log in with the provided email address and password.</string>
     <string name="simperium_dialog_message_network">There is no network available.  Please, connect to a network and try again.</string>
+    <string name="simperium_dialog_message_password">Passwords must be a minimum of %1$d characters excluding new lines, spaces, and tabs.</string>
     <string name="simperium_dialog_message_signup">Could not sign up with the provided email address and password.</string>
     <string name="simperium_dialog_message_signup_existing">The email address you entered is already associated with a Simplenote account.</string>
     <string name="simperium_dialog_progress_logging_in">Logging in&#8230;</string>


### PR DESCRIPTION
### Fix
Update the minimum number of characters required for passwords to 4 for login and 6 for signup to close #776.

### Test
#### Login
0. Clear app data.
1. Tap ***Log In*** button.
2. Notice login bottom sheet shown.
3. Tap ***Log In with Email*** button.
4. Notice ***Log In*** screen is shown.
5. Notice ***Log In*** button is disabled,
6. Enter "a@b.c" in ***Email*** field.
7. Tap ***Password*** field.
8. Enter "abc" in ***Password*** field.
9. Tap ***Email*** field.
10. Notice ***Invalid password*** error message is shown below ***Password*** field.
11. Tap ***Password*** field.
12. Enter "abcd" in ***Password*** field.
13. Notice ***Log In*** button is enabled.

#### Signup
0. Clear app data.
1. Tap ***Sign Up*** button.
2. Notice ***Sign Up*** screen is shown.
3. Notice ***Sign Up*** button is disabled,
4. Enter "a@b.c" in ***Email*** field.
5. Tap ***Password*** field.
6. Enter "abcde" in ***Password*** field.
7. Tap ***Email*** field.
8. Notice ***Invalid password*** error message is shown below ***Password*** field.
9. Tap ***Password*** field.
10. Enter "abcdef" in ***Password*** field.
11. Notice ***Sign Up*** button is enabled.

### Review
Only one developer is required to review these changes, but anyone can perform the review.