### PR TITLE
Rename Title Resource

### DIFF
--- a/Simplenote/src/main/res/layout/note_list_row.xml
+++ b/Simplenote/src/main/res/layout/note_list_row.xml
@@ -66,7 +66,7 @@
         android:lines="1"
         android:singleLine="true"
         android:textColor="?attr/noteTitleColor"
-        android:textSize="@dimen/text_title"
+        android:textSize="@dimen/text_content_title"
         tools:text="Welcome to Simplenote Android!">
     </com.automattic.simplenote.widgets.RobotoMediumTextView>
 

--- a/Simplenote/src/main/res/layout/note_widget.xml
+++ b/Simplenote/src/main/res/layout/note_widget.xml
@@ -35,7 +35,7 @@
         android:layout_width="wrap_content"
         android:text="@string/loading_note"
         android:textColor="@color/text_title_light"
-        android:textSize="@dimen/text_title"
+        android:textSize="@dimen/text_content_title"
         android:visibility="gone"
         tools:text="To-Do List"
         tools:textColor="@color/text_title_light"

--- a/Simplenote/src/main/res/layout/tag_autocomplete_list_item.xml
+++ b/Simplenote/src/main/res/layout/tag_autocomplete_list_item.xml
@@ -8,6 +8,6 @@
     android:layout_width="match_parent"
     android:padding="@dimen/padding_medium"
     android:textAppearance="@android:style/TextAppearance.Medium"
-    android:textSize="@dimen/text_title"
+    android:textSize="@dimen/text_content_title"
     tools:text="Tag Name">
 </com.automattic.simplenote.widgets.RobotoRegularTextView>

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -52,7 +52,7 @@
     <dimen name="text_passcode">18sp</dimen>
     <dimen name="text_widget">12sp</dimen>
     <dimen name="text_content">14sp</dimen>
+    <dimen name="text_content_title">16sp</dimen>
     <dimen name="text_tag">14sp</dimen>
-    <dimen name="text_title">16sp</dimen>
 
 </resources>


### PR DESCRIPTION
### Fix
Rename the `text_title` dimension resource to `text_content_title` to avoid conflicts with the `simperium-android` library dimension resource and use the proper size for the ***Simplenote*** title text on the login/signup screen.  See the screenshots below for illustration.

![update_title_resource](https://user-images.githubusercontent.com/3827611/65725183-467b7b00-e06f-11e9-8e92-b65ae1f13b6e.png)

### Test
0. Clear app data.
1. Launch app.
2. Notice ***SImplenote*** title text as shown above.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.