### PR TITLE
Remove Category Key

### DIFF
--- a/Simplenote/src/main/res/xml/preferences.xml
+++ b/Simplenote/src/main/res/xml/preferences.xml
@@ -2,7 +2,6 @@
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory
-        android:key="pref_key_note_preferences"
         android:title="@string/notes">
 
         <SwitchPreferenceCompat
@@ -19,7 +18,6 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="pref_key_tags_preferences"
         android:title="@string/tags">
         <SwitchPreferenceCompat
             android:defaultValue="false"
@@ -40,7 +38,6 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="pref_key_note_preferences"
         android:title="@string/editor">
         <ListPreference
             android:defaultValue="@integer/default_font_size"
@@ -73,14 +70,12 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="pref_key_account_preferences"
         android:title="@string/account">
         <Preference
             android:key="pref_key_authenticate"/>
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="pref_key_privacy"
         android:title="Privacy">
         <SwitchPreferenceCompat
             android:defaultValue="true"


### PR DESCRIPTION
### Fix
Remove the `key` attribute from `PreferenceCategory` views in the `preferences.xml` file.  None of the key values are being used elsewhere in the code and the `pref_key_note_preferences` key value was duplicated in the file causing the following runtime error.

```
E/PreferenceGroup: Found duplicated key: "pref_key_note_preferences". This can cause unintended behaviour, please use unique keys for every preference.
```

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Change multiple settings.
4. Notice changed settings are applied.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.