### PR TITLE
Remove Escape String

### DIFF
--- a/Simplenote/src/main/res/values-de/strings.xml
+++ b/Simplenote/src/main/res/values-de/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: de
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">Die einfachste Art, sich Notizen zu machen.</string>
     <string name="simperium_hint_password">Passwort</string>
     <string name="simperium_hint_email">E-Mail</string>

--- a/Simplenote/src/main/res/values-es/strings.xml
+++ b/Simplenote/src/main/res/values-es/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: es
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">Lo más fácil para tener notas.</string>
     <string name="simperium_hint_password">Contraseña</string>
     <string name="simperium_hint_email">Correo electrónico</string>

--- a/Simplenote/src/main/res/values-fr/strings.xml
+++ b/Simplenote/src/main/res/values-fr/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: fr
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">La manière la plus simple de conserver des notes.</string>
     <string name="simperium_hint_password">Mot de passe</string>
     <string name="simperium_hint_email">E-mail</string>

--- a/Simplenote/src/main/res/values-he/strings.xml
+++ b/Simplenote/src/main/res/values-he/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: he_IL
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">הדרך הפשוטה ביותר לרשום פתקים.</string>
     <string name="simperium_hint_password">סיסמה</string>
     <string name="simperium_hint_email">אימייל</string>

--- a/Simplenote/src/main/res/values-id/strings.xml
+++ b/Simplenote/src/main/res/values-id/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: id
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">Cara paling mudah menyimpan catatan.</string>
     <string name="simperium_hint_password">Kata Sandi</string>
     <string name="simperium_hint_email">Email</string>

--- a/Simplenote/src/main/res/values-it/strings.xml
+++ b/Simplenote/src/main/res/values-it/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: it
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">Prendere nota ora è semplice.</string>
     <string name="simperium_hint_password">Password</string>
     <string name="simperium_hint_email">E-mail</string>

--- a/Simplenote/src/main/res/values-ja/strings.xml
+++ b/Simplenote/src/main/res/values-ja/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: ja_JP
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">最も手軽にメモを残せる方法です。</string>
     <string name="simperium_hint_password">パスワード</string>
     <string name="simperium_hint_email">メール</string>

--- a/Simplenote/src/main/res/values-ko/strings.xml
+++ b/Simplenote/src/main/res/values-ko/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: ko_KR
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">메모를 보관하는 가장 간단한 방법입니다.</string>
     <string name="simperium_hint_password">비밀번호</string>
     <string name="simperium_hint_email">이메일</string>

--- a/Simplenote/src/main/res/values-nl/strings.xml
+++ b/Simplenote/src/main/res/values-nl/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: nl
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">De eenvoudigste manier om notities bij te houden.</string>
     <string name="simperium_hint_password">Wachtwoord</string>
     <string name="simperium_hint_email">E-mail</string>

--- a/Simplenote/src/main/res/values-pt-rBR/strings.xml
+++ b/Simplenote/src/main/res/values-pt-rBR/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: pt_BR
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">A melhor forma de manter notas.</string>
     <string name="simperium_hint_password">Senha</string>
     <string name="simperium_hint_email">E-mail</string>

--- a/Simplenote/src/main/res/values-ru/strings.xml
+++ b/Simplenote/src/main/res/values-ru/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: ru
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">Простой способ хранить заметки.</string>
     <string name="simperium_hint_password">Пароль</string>
     <string name="simperium_hint_email">Электронная почта</string>

--- a/Simplenote/src/main/res/values-sv/strings.xml
+++ b/Simplenote/src/main/res/values-sv/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: sv_SE
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">Det enklaste sättet att anteckna på.</string>
     <string name="simperium_hint_password">Lösenord</string>
     <string name="simperium_hint_email">E-post</string>

--- a/Simplenote/src/main/res/values-tr/strings.xml
+++ b/Simplenote/src/main/res/values-tr/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: tr
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">Not tutmanın en basit yolu.</string>
     <string name="simperium_hint_password">Parola</string>
     <string name="simperium_hint_email">E-posta</string>

--- a/Simplenote/src/main/res/values-zh-rCN/strings.xml
+++ b/Simplenote/src/main/res/values-zh-rCN/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: zh_CN
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">记录笔记最简单的方法。</string>
     <string name="simperium_hint_password">密码</string>
     <string name="simperium_hint_email">电子邮件</string>

--- a/Simplenote/src/main/res/values-zh-rTW/strings.xml
+++ b/Simplenote/src/main/res/values-zh-rTW/strings.xml
@@ -6,7 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: zh_TW
 -->
 <resources>
-    <string name="simperium_title">\@string/app_name</string>
+    <string name="simperium_title">@string/app_name</string>
     <string name="simperium_subtitle">輕鬆作筆記的最佳方式。</string>
     <string name="simperium_hint_password">密碼</string>
     <string name="simperium_hint_email">電子郵件</string>


### PR DESCRIPTION
### Fix
Remove the escape character, `\`, from the `simperium_title` string resource reference so that the `app_name` value is used in the login/signup screen rather than the `@string/app_name` text.  See the screenshots below for illustration.

![remove_escape_string](https://user-images.githubusercontent.com/3827611/67017131-8655e100-f0b6-11e9-8aaf-d34ac2d132d8.png)

### Test
1. Set device language to non-English language (e.g. Deutsch).
2. Clear app data.
3. Launch app.
4. Notice login/signup title is ***Simplenote***.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.