### PR TITLE
Update Color Shades

### DIFF
--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -13,7 +13,7 @@
 
     <!-- ELEVATION -->
     <color name="background_dark_0">#141617</color>
-    <color name="background_dark_1">#1f2021</color>
+    <color name="background_dark_1">#202324</color>
     <color name="background_dark_2">#232526</color>
     <color name="background_dark_3">#252829</color>
     <color name="background_dark_4">#282b2b</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -31,7 +31,7 @@
     <!-- SEMANTIC -->
     <color name="background_dark">@color/background_dark_0</color>
     <color name="background_dark_highlight">@color/gray_70</color>
-    <color name="background_dark_highlight_drawer">@color/gray_60</color>
+    <color name="background_dark_highlight_drawer">#4d5152</color>
     <color name="background_light">@android:color/white</color>
     <color name="background_light_highlight">@color/blue_5</color>
     <color name="divider_dark">@color/gray_60</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -16,7 +16,7 @@
     <color name="background_dark_1">#202324</color>
     <color name="background_dark_2">#242626</color>
     <color name="background_dark_3">#262829</color>
-    <color name="background_dark_4">#282b2b</color>
+    <color name="background_dark_4">#282a2b</color>
     <color name="background_dark_6">#2d2f30</color>
     <color name="background_dark_8">#2f3233</color>
     <color name="background_dark_12">#333738</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -20,7 +20,7 @@
     <color name="background_dark_6">#2d3030</color>
     <color name="background_dark_8">#2f3233</color>
     <color name="background_dark_12">#333638</color>
-    <color name="background_dark_16">#323638</color>
+    <color name="background_dark_16">#35393b</color>
     <color name="background_dark_24">#363a3c</color>
 
     <!-- PASSCODE -->

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -15,7 +15,7 @@
     <color name="background_dark_0">#141617</color>
     <color name="background_dark_1">#202324</color>
     <color name="background_dark_2">#242626</color>
-    <color name="background_dark_3">#252829</color>
+    <color name="background_dark_3">#262829</color>
     <color name="background_dark_4">#282b2b</color>
     <color name="background_dark_6">#2d2f30</color>
     <color name="background_dark_8">#2f3233</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -19,7 +19,7 @@
     <color name="background_dark_4">#282a2b</color>
     <color name="background_dark_6">#2d3030</color>
     <color name="background_dark_8">#2f3233</color>
-    <color name="background_dark_12">#333738</color>
+    <color name="background_dark_12">#333638</color>
     <color name="background_dark_16">#323638</color>
     <color name="background_dark_24">#363a3c</color>
 

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -21,7 +21,7 @@
     <color name="background_dark_8">#2f3233</color>
     <color name="background_dark_12">#333638</color>
     <color name="background_dark_16">#35393b</color>
-    <color name="background_dark_24">#363a3c</color>
+    <color name="background_dark_24">#363b3c</color>
 
     <!-- PASSCODE -->
     <color name="passcodelock_background">@color/blue</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -17,7 +17,7 @@
     <color name="background_dark_2">#242626</color>
     <color name="background_dark_3">#262829</color>
     <color name="background_dark_4">#282a2b</color>
-    <color name="background_dark_6">#2d2f30</color>
+    <color name="background_dark_6">#2d3030</color>
     <color name="background_dark_8">#2f3233</color>
     <color name="background_dark_12">#333738</color>
     <color name="background_dark_16">#323638</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -30,7 +30,7 @@
 
     <!-- SEMANTIC -->
     <color name="background_dark">@color/background_dark_0</color>
-    <color name="background_dark_highlight">@color/gray_70</color>
+    <color name="background_dark_highlight">@color/background_dark_8</color>
     <color name="background_dark_highlight_drawer">#4d5152</color>
     <color name="background_light">@android:color/white</color>
     <color name="background_light_highlight">@color/blue_5</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -14,7 +14,7 @@
     <!-- ELEVATION -->
     <color name="background_dark_0">#141617</color>
     <color name="background_dark_1">#202324</color>
-    <color name="background_dark_2">#232526</color>
+    <color name="background_dark_2">#242626</color>
     <color name="background_dark_3">#252829</color>
     <color name="background_dark_4">#282b2b</color>
     <color name="background_dark_6">#2d2f30</color>


### PR DESCRIPTION
### Fix
Update the color shades for `background_dark_` resources as well as the navigation and note list selected background color.  See the screenshots below for illustration.

![update_color_shades](https://user-images.githubusercontent.com/3827611/66319623-ae855900-e8da-11e9-8f24-c126e77492ef.png)

### Test
0. Set theme to ***Dark***.
1. Long-press any note in list.
2. Notice selected background color as shown above.
3. Tap back arrow in app bar.
4. Open navigation drawer.
5. Notice select background color as shown above.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.