### PR TITLE
Crash Save Note

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -973,14 +973,13 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     protected void saveNote() {
         try {
-            Simplenote application = (Simplenote) requireActivity().getApplication();
-            Bucket<Note> notesBucket = application.getNotesBucket();
-            mNote = notesBucket.get(mNote.getSimperiumKey());
-
             if (mNote == null || mContentEditText == null || mIsLoadingNote ||
                     (mHistoryBottomSheet != null && mHistoryBottomSheet.isShowing())) {
                 return;
             } else {
+                Simplenote application = (Simplenote) requireActivity().getApplication();
+                Bucket<Note> notesBucket = application.getNotesBucket();
+                mNote = notesBucket.get(mNote.getSimperiumKey());
                 mIsPreviewEnabled = mNote.isPreviewEnabled();
             }
 


### PR DESCRIPTION
### Fix
As a result of the bug fix in https://github.com/Automattic/simplenote-android/pull/788, a `NullPointerException` crash was introduced.  The crash only occurred on tablet devices in landscape orientation when a note was not already selected in the list.  This pull request moves the changes in the `NoteEditorFragment.saveNote()` from that bug fix after the null-check to avoid the `NullPointerException`.

### Test
Even though the crash only occurred on tablet devices in landscape orientation, tests should be run on both phone and tablet devices to ensure no other bugs were introduced.
#### Phone
1. Tap note in list with markdown enabled.
2. Notice ***Edit*** tab is shown.
3. Tap ***Preview*** tab.
4. Tap back arrow in app bar.
5. Tap note from Step 1.
6. Notice ***Preview*** tab is shown.

#### Tablet
1. Rotate device into landscape orientation.
2. Notice no note is selected in list to left.
3. Notice empty view is shown to right.
4. Tap any note in list.
5. Notice note is selected in list to left.
6. Notice note view is shown to right.
7. Notice app does not crash.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.