### PR TITLE
Issue/837 crash delete tag

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
@@ -229,9 +229,11 @@ public class TagsListFragment extends Fragment implements ActionMode.Callback, B
                 deleteButton.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
-                        if (!isAdded()) return;
+                        if (!isAdded() || !hasItem(getAdapterPosition())) {
+                            return;
+                        }
 
-                        final Tag tag = ((Bucket.ObjectCursor<Tag>)getItem(getAdapterPosition())).getObject();
+                        final Tag tag = ((Bucket.ObjectCursor<Tag>) getItem(getAdapterPosition())).getObject();
                         final int tagCount = mNotesBucket.query().where("tags", Query.ComparisonType.EQUAL_TO, tag.getName()).count();
                         if (tagCount == 0) {
                             deleteTag(tag);

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
@@ -272,12 +272,14 @@ public class TagsListFragment extends Fragment implements ActionMode.Callback, B
 
             @Override
             public void onClick(View view) {
-                if (!isAdded()) return;
+                if (!isAdded() || !hasItem(getAdapterPosition())) {
+                    return;
+                }
 
                 final AlertDialog.Builder alert = new AlertDialog.Builder(new ContextThemeWrapper(getContext(), R.style.Dialog));
                 LinearLayout alertView = (LinearLayout) getActivity().getLayoutInflater().inflate(R.layout.edit_tag, null);
 
-                final Tag tag = ((Bucket.ObjectCursor<Tag>)getItem(getAdapterPosition())).getObject();
+                final Tag tag = ((Bucket.ObjectCursor<Tag>) getItem(getAdapterPosition())).getObject();
 
                 final EditText tagNameEditText = alertView.findViewById(R.id.tag_name_edit);
                 tagNameEditText.setText(tag.getName());

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/BaseCursorAdapter.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/BaseCursorAdapter.java
@@ -61,6 +61,10 @@ public abstract class BaseCursorAdapter<V extends RecyclerView.ViewHolder> exten
         return mCursor;
     }
 
+    public boolean hasItem(int position) {
+        return mDataValid && mCursor.moveToPosition(position);
+    }
+
     public void swapCursor(Cursor newCursor) {
         if (newCursor == mCursor) {
             return;


### PR DESCRIPTION
### Fix
Add a check to ensure the tags list has the item to delete when the ***Delete tag*** button is tapped before attempting to delete the tag to close https://github.com/Automattic/simplenote-android/issues/837.

### Test
1. Tap any note in list.
2. Add new tag to ***Add tag...*** field.
3. Remove new tag from Step 2.
4. Tap back arrow in app bar.
5. Open navigation drawer.
6. Tap ***Edit*** button in ***Tags*** section.
7. Double-tap ***Delete tag*** button for tag from Step 2.
8. Notice app does not crash.
9. Notice tag from Step 2 is removed.

### Review
Only one developer is required to review these changes, but anyone can perform the review. 
 @rachelmcr, I also requested you as a reviewer since you caught the associated bugs and to ensure they are fixed.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.