### PR TITLE
Issue/862 navigation unlocked search

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -295,7 +295,9 @@ public class NotesActivity extends AppCompatActivity implements
 
     @Override
     public void onActionModeDestroyed() {
-        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
+        if (mSearchMenuItem != null && !mSearchMenuItem.isActionViewExpanded()) {
+            mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
+        }
     }
 
     private ColorStateList getIconSelector() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -670,6 +670,8 @@ public class NotesActivity extends AppCompatActivity implements
         mSearchMenuItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
             public boolean onMenuItemActionExpand(MenuItem menuItem) {
+                mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
+
                 if (DisplayUtils.isLargeScreenLandscape(NotesActivity.this)) {
                     updateActionsForLargeLandscape(menu);
                 }
@@ -690,6 +692,8 @@ public class NotesActivity extends AppCompatActivity implements
 
             @Override
             public boolean onMenuItemActionCollapse(MenuItem menuItem) {
+                mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
+
                 if (DisplayUtils.isLargeScreenLandscape(NotesActivity.this)) {
                     updateActionsForLargeLandscape(menu);
                 }


### PR DESCRIPTION
### Fix
Update the navigation drawer to be locked and unlocked when search is shown and hidden, respectively, to close #862.

### Test
1. Swipe from left/start of list.
2. Notice navigation drawer is shown.
3. Swipe from right/end of navigation drawer.
4. Notice navigation drawer is hidden.
5. Tap ***Search*** action in top app bar.
6. Notice search is shown.
7. Swipe from left/start of list.
8. Notice navigation drawer is not shown.
9. Tap back arrow in top app bar.
10. Notice search is hidden.
11. Swipe from left/start of list.
12. Notice navigation drawer is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.