### PR TITLE
Tags List Empty

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
@@ -29,6 +29,7 @@ import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
 import com.automattic.simplenote.utils.BaseCursorAdapter;
 import com.automattic.simplenote.utils.HtmlCompat;
+import com.automattic.simplenote.widgets.EmptyViewRecyclerView;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObjectNameInvalid;
 import com.simperium.client.Query;
@@ -51,11 +52,7 @@ public class TagsListFragment extends Fragment implements ActionMode.Callback, B
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View view = inflater.inflate(R.layout.fragment_tags_list, container, false);
-
-        TextView emptyTextView = view.findViewById(android.R.id.empty);
-        emptyTextView.setText(HtmlCompat.fromHtml("<strong>" + getString(R.string.no_tags_found) + "</strong>"));
-        return view;
+        return inflater.inflate(R.layout.fragment_tags_list, container, false);
     }
 
     @Override
@@ -68,11 +65,14 @@ public class TagsListFragment extends Fragment implements ActionMode.Callback, B
         mTagsBucket = application.getTagsBucket();
         mNotesBucket = application.getNotesBucket();
 
-        RecyclerView recyclerView = getActivity().findViewById(R.id.tagList);
+        EmptyViewRecyclerView recyclerView = getActivity().findViewById(R.id.list);
         mTagsAdapter = new TagsAdapter();
         recyclerView.setAdapter(mTagsAdapter);
         recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
         recyclerView.addItemDecoration(new DividerItemDecoration(recyclerView.getContext(), DividerItemDecoration.VERTICAL));
+        TextView emptyView = getActivity().findViewById(R.id.empty);
+        emptyView.setText(HtmlCompat.fromHtml("<strong>" + getString(R.string.no_tags_found) + "</strong>"));
+        recyclerView.setEmptyView(emptyView);
 
         refreshTags();
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/EmptyViewRecyclerView.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/EmptyViewRecyclerView.java
@@ -1,0 +1,72 @@
+package com.automattic.simplenote.widgets;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+import androidx.recyclerview.widget.RecyclerView;
+
+/**
+ * RecyclerView with setEmptyView method which displays a view when RecyclerView adapter is empty.
+ */
+public class EmptyViewRecyclerView extends RecyclerView {
+    private View mEmptyView;
+
+    private final AdapterDataObserver mObserver = new AdapterDataObserver() {
+        @Override
+        public void onChanged() {
+            toggleEmptyView();
+        }
+
+        @Override
+        public void onItemRangeInserted(int positionStart, int itemCount) {
+            toggleEmptyView();
+        }
+
+        @Override
+        public void onItemRangeRemoved(int positionStart, int itemCount) {
+            toggleEmptyView();
+        }
+    };
+
+    public EmptyViewRecyclerView(Context context) {
+        super(context);
+    }
+
+    public EmptyViewRecyclerView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public EmptyViewRecyclerView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    @Override
+    public void setAdapter(Adapter adapterNew) {
+        final RecyclerView.Adapter adapterOld = getAdapter();
+
+        if (adapterOld != null) {
+            adapterOld.unregisterAdapterDataObserver(mObserver);
+        }
+
+        super.setAdapter(adapterNew);
+
+        if (adapterNew != null) {
+            adapterNew.registerAdapterDataObserver(mObserver);
+        }
+
+        toggleEmptyView();
+    }
+
+    public void setEmptyView(View emptyView) {
+        mEmptyView = emptyView;
+        toggleEmptyView();
+    }
+
+    private void toggleEmptyView() {
+        if (mEmptyView != null && getAdapter() != null) {
+            final boolean empty = getAdapter().getItemCount() == 0;
+            mEmptyView.setVisibility(empty ? VISIBLE : GONE);
+        }
+    }
+}

--- a/Simplenote/src/main/res/layout/fragment_notes_list.xml
+++ b/Simplenote/src/main/res/layout/fragment_notes_list.xml
@@ -38,7 +38,7 @@
             android:layout_width="wrap_content"
             android:padding="8dp"
             android:textColor="?attr/notePreviewColor"
-            android:textSize="20sp">
+            android:textSize="@dimen/text_empty">
         </com.automattic.simplenote.widgets.RobotoRegularTextView>
 
     </LinearLayout>

