### PR TITLE
Update release-toolkit to 0.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: c555066402074a527a9853932790da8198eb7f21
-  tag: 0.6.0
+  revision: b57127b313fd06519cbebfd4a3f6784eec1ef5fc
+  tag: 0.7.1
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.6.0)
+    fastlane-plugin-wpmreleasetoolkit (0.7.1)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
-      nokogiri (= 1.10.1)
+      nokogiri (>= 1.10.4)
       octokit (~> 4.13)
       parallel (~> 1.14)
       progress_bar (~> 1.3)
@@ -22,7 +22,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     atomos (0.1.3)
     babosa (1.0.2)
-    claide (1.0.2)
+    claide (1.0.3)
     colored (1.2)
     colored2 (3.1.2)
     commander-fastlane (4.4.6)
@@ -33,9 +33,9 @@ GEM
     digest-crc (0.4.1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.7.4)
+    dotenv (2.7.5)
     emoji_regex (1.0.1)
-    excon (0.65.0)
+    excon (0.66.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -127,11 +127,11 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.2.6)
     naturally (2.2.0)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.8.0)
+    oj (3.9.0)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)
@@ -141,7 +141,7 @@ GEM
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (2.0.5)
-    rake (12.3.2)
+    rake (12.3.3)
     rake-compiler (1.0.7)
       rake
     representable (3.0.4)
@@ -177,7 +177,7 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     word_wrap (1.0.0)
-    xcodeproj (1.11.0)
+    xcodeproj (1.12.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.6.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.7.1'


### PR DESCRIPTION
This PR updates `release-toolkit` to `0.7.1` to get rid of the security alert related to `Nokogiri`.

Update release notes:

[x] If there are user facing changes, I have added an item to RELEASE-NOTES.txt.
