### PR TITLE
Update About Status

### DIFF
--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -152,6 +152,7 @@
         <item name="android:textColor">@android:color/white</item>
         <item name="android:windowBackground">@color/blue</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:windowLightStatusBar">false</item>
         <item name="actionBarTextColor">@android:color/white</item>
         <item name="colorPrimaryDark">@color/blue_dark</item>
         <item name="toolbarColor">@color/blue</item>


### PR DESCRIPTION
### Fix
Add the `<item name="android:windowLightStatusBar">false</item>` item to the `Theme.Simplestyle.About` style to change the status bar icons from gray to white.  See the screenshots below for illustration.

![update_about_status](https://user-images.githubusercontent.com/3827611/63868500-dd232200-c973-11e9-9ba0-696595906ce8.png)

### Test
1. Open navigation drawer.
2. Tap ***Settings*** in navigation drawer.
3. Tap ***About Simplenote*** in ***More Information*** section.
4. Notice white status icons.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.