### PR TITLE
Update Gradle Dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   Test:
     executor: 
       name: android/default
-      api-version: "28"
+      api-version: "29"
     steps:
       - checkout
       - android/restore-gradle-cache
@@ -22,7 +22,7 @@ jobs:
   Lint:
     executor: 
       name: android/default
-      api-version: "28"
+      api-version: "29"
     steps:
       - checkout
       - android/restore-gradle-cache
@@ -34,7 +34,7 @@ jobs:
   Installable Build:
     executor:
       name: android/default
-      api-version: "28"
+      api-version: "29"
     steps:
       - checkout
       - bundle-install/bundle-install

--- a/.gitignore
+++ b/.gitignore
@@ -40,9 +40,6 @@ Simplenote/gradle.properties
 # When developing against Simperium-android source directly
 Simperium
 
-# Crashlytics API Key
-Simplenote/crashlytics.properties
-
 # Fastlane
 fastlane/README.md
 fastlane/report.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     - platform-tools
     - tools
     - build-tools-28.0.3
-    - android-28
+    - android-29
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-28.0.3
+    - build-tools-29.0.2
     - android-29
 
 env:

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -74,7 +74,7 @@ dependencies {
 
     // Google Support
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0-alpha07'
+    implementation 'com.google.android.material:material:1.1.0-beta01'
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation 'androidx.preference:preference:1.1.0'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     implementation 'org.wordpress:passcodelock:1.7.0'
 
     // Google Support
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.1.0-alpha07'
     implementation 'androidx.vectordrawable:vectordrawable:1.0.1'
     implementation 'androidx.preference:preference:1.0.0'

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'io.sentry.android.gradle'
 
 android {
     buildToolsVersion '28.0.3'
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     buildTypes {
         debug {
@@ -27,7 +27,7 @@ android {
         }
         versionCode 83
         minSdkVersion 23
-        targetSdkVersion 28
+        targetSdkVersion 29
 
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     // Google Play Services
     implementation 'com.google.android.gms:play-services-wearable:17.0.0'
     // Third Party
-    implementation 'com.squareup.okhttp3:okhttp:3.11.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.0'
     implementation 'com.commonsware.cwac:anddown:0.4.0'
     implementation 'net.openid:appauth:0.7.0'
     wearApp project(':Wear')

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     // Google Support
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.1.0-alpha07'
-    implementation 'androidx.vectordrawable:vectordrawable:1.0.1'
+    implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation 'androidx.preference:preference:1.1.0'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
     // Google Play Services

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'io.sentry.android.gradle'
 
 android {
-    buildToolsVersion '28.0.3'
+    buildToolsVersion '29.0.2'
     compileSdkVersion 29
 
     buildTypes {

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.1.0-alpha07'
     implementation 'androidx.vectordrawable:vectordrawable:1.0.1'
-    implementation 'androidx.preference:preference:1.0.0'
+    implementation 'androidx.preference:preference:1.1.0'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
     // Google Play Services
     implementation 'com.google.android.gms:play-services-wearable:17.0.0'

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -84,9 +84,6 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation 'com.commonsware.cwac:anddown:0.4.0'
     implementation 'net.openid:appauth:0.7.0'
-    implementation('com.crashlytics.sdk.android:crashlytics:2.9.5@aar') {
-        transitive = true
-    }
     wearApp project(':Wear')
 }
 

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -87,7 +87,6 @@ dependencies {
     implementation('com.crashlytics.sdk.android:crashlytics:2.9.5@aar') {
         transitive = true
     }
-    implementation 'androidx.browser:browser:1.0.0'
     wearApp project(':Wear')
 }
 

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -113,29 +113,14 @@ if(["storeFile", "storePassword", "keyAlias", "keyPassword"].count { !project.ha
     android.buildTypes.release.signingConfig = android.signingConfigs.release
 }
 
-task generateCrashlyticsConfig(group: "generate", description: "Generate Crashlytics config") {
-    def outputFile = new File("${rootDir}/Simplenote/crashlytics.properties")
-    def inputFile = file("${rootDir}/Simplenote/gradle.properties")
-    if (!inputFile.exists()) {
+task copyGradlePropertiesIfMissing(group: "generate", description: "Copy Gradle Properties") {
+    if (!file("${rootDir}/Simplenote/gradle.properties").exists()) {
         copy {
             from("${rootDir}/Simplenote")
             into("${rootDir}/Simplenote")
             include('gradle.properties-example')
             rename('gradle.properties-example', 'gradle.properties')
         }
-    }
-    outputs.file outputFile
-    inputs.file inputFile
-    doLast {
-        def properties = new Properties()
-        inputFile.withInputStream { stream ->
-            properties.load(stream)
-        }
-        def crashlyticsApiKey = properties.getProperty('crashlyticsApiKey', '0')
-        def writer = new FileWriter(outputFile)
-        writer.write("""// auto-generated file from ${rootDir}/gradle.properties do not modify
-apiKey=${crashlyticsApiKey}""")
-        writer.close()
     }
 }
 
@@ -153,7 +138,7 @@ static String toSnakeCase( String text ) {
 
 android.applicationVariants.all { variant ->
     variant.generateBuildConfigProvider.configure {
-        dependsOn(generateCrashlyticsConfig)
+        dependsOn(copyGradlePropertiesIfMissing)
     }
     def inputFile = file("${rootDir}/Simplenote/gradle.properties")
     def properties = loadPropertiesFromFile(inputFile)

--- a/Wear/build.gradle
+++ b/Wear/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-    buildToolsVersion "28.0.3"
+    buildToolsVersion '29.0.2'
     compileSdkVersion 29
 
     buildTypes {

--- a/Wear/build.gradle
+++ b/Wear/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'com.android.application'
 
 android {
     buildToolsVersion "28.0.3"
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     buildTypes {
         release {
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         applicationId "com.automattic.simplenote"
         minSdkVersion 23
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 2
         versionName "1.1.0"
     }


### PR DESCRIPTION
### Fix
Update versions of libraries used and remove unused dependencies.  The compile and target SDK versions were updated from 28 to 29.  The `bulid.gradle` method used to generate a `crashlytics.properties` file was updated to copy the `gradle.properties` file only since Crashlytics is no longer used in the app.

### Test
The changes affect numerous areas of the app including interface components and network calls.  The interface can be verified by smoke testing the app screens.  The network can be verified by using the ***WordPress Post*** feature.

#### Interface
1. Notice note list is unchanged.
2. Open navigation drawer.
3. Notice navigation drawer is unchanged.
4. Tap ***Settings*** in navigation drawer.
5. Notice ***Settings*** is unchanged.
6. Tap back arrow in app bar.
7. Tap any note in list.
8. Notice note editor is unchanged.
9. Tap ***Info*** action in app bar.
10. Notice ***Info*** sheet is unchanged.

#### Network
1. Tap any note in list.
2. Tap ***Share*** action in app bar.
3. Tap ***WordPress Post*** button in bottom sheet.
4. Tap ***Connect*** button in dialog.
5. Tap ***Approve*** button in browser.
6. Notice list of sites in dialog.
7. Tap ***Post*** button in dialog.
8. Notice note is posted to selected site.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.