### PR TITLE
Update About Status

### DIFF
--- a/Simplenote/src/main/res/values-v27/styles.xml
+++ b/Simplenote/src/main/res/values-v27/styles.xml
@@ -16,6 +16,7 @@
         <item name="android:windowBackground">@color/blue</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:windowLightStatusBar">false</item>
         <item name="actionBarTextColor">@android:color/white</item>
         <item name="colorPrimaryDark">@color/blue_dark</item>
         <item name="toolbarColor">@color/blue</item>

--- a/Simplenote/src/main/res/values-v27/styles.xml
+++ b/Simplenote/src/main/res/values-v27/styles.xml
@@ -9,7 +9,8 @@
         <item name="android:windowLightNavigationBar">true</item>
         <item name="android:windowLightStatusBar">true</item>
     </style>
-    <style name="Theme.Simplestyle.About">
+
+    <style name="Theme.Simplestyle.About" parent="Theme.MaterialComponents.NoActionBar">
         <item name="android:navigationBarColor">@color/blue</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:textColor">@android:color/white</item>


### PR DESCRIPTION
### Fix
Add the `windowLightStatusBar` attribute to the `Theme.Simplestyle.About` style in the `values-v27/styles.xml` file so that the status bar icons are white and match the style from the `values/styles.xml` file.  See the screenshots below for illustration.

![update_about_status](https://user-images.githubusercontent.com/3827611/64452743-33930d80-d0a4-11e9-8388-b9a8260cacc6.png)

### Test
Since only the `values-v27/styles.xml` file was updated, these changes only apply to devices running API 27 or later and the test steps should be executed on an applicable device.
1. Open navigation drawer.
2. Tap ***Settings*** in navigation drawer.
3. Tap ***About Simplenote*** in ***More Information*** section.
4. Notice white status bar icons.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.