### PR TITLE
Update Tab Background

### DIFF
--- a/Simplenote/src/main/res/layout/activity_note_editor.xml
+++ b/Simplenote/src/main/res/layout/activity_note_editor.xml
@@ -9,7 +9,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:animateLayoutChanges="true">
+        android:animateLayoutChanges="true"
+        android:background="?attr/mainBackgroundColor">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"


### PR DESCRIPTION
### Fix
Add the `android:background="?attr/mainBackgroundColor"` attribute to the `AppBarLayout` view in the `activity_note_editor` layout so that the color shown during layout change animations follows the theme background color.  See the animations below for illustration.

#### Dark
Before|After
-|-
![tab_background_before_dark](https://user-images.githubusercontent.com/3827611/63486747-0587b980-c466-11e9-86b5-fb6a0dcdbf9f.gif)|![tab_background_after_dark](https://user-images.githubusercontent.com/3827611/63486753-0ae50400-c466-11e9-93b9-867c6eafa3be.gif)

#### Light
Before|After
-|-
![tab_background_before_light](https://user-images.githubusercontent.com/3827611/63486779-1a644d00-c466-11e9-97f1-4f36915814b9.gif)|![tab_background_after_light](https://user-images.githubusercontent.com/3827611/63486785-1c2e1080-c466-11e9-9e60-50b1e64618e4.gif)

### Test
1. Tap any note in list.
2. Tap ***Info*** action in app bar.
3. Toggle ***Enable markdown*** switch.
4. Notice app bar background during layout change animation.

### Review
Only one developer is required to review these changes, but anyone can perform the review.