### PR TITLE
Remove Location Permission

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Updated dark theme with darker colors for less eye fatigue and better battery life
 * Updated navigation drawer interface for better organization and compatibility
 * Updated note list interface for better performance and readability
+* Removed location permission for dark at night only theme
 
 2.0.0
 -----

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -88,7 +88,6 @@ dependencies {
         transitive = true
     }
     implementation 'androidx.browser:browser:1.0.0'
-    implementation 'com.karumi:dexter:5.0.0'
     wearApp project(':Wear')
 }
 

--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:name=".Simplenote"

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -1,6 +1,5 @@
 package com.automattic.simplenote;
 
-import android.Manifest;
 import android.app.Activity;
 import android.app.Fragment;
 import android.content.DialogInterface;
@@ -24,13 +23,7 @@ import com.automattic.simplenote.models.Preferences;
 import com.automattic.simplenote.utils.CrashUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
 import com.automattic.simplenote.utils.PrefUtils;
-import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.utils.WidgetUtils;
-import com.karumi.dexter.Dexter;
-import com.karumi.dexter.listener.PermissionDeniedResponse;
-import com.karumi.dexter.listener.PermissionGrantedResponse;
-import com.karumi.dexter.listener.single.BasePermissionListener;
-import com.karumi.dexter.listener.single.PermissionListener;
 import com.simperium.Simperium;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObjectMissingException;
@@ -120,41 +113,9 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
 
         final ListPreference themePreference = (ListPreference) findPreference(PrefUtils.PREF_THEME);
         themePreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
-
-                final Activity activity = getActivity();
-                final int index = Integer.parseInt(newValue.toString());
-                if (index == ThemeUtils.THEME_AUTO) {
-
-                    PermissionListener permissionListener = new BasePermissionListener() {
-                        @Override
-                        public void onPermissionGranted(PermissionGrantedResponse response) {
-                            updateTheme(activity, index);
-                        }
-                        @Override
-                        public void onPermissionDenied(PermissionDeniedResponse response) {
-                            new AlertDialog.Builder(activity)
-                                    .setTitle(R.string.location_permission_denied)
-                                    .setMessage(R.string.location_permission_explanation)
-                                    .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                                        @Override public void onClick(DialogInterface dialog, int which) {
-                                            dialog.dismiss();
-                                        }
-                                    })
-                                    .show();
-                        }
-                    };
-                    Dexter.withActivity(activity)
-                            .withPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
-                            .withListener(permissionListener)
-                            .check();
-                    updateTheme(activity, index);
-                } else {
-                    updateTheme(activity, index);
-                }
-
+                updateTheme(requireActivity(), Integer.parseInt(newValue.toString()));
                 return true;
             }
 
@@ -175,7 +136,6 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
 
         final ListPreference sortPreference = (ListPreference) findPreference(PrefUtils.PREF_SORT_ORDER);
         sortPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 int index = Integer.parseInt(newValue.toString());

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -194,10 +194,6 @@
     <string name="font_size_large">Large</string>
     <string name="font_size_extra_large">Extra large</string>
 
-    <!--Permissions-->
-    <string name="location_permission_denied">Location Permission Denied</string>
-    <string name="location_permission_explanation">Simplenote needs to know your approximate location to accurately determine sunset and sunrise times. Otherwise, night time is assumed to be from 10:00 PM to 6:00 AM.</string>
-
     <!-- Pinned Note Widget -->
     <string name="label_note">Note</string>
     <string name="loading_note">Loading note&#8230;</string>


### PR DESCRIPTION
### Fix
Remove the location permission as a result of removing the [Dexter](https://github.com/Karumi/Dexter) library from the app.  The library helps request permissions at runtime, but the library is no longer working.  The location permission was used only to determine the time of day to change the app theme when the ***Dark at night only*** theme was selected.  Without the location permission, the ***Dark at night only*** theme will still work with hard-coded hours (i.e. 6am to 10pm will be ***Light*** and 10pm to 6am will be ***Dark***).  Now the app requires no runtime permission whatsoever.

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Tap ***Theme*** item in ***Appearance*** section.
4. Tap ***Dark at night only*** item in dialog.
5. Change time of device to 11am.
6. Notice app uses ***Light*** theme.
7. Change time of device to 11pm.
8. Notice app uses ***Dark*** theme.
9. Go to Simplenote app settings in ***Settings*** app.
10. Notice no permissions are required.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in acf85371 with:
> Removed location permission for dark at night only theme