### PR TITLE
Issue/828 update note tags

### DIFF
--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -18,7 +18,7 @@
         <item name="actionModeTextColor">@color/item_blue_dark</item>
         <item name="bottomSheetDialogTheme">@style/Theme.MaterialComponents.BottomSheetDialog</item>
         <item name="chipCheckedOnBackgroundColor">@color/gray_70</item>
-        <item name="chipCheckedOffBackgroundColor">@color/gray_50</item>
+        <item name="chipCheckedOffBackgroundColor">@color/gray_60</item>
         <item name="chipTextColor">@color/text_chip_dark</item>
         <item name="colorAccent">@color/item_blue_dark</item>
         <item name="colorPrimary">@color/blue</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -17,7 +17,7 @@
         <item name="actionModeStyle">@style/ActionMode.Simplestyle</item>
         <item name="actionModeTextColor">@color/item_blue_dark</item>
         <item name="bottomSheetDialogTheme">@style/Theme.MaterialComponents.BottomSheetDialog</item>
-        <item name="chipCheckedOnBackgroundColor">@color/gray_60</item>
+        <item name="chipCheckedOnBackgroundColor">@color/gray_70</item>
         <item name="chipCheckedOffBackgroundColor">@color/gray_50</item>
         <item name="chipTextColor">@color/text_chip_dark</item>
         <item name="colorAccent">@color/item_blue_dark</item>


### PR DESCRIPTION
### Fix
Update the tag background color from `gray_50`/`gray_60` to `gray_60`/`gray_70` to close https://github.com/Automattic/simplenote-android/issues/828.  These changes differ from the issue.  Rather than updating the tag background color to `gray_70`/`gray_80`, they were updated to `gray_60`/`gray_70` in order to maintain proper contrast with the tag text and note background.  See the screenshots below for illustration.

![828_update_note_tags](https://user-images.githubusercontent.com/3827611/66317022-fd7cbf80-e8d5-11e9-8691-18286ceaf089.png)

### Test
0. Set theme to ***Dark***.
1. Tap any note in list with tag(s).
2. Notice tag background is `gray_60` (`#50575e`) for untapped tag.
3. Tap any tag.
4. Notice tag background is `gray_70` (`#3c434a`) for tapped tag.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.