### PR TITLE
Note Saving Preview

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -68,14 +68,6 @@ public class NoteEditorActivity extends AppCompatActivity {
         Intent intent = getIntent();
         mNoteId = intent.getStringExtra(NoteEditorFragment.ARG_ITEM_ID);
 
-        try {
-            Simplenote application = (Simplenote) getApplication();
-            Bucket<Note> notesBucket = application.getNotesBucket();
-            mNote = notesBucket.get(mNoteId);
-        } catch (BucketObjectMissingException exception) {
-            exception.printStackTrace();
-        }
-
         if (savedInstanceState == null) {
             // Create the note editor fragment
             Bundle arguments = new Bundle();
@@ -109,9 +101,17 @@ public class NoteEditorActivity extends AppCompatActivity {
                                 DisplayUtils.hideKeyboard(mViewPager);
                             }
 
-                            if (mNote != null) {
-                                mNote.setPreviewEnabled(position == 1);  // Preview is position 1
-                                mNote.save();
+                            try {
+                                Simplenote application = (Simplenote) getApplication();
+                                Bucket<Note> notesBucket = application.getNotesBucket();
+                                mNote = notesBucket.get(mNoteId);
+
+                                if (mNote != null) {
+                                    mNote.setPreviewEnabled(position == 1);  // Preview is position 1
+                                    mNote.save();
+                                }
+                            } catch (BucketObjectMissingException exception) {
+                                exception.printStackTrace();
                             }
                         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -969,33 +969,40 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     @Override
     public void onInfoDismissed() {
-
     }
 
     protected void saveNote() {
-        if (mNote == null ||
-                mContentEditText == null ||
-                mIsLoadingNote ||
-                (mHistoryBottomSheet != null && mHistoryBottomSheet.isShowing())) {
-            return;
-        }
+        try {
+            Simplenote application = (Simplenote) requireActivity().getApplication();
+            Bucket<Note> notesBucket = application.getNotesBucket();
+            mNote = notesBucket.get(mNote.getSimperiumKey());
 
-        String content = mContentEditText.getPlainTextContent();
-        String tagString = getNoteTagsString();
+            if (mNote == null || mContentEditText == null || mIsLoadingNote ||
+                    (mHistoryBottomSheet != null && mHistoryBottomSheet.isShowing())) {
+                return;
+            } else {
+                mIsPreviewEnabled = mNote.isPreviewEnabled();
+            }
 
-        if (mNote.hasChanges(content, tagString.trim(), mNote.isPinned(), mIsMarkdownEnabled, mIsPreviewEnabled)) {
-            mNote.setContent(content);
-            mNote.setTagString(tagString);
-            mNote.setModificationDate(Calendar.getInstance());
-            mNote.setMarkdownEnabled(mIsMarkdownEnabled);
-            mNote.setPreviewEnabled(mIsPreviewEnabled);
-            mNote.save();
+            String content = mContentEditText.getPlainTextContent();
+            String tagString = getNoteTagsString();
 
-            AnalyticsTracker.track(
-                    AnalyticsTracker.Stat.EDITOR_NOTE_EDITED,
-                    AnalyticsTracker.CATEGORY_NOTE,
-                    "editor_save"
-            );
+            if (mNote.hasChanges(content, tagString.trim(), mNote.isPinned(), mIsMarkdownEnabled, mIsPreviewEnabled)) {
+                mNote.setContent(content);
+                mNote.setTagString(tagString);
+                mNote.setModificationDate(Calendar.getInstance());
+                mNote.setMarkdownEnabled(mIsMarkdownEnabled);
+                mNote.setPreviewEnabled(mIsPreviewEnabled);
+                mNote.save();
+
+                AnalyticsTracker.track(
+                        AnalyticsTracker.Stat.EDITOR_NOTE_EDITED,
+                        AnalyticsTracker.CATEGORY_NOTE,
+                        "editor_save"
+                );
+            }
+        } catch (BucketObjectMissingException exception) {
+            exception.printStackTrace();
         }
     }
 


### PR DESCRIPTION
### Fix
Update the note saving logic on the ***Preview*** tab to retrieve the `Note` object after the ***Preview*** tab is viewed in order to close #785, close #786, and close #787.  When the `Note` object was retrieved before the ***Preview*** tab was viewed, any changes made in the ***Edit*** tab were overridden by the saving logic on the ***Preview*** tab.  The changes on the ***Edit*** tab that were being overridden included any note content, the last-viewed tab setting, and the markdown setting.

### Test
### 785: Content Loss
1. Tap note in list with markdown enabled.
2. Add/Remove any text to note in ***Edit*** tab.
3. Tap ***Preview*** tab.
4. Notice changes from Step 2 are shown in ***Preview*** tab.
5. Tap back arrow in app bar.
6. Tap note from Step 1.
7. Notice changes from Step 2 are shown in ***Preview*** tab.

### 786: Last-Viewed Tab
1. Tap ***New note*** floating action button.
2. Notice markdown in enabled (i.e. ***Edit*** and ***Preview*** tabs are shown).
3. Add any text to note in ***Edit*** tab.
4. Tap ***Preview*** tab.
5. Notice changes from Step 3 are shown in ***Preview*** tab.
6. Tap back arrow in app bar.
7. Tap note from Step 1.
8. Notice changes from Step 3 are shown in ***Preview*** tab.

### 787: Markdown Enabled
0. Disable markdown (i.e. toggle ***Enable markdown*** off in existing note and exit note).
1. Tap ***New note*** floating action button.
2. Tap ***Info*** action in app bar.
3. Tap ***Enable markdown*** switch.
4. Dismiss ***Info*** bottom sheet.
5. Notice ***Edit*** and ***Preview*** tabs are shown.
6. Tap ***Preview*** tab.
7. Tap back arrow in app bar.
8. Tap note from Step 1.
9. Notice ***Edit*** and ***Preview*** tabs are shown and ***Preview*** tab is selected.

### Review
Only one developer is required to review these changes, but anyone can perform the review. 
 @rachelmcr, I also requested you as a reviewer since you caught the associated bugs and to ensure they are fixed.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.