### PR TITLE
Fix typo in Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -321,7 +321,7 @@ SUPPORTED_LOCALES = [
       f.puts("<en-US>")
       f.puts("#{options[:version_name]}:")
       f.puts(File.open(en_release_notes_path).read)
-      f.puts("/<en-US>")
+      f.puts("</en-US>")
     }
   end
 


### PR DESCRIPTION
### Fix
This PR fixes a typo in Fastfile that causes an error in the xml file that contains the translated release notes. 

These changes do not require release notes.
