### PR TITLE
Add beta build lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -159,6 +159,50 @@ SUPPORTED_LOCALES = [
   end
   
   #####################################################################################
+  # build_pre_releases
+  # -----------------------------------------------------------------------------------
+  # This lane builds the app it for both internal and external distribution 
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane build_pre_releases [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane build_pre_releases 
+  # bundle exec fastlane build_pre_releases skip_confirm:true 
+  #####################################################################################
+  desc "Builds and updates for distribution"
+  lane :build_pre_releases do | options |
+    android_build_prechecks(skip_confirm: options[:skip_confirm], 
+      alpha: false,
+      beta: true,
+      final: false)
+    android_build_preflight()
+    build_beta(skip_prechecks: true, skip_confirm: options[:skip_confirm])
+  end
+
+  #####################################################################################
+  # build_beta
+  # -----------------------------------------------------------------------------------
+  # This lane builds the app it for internal testing  
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane build_beta [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane build_beta 
+  # bundle exec fastlane build_beta skip_confirm:true 
+  #####################################################################################
+  desc "Builds and updates for distribution"
+  lane :build_beta do | options |
+    android_build_prechecks(skip_confirm: options[:skip_confirm], beta: true) unless (options[:skip_prechecks])
+    android_build_preflight() unless (options[:skip_prechecks])
+
+    # Create the file names
+    version=android_get_release_version()
+    build_apk(version: version, flavor:"Vanilla")
+  end
+
+  #####################################################################################
   # build_release
   # -----------------------------------------------------------------------------------
   # This lane builds the final release of the app and uploads it 


### PR DESCRIPTION
### Fix
This PR adds a lane to build the beta version of the app. Even if there is only one configuration, the `release-toolkit` `build_release` action checks the `versionName` fields and doesn't allow to build a `-rc-` version.
This PR uses the correct action.

I'm targeting the release branch because it will be useful to have this if we'll need to build new betas. I'll open a PR to merge in `develop` as soon as this is merged. 

### Test
> 1. Make sure the `versionName` is on a `rc` version (this branch is).
> 2. Run `bundle exec fastlane build_pre_releases`.
> 3. Verify that the apk is built without errors.

### Release
These changes do not require release notes.
