### PR TITLE
Update About Style

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/AboutActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AboutActivity.java
@@ -12,21 +12,16 @@ public class AboutActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
         setContentView(R.layout.activity_about);
-
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
         setTitle("");
 
-        Toolbar toolbar = findViewById(R.id.toolbar);
-        if (toolbar != null) {
-            toolbar.setElevation(0);
-        }
-
-        setSupportActionBar(toolbar);
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-            getSupportActionBar().setHomeAsUpIndicator(DrawableUtils.tintDrawableWithResource(this,
-                    R.drawable.ic_action_remove_24dp, android.R.color.white));
+            getSupportActionBar().setHomeAsUpIndicator(DrawableUtils.tintDrawableWithResource(
+                this, R.drawable.ic_action_remove_24dp, android.R.color.white
+            ));
         }
     }
 

--- a/Simplenote/src/main/res/layout/activity_about.xml
+++ b/Simplenote/src/main/res/layout/activity_about.xml
@@ -1,11 +1,18 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/main_parent_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/toolbar"/>
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:background="?attr/toolbarColor"
+        android:elevation="0dp"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        app:theme="@style/ThemeOverlay.MaterialComponents"/>
 
     <fragment
         android:id="@+id/about_fragment"

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -153,8 +153,6 @@
         <item name="android:windowBackground">@color/blue</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLightStatusBar">false</item>
-        <item name="actionBarTextColor">@android:color/white</item>
-        <item name="colorPrimaryDark">@color/blue_dark</item>
         <item name="toolbarColor">@color/blue</item>
     </style>
 

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -147,7 +147,7 @@
         <item name="android:textColor">?attr/actionModeTextColor</item>
     </style>
 
-    <style name="Theme.Simplestyle.About">
+    <style name="Theme.Simplestyle.About" parent="Theme.MaterialComponents.NoActionBar">
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:textColor">@android:color/white</item>
         <item name="android:windowBackground">@color/blue</item>


### PR DESCRIPTION
### Fix
Update style on ***About Simplenote*** screen to use white touch feedback for better visibility and theme consistency.  See the screenshots below for illustration.

![update_about_style](https://user-images.githubusercontent.com/3827611/64186726-8febf800-ce2c-11e9-884d-daf77c40b76f.png)

### Test
1. Open navigation drawer.
2. Tap ***Settings*** in navigation drawer.
3. Tap ***About Simplenote*** in ***More Information*** section.
4. Long-press close icon in app bar.
5. Notice white touch feedback background.
6. Long-press item in list.
7. Notice white touch feedback background.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.