### PR TITLE
Update Merge Conflicts

### DIFF
--- a/Simplenote/src/main/assets/dark.css
+++ b/Simplenote/src/main/assets/dark.css
@@ -20,7 +20,7 @@ img {
 html {
     margin: 0;
     padding: 0;
-    background: #101517;
+    background: #141617;
     color: #dbdee0;
     text-rendering: optimizeLegibility;
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -326,6 +326,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mContentEditText.setOnCheckboxToggledListener(this);
         mContentEditText.setMovementMethod(SimplenoteMovementMethod.getInstance());
         mTagInput = mRootView.findViewById(R.id.tag_input);
+        mTagInput.setDropDownBackgroundResource(R.drawable.bg_list_popup);
         mTagInput.setTokenizer(new SpaceTokenizer());
         mTagInput.setOnFocusChangeListener(this);
         mTagChips = mRootView.findViewById(R.id.tag_chips);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -147,7 +147,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mCallbacks.onActionModeCreated();
         MenuInflater inflater = actionMode.getMenuInflater();
         inflater.inflate(R.menu.bulk_edit, menu);
-        DrawableUtils.tintMenuWithAttribute(getActivity(), menu, R.attr.toolbarIconColor);
+        DrawableUtils.tintMenuWithAttribute(getActivity(), menu, R.attr.actionModeTextColor);
         mActionMode = actionMode;
         int colorResId = ThemeUtils.isLightTheme(requireContext()) ? R.color.background_light : R.color.background_dark;
         requireActivity().getWindow().setStatusBarColor(getResources().getColor(colorResId, requireActivity().getTheme()));

--- a/Simplenote/src/main/res/color/bg_drawer_selector_dark.xml
+++ b/Simplenote/src/main/res/color/bg_drawer_selector_dark.xml
@@ -3,7 +3,7 @@
 <selector
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item android:color="?attr/actionModeBackgroundColor" android:state_checked="true"/>
+    <item android:color="@color/background_dark_highlight" android:state_checked="true"/>
     <item android:color="@android:color/transparent"/>
 
 </selector>

--- a/Simplenote/src/main/res/color/bg_drawer_selector_dark.xml
+++ b/Simplenote/src/main/res/color/bg_drawer_selector_dark.xml
@@ -3,7 +3,7 @@
 <selector
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item android:color="@color/background_dark_highlight" android:state_checked="true"/>
+    <item android:color="@color/background_dark_highlight_drawer" android:state_checked="true"/>
     <item android:color="@android:color/transparent"/>
 
 </selector>

--- a/Simplenote/src/main/res/color/bg_drawer_selector_light.xml
+++ b/Simplenote/src/main/res/color/bg_drawer_selector_light.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:color="@color/background_light_highlight" android:state_checked="true"/>
+    <item android:color="@android:color/transparent"/>
+
+</selector>

--- a/Simplenote/src/main/res/drawable/bg_list_popup.xml
+++ b/Simplenote/src/main/res/drawable/bg_list_popup.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid
+        android:color="?attr/toolbarColor">
+    </solid>
+
+    <corners
+        android:radius="@dimen/card_radius">
+    </corners>
+
+</shape>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -26,7 +26,7 @@
         <item name="dividerColor">@color/divider_dark</item>
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
         <item name="drawerBackgroundColor">@color/background_dark_16</item>
-        <item name="drawerBackgroundSelector">@color/bg_drawer_selector</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_dark</item>
         <item name="editorSearchHighlightBackgroundColor">@color/blue_60</item>
         <item name="editorSearchHighlightForegroundColor">@color/blue_5</item>
         <item name="fabColor">@color/item_blue_dark</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -11,7 +11,7 @@
         <item name="android:windowBackground">@color/background_dark</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="actionBarTextColor">@color/text_title_dark</item>
-        <item name="actionModeBackgroundColor">@color/background_dark</item>
+        <item name="actionModeBackgroundColor">@color/background_dark_4</item>
         <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle</item>
         <item name="actionModeCloseDrawable">@drawable/ic_arrow_left_24dp</item>
         <item name="actionModeStyle">@style/ActionMode.Simplestyle</item>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -12,14 +12,15 @@
     <color name="yellow">@color/yellow_20</color>
 
     <!-- ELEVATION -->
-    <color name="background_dark_1">#1c2022</color>
-    <color name="background_dark_2">#202527</color>
-    <color name="background_dark_3">#222729</color>
-    <color name="background_dark_4">#252a2b</color>
-    <color name="background_dark_6">#2a2e30</color>
-    <color name="background_dark_8">#2d3133</color>
-    <color name="background_dark_12">#313637</color>
-    <color name="background_dark_16">#333739</color>
+    <color name="background_dark_0">#141617</color>
+    <color name="background_dark_1">#1f2021</color>
+    <color name="background_dark_2">#232526</color>
+    <color name="background_dark_3">#252829</color>
+    <color name="background_dark_4">#282b2b</color>
+    <color name="background_dark_6">#2d2f30</color>
+    <color name="background_dark_8">#2f3233</color>
+    <color name="background_dark_12">#333738</color>
+    <color name="background_dark_16">#323638</color>
     <color name="background_dark_24">#363a3c</color>
 
     <!-- PASSCODE -->
@@ -28,7 +29,7 @@
     <color name="passcodelock_prompt_text_color">@android:color/white</color>
 
     <!-- SEMANTIC -->
-    <color name="background_dark">@color/gray_100</color>
+    <color name="background_dark">@color/background_dark_0</color>
     <color name="background_dark_highlight">@color/gray_60</color>
     <color name="background_light">@android:color/white</color>
     <color name="background_light_highlight">@color/blue_5</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -30,7 +30,8 @@
 
     <!-- SEMANTIC -->
     <color name="background_dark">@color/background_dark_0</color>
-    <color name="background_dark_highlight">@color/gray_60</color>
+    <color name="background_dark_highlight">@color/gray_70</color>
+    <color name="background_dark_highlight_drawer">@color/gray_60</color>
     <color name="background_light">@android:color/white</color>
     <color name="background_light_highlight">@color/blue_5</color>
     <color name="divider_dark">@color/gray_60</color>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -38,7 +38,7 @@
         <item name="dividerColor">@color/divider_light</item>
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
         <item name="drawerBackgroundColor">@color/background_light</item>
-        <item name="drawerBackgroundSelector">@color/bg_drawer_selector</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_light</item>
         <item name="editorSearchHighlightBackgroundColor">@color/blue_5</item>
         <item name="editorSearchHighlightForegroundColor">@color/blue_60</item>
         <item name="fabColor">@color/item_blue_light</item>


### PR DESCRIPTION
### Fix
Update multiple bugs caused by sequential pull requests with conflicting changes.  The `background_gray_` color values were updated.  The action mode background color was updated.  The action mode icon color was updated.  The drawer background color was updated.  See the screenshots below for illustration.

![update_merge_conflicts_light](https://user-images.githubusercontent.com/3827611/66176303-6afcc780-e61a-11e9-9f49-34e739f2579e.png)

![update_merge_conflicts_dark](https://user-images.githubusercontent.com/3827611/66176868-8b2d8600-e61c-11e9-85f6-5b68abe9a813.png)

### Test
1. Notice note list background color is unchanged with ***Light*** theme and updated with ***Dark*** theme.
2. Long-press any note in list.
3. Notice app bar background is unchanged.
4. Notice app bar icons and text are blue.
5. Tap back arrow in app bar.
6. Open navigation drawer.
7. Notice selected item is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.