### PR TITLE
Update Default Theme

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -47,7 +47,7 @@ public class ThemeUtils {
             }
         }
 
-        switch (PrefUtils.getIntPref(activity, PrefUtils.PREF_THEME, THEME_SYSTEM)) {
+        switch (PrefUtils.getIntPref(activity, PrefUtils.PREF_THEME, THEME_LIGHT)) {
             case THEME_AUTO:
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
                 break;


### PR DESCRIPTION
### Fix
Update the default theme to ***Light***.  Even though the ***Theme*** setting was ***Light*** by default, the ***System default*** theme was being used by default.

### Test
Since the ***System default*** option only works for Android Q (API 29), the option is not displayed for devices running other Android versions.  However, the steps will produce the same result on any device.

0. Clear app data.
1. Launch app.
2. Notice theme is ***Light***.
3. Finish login/signup.
4. Notice theme is ***Light***.
5. Open navigation drawer.
6. Tap ***Settings*** option.
7. Tap ***Theme*** under ***Appearance*** section.
8. Notice ***Light*** option is selected.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.  I requested @iamthomasbishop as a reviewer since he discovered the issue.

### Release
These changes do not require release notes.