### PR TITLE
Update Markdown Action

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -800,7 +800,7 @@ public class NotesActivity extends AppCompatActivity implements
                 }
 
                 mCurrentNote.save();
-                DrawableUtils.tintMenuItemWithAttribute(this, item, R.attr.actionBarTextColor);
+                DrawableUtils.tintMenuItemWithAttribute(this, item, R.attr.toolbarIconColor);
 
                 return true;
             case R.id.menu_delete:
@@ -856,7 +856,7 @@ public class NotesActivity extends AppCompatActivity implements
             markdownItem.setTitle(getString(R.string.markdown_show));
         }
 
-        DrawableUtils.tintMenuItemWithAttribute(this, markdownItem, R.attr.actionBarTextColor);
+        DrawableUtils.tintMenuItemWithAttribute(this, markdownItem, R.attr.toolbarIconColor);
 
         return super.onPrepareOptionsMenu(menu);
     }


### PR DESCRIPTION
### Fix
Update the markdown action icon color tint from `actionBarTextColor` to `toolbarIconColor` in order to match other action icons in the app bar.  See the screenshots below for illustration.

Before|After
-|-
![update_markdown_action_before_light_01](https://user-images.githubusercontent.com/3827611/66332463-0c716b00-e8f2-11e9-866f-2653fc831e32.png)|![update_markdown_action_after_light_01](https://user-images.githubusercontent.com/3827611/66332468-11ceb580-e8f2-11e9-87f1-f4cb227e845f.png)
![update_markdown_action_before_light_02](https://user-images.githubusercontent.com/3827611/66332475-15fad300-e8f2-11e9-9ae1-b00f76dff4f3.png)|![update_markdown_action_after_light_02](https://user-images.githubusercontent.com/3827611/66332488-1d21e100-e8f2-11e9-9459-bf9a6ea391ba.png)

Before|After
-|-
![update_markdown_action_before_dark_01](https://user-images.githubusercontent.com/3827611/66332518-2f9c1a80-e8f2-11e9-9846-51b6c4b25f7b.png)|![update_markdown_action_after_dark_01](https://user-images.githubusercontent.com/3827611/66332529-3460ce80-e8f2-11e9-8322-61fe85d3624f.png)
![update_markdown_action_before_dark_02](https://user-images.githubusercontent.com/3827611/66332536-388cec00-e8f2-11e9-935d-9885394bcde9.png)|![update_markdown_action_after_dark_02](https://user-images.githubusercontent.com/3827611/66332553-3f1b6380-e8f2-11e9-8da8-f9cee1fb78e9.png)

### Test
Both the ***Show Markdown*** and ***Hide Markdown*** actions are only visible with the two-pane layout on large screen devices (e.g. tablet).  When performing the test steps below, be sure to use a large screen device.
1. Tap any note in list with markdown enabled.
2. Notice ***Show Markdown*** action icon tint matches other action icons.
3. Tap ***Show Markdown*** action.
4. Notice ***Hide Markdown*** action icon tint matches other action icons.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.