### PR TITLE
Update Snackbar Background

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SnackbarUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SnackbarUtils.java
@@ -1,6 +1,7 @@
 package com.automattic.simplenote.utils;
 
 import android.app.Activity;
+import android.content.res.ColorStateList;
 import android.view.View;
 
 import androidx.annotation.ColorRes;
@@ -10,10 +11,9 @@ import androidx.core.content.ContextCompat;
 import com.google.android.material.snackbar.Snackbar;
 
 public class SnackbarUtils {
-
     public static Snackbar showSnackbar(Activity activity, @StringRes int message, @ColorRes int color, int duration) {
         Snackbar snackbar = Snackbar.make(activity.findViewById(android.R.id.content), message, duration);
-        snackbar.getView().setBackgroundColor(ContextCompat.getColor(activity, color));
+        snackbar.getView().setBackgroundTintList(ColorStateList.valueOf(ContextCompat.getColor(activity, color)));
         snackbar.show();
         return snackbar;
     }
@@ -22,7 +22,7 @@ public class SnackbarUtils {
                                         @StringRes int action, View.OnClickListener onClick) {
         Snackbar snackbar = Snackbar.make(activity.findViewById(android.R.id.content), message, duration);
         snackbar.setAction(action, onClick);
-        snackbar.getView().setBackgroundColor(ContextCompat.getColor(activity, color));
+        snackbar.getView().setBackgroundTintList(ColorStateList.valueOf(ContextCompat.getColor(activity, color)));
         snackbar.setActionTextColor(ContextCompat.getColor(activity, android.R.color.white));
         snackbar.show();
         return snackbar;


### PR DESCRIPTION
### Fix
Update the `showSnackbar` methods in the `SnackbarUtils` class to use the `setBackgroundTintList` method with `ColorStateList` as a parameter in order for the snackbar background to inherit the rounded corners of the updated [Material design specifications](https://material.io/components/snackbars/#specs).  See the screenshots below for illustration.

![update_snackbar_background](https://user-images.githubusercontent.com/3827611/64032000-d24cc680-cb06-11e9-90c9-eb491950f13f.png)

### Test
1. Go to note list.
2. Tap unpublished note in list.
3. Tap ***Share*** action in app bar.
4. Tap ***Publish*** button.
5. Notice snackbar has rounded corners with blue background.
6. Wait for note to publish.
7. Notice snackbar has rounded corners with green background.
8. Tap ***Share*** action in app bar.
9. Tap ***Remove public link*** button.
10. Notice snackbar has rounded corners with blue background.
11. Wait for note to unpublish.
12. Notice snackbar has rounded corners with red background.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.