--- a/Simplenote/src/main/res/layout/fragment_tags_list.xml
+++ b/Simplenote/src/main/res/layout/fragment_tags_list.xml
@@ -1,25 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_height="match_parent"
-    android:layout_weight="6.5"
+    android:layout_width="match_parent"
     android:orientation="vertical">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/tagList"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+    <com.automattic.simplenote.widgets.EmptyViewRecyclerView
+        android:id="@+id/list"
         android:background="@android:color/transparent"
         android:divider="?attr/listDividerDrawable"
-        android:dividerHeight="@dimen/divider_height"/>
+        android:dividerHeight="@dimen/divider_height"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent">
+    </com.automattic.simplenote.widgets.EmptyViewRecyclerView>
 
     <com.automattic.simplenote.widgets.RobotoRegularTextView
-        android:id="@android:id/empty"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:id="@+id/empty"
         android:gravity="center"
-        android:padding="16dp"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:padding="@dimen/padding_large"
+        android:text="@string/no_tags_found"
         android:textColor="?attr/placeholderLogoColor"
-        android:textSize="20sp"/>
+        android:textSize="20sp">
+    </com.automattic.simplenote.widgets.RobotoRegularTextView>
 
-</LinearLayout>
+</RelativeLayout>

--- a/Simplenote/src/main/res/layout/fragment_tags_list.xml
+++ b/Simplenote/src/main/res/layout/fragment_tags_list.xml
@@ -23,7 +23,7 @@
         android:padding="@dimen/padding_large"
         android:text="@string/no_tags_found"
         android:textColor="?attr/placeholderLogoColor"
-        android:textSize="20sp">
+        android:textSize="@dimen/text_empty">
     </com.automattic.simplenote.widgets.RobotoRegularTextView>
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -39,7 +39,7 @@
         <item name="mainBackgroundColor">@color/background_dark</item>
         <item name="tagChipShadowColor">@color/background_dark</item>
         <item name="pinIconSelector">@drawable/bg_pin_selector_dark</item>
-        <item name="placeholderLogoColor">@color/empty</item>
+        <item name="placeholderLogoColor">@color/empty_dark</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
         <item name="settingsTextColor">@android:color/white</item>
         <item name="tagChipBackgroundDrawable">@drawable/bg_tag_dark</item>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -23,7 +23,8 @@
     <color name="background_light_highlight">@color/blue_0</color>
     <color name="divider_dark">@color/gray_60</color>
     <color name="divider_light">@color/gray_5</color>
-    <color name="empty">@color/gray_40</color>
+    <color name="empty_dark">@color/gray_40</color>
+    <color name="empty_light">@color/gray_20</color>
     <color name="item_blue_dark">@color/blue_20</color>
     <color name="item_blue_light">@color/blue_50</color>
     <color name="status_negative">@color/red</color>

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -47,6 +47,7 @@
     <dimen name="line_spacing">4dp</dimen>
     <dimen name="passcode_logo">96dp</dimen>
     <dimen name="passcode_width">480dp</dimen>
+    <dimen name="text_empty">20sp</dimen>
     <dimen name="text_passcode">18sp</dimen>
     <dimen name="text_widget">12sp</dimen>
     <dimen name="text_content">14sp</dimen>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -50,7 +50,7 @@
         <item name="notePreviewColor">@color/text_content_light</item>
         <item name="noteTitleColor">@color/text_title_light</item>
         <item name="pinIconSelector">@drawable/bg_pin_selector_light</item>
-        <item name="placeholderLogoColor">@color/gray_5</item>
+        <item name="placeholderLogoColor">@color/empty_light</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
         <item name="settingsTextColor">@color/black</item>
         <item name="tagChipBackgroundDrawable">@drawable/bg_tag_light</item>


### PR DESCRIPTION
### Fix
After updating the ***Edit Tags*** screen from `ListView` to `RecyclerView` in https://github.com/Automattic/simplenote-android/pull/730, the empty view is no longer being shown when there are no tags.  These changes add the `EmptyViewRecyclerView` class and update the files associated with the ***Edit Tags*** screen to show the empty view when applicable.  See the screenshots below for illustration.

![tags_list_empty](https://user-images.githubusercontent.com/3827611/64349756-b8066300-cfb4-11e9-80ea-e901cfb6e6c6.png)

### Test
0. Use account with no tags.
1. Open navigation drawer.
2. Tap ***Edit*** in ***Tags*** header.
3. Notice ***No tags found.*** empty view is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.