### PR TITLE
Update Visibility Icon

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -800,7 +800,7 @@ public class NotesActivity extends AppCompatActivity implements
                 }
 
                 mCurrentNote.save();
-                DrawableUtils.tintMenuItemWithAttribute(this, item, R.attr.actionBarTextColor);
+                DrawableUtils.tintMenuItemWithAttribute(this, item, R.attr.toolbarIconColor);
 
                 return true;
             case R.id.menu_delete:
@@ -856,7 +856,7 @@ public class NotesActivity extends AppCompatActivity implements
             markdownItem.setTitle(getString(R.string.markdown_show));
         }
 
-        DrawableUtils.tintMenuItemWithAttribute(this, markdownItem, R.attr.actionBarTextColor);
+        DrawableUtils.tintMenuItemWithAttribute(this, markdownItem, R.attr.toolbarIconColor);
 
         return super.onPrepareOptionsMenu(menu);
     }


### PR DESCRIPTION
### Fix
Update the markdown action icon color tint from `actionBarTextColor` to `toolbarIconColor` in order to match other action icons in the app bar.  This pull request is to cherry-pick the e3e266d8582ca13c52aad5361e6d5de897802df9 commit from https://github.com/Automattic/simplenote-android/pull/834.

### Test
There are no added test steps for this pull request.  The changes were tested and verified in https://github.com/Automattic/simplenote-android/pull/834.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.