### PR TITLE
Add Center Credentials

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -68,7 +68,7 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Automattic and WordPress dependencies
-    implementation 'com.simperium.android:simperium:0.9.0'
+    implementation 'com.simperium.android:simperium:0.9.1'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:1.7.0'
 


### PR DESCRIPTION
### Fix
Update the `com.simperium.android:simperium` library dependency from `0.9.0` to `0.9.1` in order to center the view on large screens as described in https://github.com/Simperium/simperium-android/pull/211.  See the screenshots below for illustration.

Before|After
-|-
![1569247536](https://user-images.githubusercontent.com/3827611/65432893-3e0a1280-ddd9-11e9-9124-4a3ce822bd06.png)|![1569247502](https://user-images.githubusercontent.com/3827611/65432910-46624d80-ddd9-11e9-96bb-082440877694.png)
![1569247540](https://user-images.githubusercontent.com/3827611/65432896-3f3b3f80-ddd9-11e9-9813-19f899441708.png)|![1569247508](https://user-images.githubusercontent.com/3827611/65432934-524e0f80-ddd9-11e9-9112-81bd633b1f97.png)

### Test
These changes only apply to devices 640dp x 480dp and larger.  Use a device that falls into the `layout-large` category (e.g. Nexus 9 tablet in landscape orientation) for testing.

0. Clear app data.
1. Tap ***Sign Up*** button.
2. Notice layout is centered.
3. Tap back arrow in app bar.
4. Tap ***Log In*** button.
5. Tap ***Log In with Email*** button.
6. Notice layout is centered.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.