### PR TITLE
Note List Padding

### DIFF
--- a/Simplenote/src/main/res/layout/fragment_notes_list.xml
+++ b/Simplenote/src/main/res/layout/fragment_notes_list.xml
@@ -18,7 +18,6 @@
         android:layout_height="match_parent"
         android:layout_width="match_parent"
         android:paddingBottom="@dimen/note_list_item_padding_bottom_button"
-        android:paddingTop="@dimen/note_list_item_padding_top"
         android:scrollbarStyle="outsideOverlay"
         tools:listitem="@layout/note_list_row">
     </ListView>


### PR DESCRIPTION
### Fix
Remove the 8dp top padding from the list view in the note list layout.  See the screenshots below for illustration.

![update_note_list_padding_top](https://user-images.githubusercontent.com/3827611/65431215-4f055480-ddd6-11e9-920d-1b6a75da91d9.png)

### Test
1. Go to note list.
2. Long-press top note in list.
3. Notice no padding between note and app bar.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.