### PR TITLE
Issue/840 update search view

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1,6 +1,5 @@
 package com.automattic.simplenote;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -644,7 +643,7 @@ public class NotesActivity extends AppCompatActivity implements
             mSearchMenuItem.expandActionView();
         } else {
             // Workaround for setting the search placeholder text color
-            @SuppressLint("ResourceType")
+            @SuppressWarnings("ResourceType")
             String hintHexColor = getString(R.color.text_title_disabled).replace("ff", "");
             mSearchView.setQueryHint(HtmlCompat.fromHtml(String.format("<font color=\"%s\">%s</font>",
                     hintHexColor,

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -625,7 +625,6 @@ public class NotesActivity extends AppCompatActivity implements
         return mNoteListFragment;
     }
 
-    @SuppressWarnings("ResourceType")
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         super.onCreateOptionsMenu(menu);
@@ -645,6 +644,7 @@ public class NotesActivity extends AppCompatActivity implements
             mSearchMenuItem.expandActionView();
         } else {
             // Workaround for setting the search placeholder text color
+            @SuppressLint("ResourceType")
             String hintHexColor = getString(R.color.text_title_disabled).replace("ff", "");
             mSearchView.setQueryHint(HtmlCompat.fromHtml(String.format("<font color=\"%s\">%s</font>",
                     hintHexColor,

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1,5 +1,6 @@
 package com.automattic.simplenote;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -626,7 +627,7 @@ public class NotesActivity extends AppCompatActivity implements
 
     @SuppressWarnings("ResourceType")
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(final Menu menu) {
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.notes_list, menu);
@@ -670,10 +671,16 @@ public class NotesActivity extends AppCompatActivity implements
         mSearchMenuItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
             public boolean onMenuItemActionExpand(MenuItem menuItem) {
+                if (DisplayUtils.isLargeScreenLandscape(NotesActivity.this)) {
+                    updateActionsForLargeLandscape(menu);
+                }
+
                 checkEmptyListText(true);
+
                 if (mNoteListFragment != null) {
                     mNoteListFragment.setFloatingActionButtonVisible(false);
                 }
+
                 AnalyticsTracker.track(
                         AnalyticsTracker.Stat.LIST_NOTES_SEARCHED,
                         AnalyticsTracker.CATEGORY_NOTE,
@@ -684,10 +691,15 @@ public class NotesActivity extends AppCompatActivity implements
 
             @Override
             public boolean onMenuItemActionCollapse(MenuItem menuItem) {
+                if (DisplayUtils.isLargeScreenLandscape(NotesActivity.this)) {
+                    updateActionsForLargeLandscape(menu);
+                }
+
                 // Show all notes again
                 if (mNoteListFragment != null) {
                     mNoteListFragment.setFloatingActionButtonVisible(true);
                 }
+
                 mTabletSearchQuery = "";
                 mSearchView.setQuery("", false);
                 checkEmptyListText(false);
@@ -714,7 +726,7 @@ public class NotesActivity extends AppCompatActivity implements
             trashItem.setIcon(R.drawable.ic_trash_24dp);
         }
 
-        if (DisplayUtils.isLargeScreenLandscape(this)) {
+        if (DisplayUtils.isLargeScreenLandscape(NotesActivity.this)) {
             // Restore the search query on landscape tablets
             if (!TextUtils.isEmpty(mTabletSearchQuery)) {
                 mSearchMenuItem.expandActionView();
@@ -722,24 +734,7 @@ public class NotesActivity extends AppCompatActivity implements
                 mSearchView.clearFocus();
             }
 
-            if (mCurrentNote != null) {
-                menu.findItem(R.id.menu_share).setVisible(true);
-                menu.findItem(R.id.menu_view_info).setVisible(true);
-                menu.findItem(R.id.menu_checklist).setVisible(true);
-                menu.findItem(R.id.menu_history).setVisible(true);
-                menu.findItem(R.id.menu_markdown_preview).setVisible(mCurrentNote.isMarkdownEnabled());
-                menu.findItem(R.id.menu_sidebar).setVisible(true);
-                trashItem.setVisible(true);
-            } else {
-                menu.findItem(R.id.menu_share).setVisible(false);
-                menu.findItem(R.id.menu_view_info).setVisible(false);
-                menu.findItem(R.id.menu_checklist).setVisible(false);
-                menu.findItem(R.id.menu_history).setVisible(false);
-                menu.findItem(R.id.menu_markdown_preview).setVisible(false);
-                menu.findItem(R.id.menu_sidebar).setVisible(false);
-                trashItem.setVisible(false);
-            }
-            menu.findItem(R.id.menu_empty_trash).setVisible(false);
+            updateActionsForLargeLandscape(menu);
         } else {
             menu.findItem(R.id.menu_search).setVisible(true);
             menu.findItem(R.id.menu_share).setVisible(false);
@@ -858,6 +853,28 @@ public class NotesActivity extends AppCompatActivity implements
         DrawableUtils.tintMenuItemWithAttribute(this, markdownItem, R.attr.toolbarIconColor);
 
         return super.onPrepareOptionsMenu(menu);
+    }
+
+    private void updateActionsForLargeLandscape(Menu menu) {
+        if (mCurrentNote != null) {
+            menu.findItem(R.id.menu_checklist).setVisible(true);
+            menu.findItem(R.id.menu_delete).setVisible(true);
+            menu.findItem(R.id.menu_history).setVisible(true);
+            menu.findItem(R.id.menu_markdown_preview).setVisible(mCurrentNote.isMarkdownEnabled());
+            menu.findItem(R.id.menu_share).setVisible(true);
+            menu.findItem(R.id.menu_sidebar).setVisible(true);
+            menu.findItem(R.id.menu_view_info).setVisible(true);
+        } else {
+            menu.findItem(R.id.menu_checklist).setVisible(false);
+            menu.findItem(R.id.menu_delete).setVisible(false);
+            menu.findItem(R.id.menu_history).setVisible(false);
+            menu.findItem(R.id.menu_markdown_preview).setVisible(false);
+            menu.findItem(R.id.menu_share).setVisible(false);
+            menu.findItem(R.id.menu_sidebar).setVisible(false);
+            menu.findItem(R.id.menu_view_info).setVisible(false);
+        }
+
+        menu.findItem(R.id.menu_empty_trash).setVisible(false);
     }
 
     public void updateViewsAfterTrashAction(Note note) {

--- a/Simplenote/src/main/res/layout/activity_note_editor.xml
+++ b/Simplenote/src/main/res/layout/activity_note_editor.xml
@@ -20,7 +20,7 @@
             app:contentInsetStart="@dimen/toolbar_title_keyline"
             app:layout_scrollFlags="scroll|enterAlways"
             app:popupTheme="?attr/toolbarPopupTheme"
-            app:theme="@style/ToolbarTheme">
+            style="@style/ToolbarTheme">
         </androidx.appcompat.widget.Toolbar>
 
         <com.google.android.material.tabs.TabLayout

--- a/Simplenote/src/main/res/layout/toolbar.xml
+++ b/Simplenote/src/main/res/layout/toolbar.xml
@@ -1,11 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+
+<com.google.android.material.appbar.AppBarLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/toolbar"
-    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/toolbarColor"
-    android:elevation="3dp"
-    app:contentInsetStart="@dimen/toolbar_title_keyline"
-    app:popupTheme="?attr/toolbarPopupTheme"
-    app:theme="@style/ToolbarTheme"/>
+    android:layout_width="match_parent"
+    android:theme="@style/ToolbarTheme.AppBarOverlay">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:background="?attr/toolbarColor"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        app:contentInsetStart="@dimen/toolbar_title_keyline"
+        app:popupTheme="?attr/toolbarPopupTheme"
+        app:theme="@style/Widget.AppCompat.SearchView.ActionBar"
+        style="@style/ToolbarTheme">
+    </androidx.appcompat.widget.Toolbar>
+
+</com.google.android.material.appbar.AppBarLayout>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -87,9 +87,4 @@
         <item name="android:textColor">@android:color/white</item>
     </style>
 
-    <style name="ToolbarTheme" parent="@style/ThemeOverlay.MaterialComponents">
-        <item name="android:textColorPrimary">?attr/actionBarTextColor</item>
-        <item name="android:textColorSecondary">?attr/toolbarIconColor</item>
-    </style>
-
 </resources>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -121,6 +121,10 @@
         <item name="android:textColorSecondary">?attr/toolbarIconColor</item>
     </style>
 
+    <style name="ToolbarTheme.AppBarOverlay" parent="ThemeOverlay.MaterialComponents.ActionBar">
+        <item name="colorControlNormal">?attr/toolbarIconColor</item>
+    </style>
+
     <style name="Simplestyle.IndeterminateProgress" parent="@android:style/Widget.Material.Light.ProgressBar">
         <item name="android:minWidth">24dp</item>
         <item name="android:maxWidth">24dp</item>


### PR DESCRIPTION
### Fix
Update the style of the `SearchView` component to follow Material guidelines by removing the magnifying glass icon and input field underline to close #840.  See the screenshots below for illustration.

![840_update_search_view](https://user-images.githubusercontent.com/3827611/67236103-d4941880-f405-11e9-9337-c1a57156ff51.png)

### Test
1. Tap ***Search*** action in top app bar.
2. Notice search view is expanded.
3. Notice magnifying glass icon and input field underline are not shown.
4. Enter query to search.
5. Notice notes list is updated based on query from Step 3.
6. Tap ***X*** in top app bar.
7. Notice query is cleared.
8. Tap back arrow in top app bar.
9. Notice search view is collapsed.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.