### PR TITLE
Update Dark Background

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.1.0
 -----
+* Updated dark theme with darker colors for less eye fatigue and better battery life
 * Updated navigation drawer interface for better organization and compatibility
 * Updated note list interface for better performance and readability
 

--- a/Simplenote/src/main/assets/dark.css
+++ b/Simplenote/src/main/assets/dark.css
@@ -20,7 +20,7 @@ img {
 html {
     margin: 0;
     padding: 0;
-    background: #2d3034;
+    background: #101517;
     color: #dbdee0;
     text-rendering: optimizeLegibility;
 }

--- a/Simplenote/src/main/res/layout/activity_notes.xml
+++ b/Simplenote/src/main/res/layout/activity_notes.xml
@@ -38,6 +38,7 @@
 
     <com.google.android.material.navigation.NavigationView
         android:id="@+id/navigation_view"
+        android:background="?attr/drawerBackgroundColor"
         android:layout_gravity="start"
         android:layout_height="match_parent"
         android:layout_width="wrap_content"

--- a/Simplenote/src/main/res/values-night-v27/styles.xml
+++ b/Simplenote/src/main/res/values-night-v27/styles.xml
@@ -11,8 +11,8 @@
     </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialog" parent="Theme.MaterialComponents.BottomSheetDialog">
-        <item name="android:colorBackground">?attr/mainBackgroundColor</item>
-        <item name="android:navigationBarColor">?attr/mainBackgroundColor</item>
+        <item name="android:colorBackground">@color/background_dark_16</item>
+        <item name="android:navigationBarColor">@color/background_dark_16</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowLightNavigationBar">false</item>

--- a/Simplenote/src/main/res/values-night-v27/styles.xml
+++ b/Simplenote/src/main/res/values-night-v27/styles.xml
@@ -3,7 +3,7 @@
 <resources>
 
     <style name="Theme.Simplestyle" parent="Base.Theme.Simplestyle">
-        <item name="android:navigationBarColor">@color/background_dark</item>
+        <item name="android:navigationBarColor">?attr/mainBackgroundColor</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLightNavigationBar">false</item>
@@ -12,7 +12,7 @@
 
     <style name="Theme.Simplestyle.BottomSheetDialog" parent="Theme.MaterialComponents.BottomSheetDialog">
         <item name="android:colorBackground">?attr/mainBackgroundColor</item>
-        <item name="android:navigationBarColor">@color/background_dark</item>
+        <item name="android:navigationBarColor">?attr/mainBackgroundColor</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowLightNavigationBar">false</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -74,7 +74,7 @@
 
     <style name="Theme.Simplestyle.BottomSheetDialog" parent="Theme.MaterialComponents.BottomSheetDialog">
         <item name="android:colorBackground">?attr/mainBackgroundColor</item>
-        <item name="android:navigationBarColor">@color/background_dark</item>
+        <item name="android:navigationBarColor">?attr/mainBackgroundColor</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowIsFloating">false</item>
         <item name="bottomSheetStyle">@style/Widget.Design.BottomSheet.Modal</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -73,8 +73,8 @@
     </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialog" parent="Theme.MaterialComponents.BottomSheetDialog">
-        <item name="android:colorBackground">?attr/mainBackgroundColor</item>
-        <item name="android:navigationBarColor">?attr/mainBackgroundColor</item>
+        <item name="android:colorBackground">@color/background_dark_16</item>
+        <item name="android:navigationBarColor">@color/background_dark_16</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowIsFloating">false</item>
         <item name="bottomSheetStyle">@style/Widget.Design.BottomSheet.Modal</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -48,7 +48,7 @@
         <item name="placeholderLogoColor">@color/empty_dark</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
         <item name="settingsTextColor">@android:color/white</item>
-        <item name="toolbarColor">@color/background_dark</item>
+        <item name="toolbarColor">@color/background_dark_4</item>
         <item name="toolbarPopupTheme">@style/ThemeOverlay.MaterialComponents</item>
         <item name="windowActionModeOverlay">true</item>
     </style>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -38,11 +38,11 @@
         <item name="listDividerDrawable">@drawable/divider_dark</item>
         <item name="listSearchHighlightBackgroundColor">@color/blue_60</item>
         <item name="listSearchHighlightForegroundColor">@color/blue_5</item>
+        <item name="mainBackgroundColor">@color/background_dark</item>
         <item name="noteEditorTextColor">@android:color/white</item>
         <item name="notePinColor">@android:color/white</item>
         <item name="notePreviewColor">@color/text_content_dark</item>
         <item name="noteTitleColor">@android:color/white</item>
-        <item name="mainBackgroundColor">@color/background_dark</item>
         <item name="tagChipShadowColor">@color/background_dark</item>
         <item name="pinIconSelector">@drawable/bg_pin_selector_dark</item>
         <item name="placeholderLogoColor">@color/empty_dark</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -25,6 +25,7 @@
         <item name="colorPrimaryDark">@color/background_dark</item>
         <item name="dividerColor">@color/divider_dark</item>
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
+        <item name="drawerBackgroundColor">@color/background_dark_16</item>
         <item name="drawerBackgroundSelector">@color/bg_drawer_selector</item>
         <item name="editorSearchHighlightBackgroundColor">@color/blue_60</item>
         <item name="editorSearchHighlightForegroundColor">@color/blue_5</item>

--- a/Simplenote/src/main/res/values-v27/styles.xml
+++ b/Simplenote/src/main/res/values-v27/styles.xml
@@ -25,7 +25,7 @@
 
     <style name="Theme.Simplestyle.BottomSheetDialog" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
         <item name="android:colorBackground">?attr/mainBackgroundColor</item>
-        <item name="android:navigationBarColor">@color/background_light</item>
+        <item name="android:navigationBarColor">?attr/mainBackgroundColor</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowLightNavigationBar">true</item>

--- a/Simplenote/src/main/res/values/attrs.xml
+++ b/Simplenote/src/main/res/values/attrs.xml
@@ -36,4 +36,6 @@
     <attr name="fabColor" format="reference"/>
     <attr name="fabIconColor" format="reference"/>
 
+    <attr name="drawerBackgroundColor" format="reference|color"/>
+
 </resources>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -11,6 +11,17 @@
     <color name="red">@color/red_50</color>
     <color name="yellow">@color/yellow_20</color>
 
+    <!-- ELEVATION -->
+    <color name="background_dark_1">#1c2022</color>
+    <color name="background_dark_2">#202527</color>
+    <color name="background_dark_3">#222729</color>
+    <color name="background_dark_4">#252a2b</color>
+    <color name="background_dark_6">#2a2e30</color>
+    <color name="background_dark_8">#2d3133</color>
+    <color name="background_dark_12">#313637</color>
+    <color name="background_dark_16">#333739</color>
+    <color name="background_dark_24">#363a3c</color>
+
     <!-- PASSCODE -->
     <color name="passcodelock_background">@color/blue</color>
     <color name="passcodelock_button_text_color">@android:color/white</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -28,7 +28,7 @@
     <color name="passcodelock_prompt_text_color">@android:color/white</color>
 
     <!-- SEMANTIC -->
-    <color name="background_dark">@color/gray_70</color>
+    <color name="background_dark">@color/gray_100</color>
     <color name="background_dark_highlight">@color/gray_60</color>
     <color name="background_light">@android:color/white</color>
     <color name="background_light_highlight">@color/blue_0</color>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -37,6 +37,7 @@
         <item name="colorPrimaryDark">@color/background_light</item>
         <item name="dividerColor">@color/divider_light</item>
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
+        <item name="drawerBackgroundColor">@color/background_light</item>
         <item name="drawerBackgroundSelector">@color/bg_drawer_selector</item>
         <item name="editorSearchHighlightBackgroundColor">@color/blue_5</item>
         <item name="editorSearchHighlightForegroundColor">@color/blue_60</item>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -78,12 +78,12 @@
     </style>
 
     <style name="Button.Flat" parent="Widget.MaterialComponents.Button.TextButton">
-        <item name="android:textColor">@color/blue</item>
+        <item name="android:textColor">?attr/iconTintColor</item>
     </style>
 
     <style name="Button.Flat.Icon" parent="Widget.MaterialComponents.Button.TextButton.Icon">
-        <item name="android:textColor">@color/blue</item>
-        <item name="iconTint">@color/blue</item>
+        <item name="android:textColor">?attr/iconTintColor</item>
+        <item name="iconTint">?attr/iconTintColor</item>
     </style>
 
     <style name="PopupMenu.Simplestyle" parent="@android:style/Widget.Material.Light.ListPopupWindow">

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -78,12 +78,12 @@
     </style>
 
     <style name="Button.Flat" parent="Widget.MaterialComponents.Button.TextButton">
-        <item name="android:textColor">?attr/iconTintColor</item>
+        <item name="android:textColor">?attr/colorAccent</item>
     </style>
 
     <style name="Button.Flat.Icon" parent="Widget.MaterialComponents.Button.TextButton.Icon">
-        <item name="android:textColor">?attr/iconTintColor</item>
-        <item name="iconTint">?attr/iconTintColor</item>
+        <item name="android:textColor">?attr/colorAccent</item>
+        <item name="iconTint">?attr/colorAccent</item>
     </style>
 
     <style name="PopupMenu.Simplestyle" parent="@android:style/Widget.Material.Light.ListPopupWindow">


### PR DESCRIPTION
### Fix
Update the color values used in ***Dark*** theme to use darker shades of gray and follow [Material guidelines for elevation](https://material.io/design/color/dark-theme.html#properties).  See the screenshots below for illustration.

![update_dark_background](https://user-images.githubusercontent.com/3827611/65899070-2ea63e80-e370-11e9-96aa-3a33fda64d84.png)

### Test
0. Set theme to ***Dark***.
1. Open navigation drawer.
2. Notice navigation drawer background is lighter than navigation bar background.
3. Close navigation drawer.
4. Notice app bar background is lighter than note list background and status bar background.
5. Notice note list background is equal to navigation bar background.
6. Tap note in list with markdown enabled.
7. Tap ***Edit*** tab in app bar.
8. Notice app bar background is lighter than note content background and status bar background.
9. Tap ***Preview*** tab in app bar.
10. Notice app bar background is lighter than note content background and status bar background.
11. Notice note content background is equal in both ***Edit*** and ***Preview*** tabs.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 83bbe974 with:
> Updated dark theme with darker colors for less eye fatigue and better battery life