### PR TITLE
Issue/843 add autocomplete suggestions

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -673,7 +673,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mSelectedNoteId = selectedNoteID;
     }
 
-    public void searchNotes(String searchString) {
+    public void searchNotes(String searchString, boolean isSubmit) {
         mIsSearching = true;
         mSortLayoutContent.setVisibility(View.VISIBLE);
         // Start search with Relevance sort order selected.

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -743,9 +743,11 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     private void getTagSuggestions(String query) {
         ArrayList<Suggestion> suggestions = new ArrayList<>();
         suggestions.add(new Suggestion(query, QUERY));
-        Query<Tag> tags = Tag.all(mBucket)
-                .where(NAME_PROPERTY, Query.ComparisonType.LIKE, "%" + query + "%")
-                .reorder().order(Tag.NOTE_COUNT_INDEX_NAME, Query.SortType.DESCENDING);
+        Query<Tag> tags = Tag.all(mBucket).reorder().order(Tag.NOTE_COUNT_INDEX_NAME, Query.SortType.DESCENDING);
+
+        if (!query.endsWith(TAG_PREFIX)) {
+            tags.where(NAME_PROPERTY, Query.ComparisonType.LIKE, "%" + query + "%");
+        }
 
         try (ObjectCursor<Tag> cursor = tags.execute()) {
             while (cursor.moveToNext()) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -972,6 +972,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             holder.mView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
+                    ((NotesActivity) requireActivity()).submitSearch(holder.mSuggestionText.getText().toString());
                 }
             });
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -121,6 +121,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     private boolean mIsSearching;
     private ImageView mSortDirection;
     private RelativeLayout mSortLayoutContent;
+    private RelativeLayout mSuggestionLayout;
     private SharedPreferences mPreferences;
     private String mSelectedNoteId;
     private TextView mSortOrder;
@@ -297,6 +298,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         });
 
         mPreferenceSortOrder = PrefUtils.getIntPref(requireContext(), PrefUtils.PREF_SORT_ORDER);
+        mSuggestionLayout = view.findViewById(R.id.suggestion_layout);
         @SuppressLint("InflateParams")
         LinearLayout sortLayoutContainer = (LinearLayout) getLayoutInflater().inflate(R.layout.search_sort, null, false);
         mSortLayoutContent = sortLayoutContainer.findViewById(R.id.sort_content);
@@ -427,7 +429,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     public void onResume() {
         super.onResume();
         getPrefs();
-
         refreshList();
     }
 
@@ -676,16 +677,20 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     public void searchNotes(String searchString, boolean isSubmit) {
         mIsSearching = true;
         mSortLayoutContent.setVisibility(View.VISIBLE);
+        mSuggestionLayout.setVisibility(View.VISIBLE);
         // Start search with Relevance sort order selected.
         mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
             String.valueOf(mIsSortDown ? DATE_MODIFIED_DESCENDING : DATE_MODIFIED_ASCENDING)
         ).apply();
         mSortOrder.setText(R.string.sort_search_relevance);
-        refreshListForSearch();
 
         if (!searchString.equals(mSearchString)) {
             mSearchString = searchString;
-            refreshList();
+        }
+
+        if (isSubmit) {
+            mSuggestionLayout.setVisibility(View.GONE);
+            refreshListForSearch();
         }
     }
 
@@ -695,6 +700,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     public void clearSearch() {
         mIsSearching = false;
         mSortLayoutContent.setVisibility(View.GONE);
+        mSuggestionLayout.setVisibility(View.GONE);
         // Restore sort order from Settings.
         mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER, String.valueOf(mPreferenceSortOrder)).apply();
         refreshList();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -95,6 +95,7 @@ import static com.automattic.simplenote.utils.PrefUtils.DATE_MODIFIED_DESCENDING
  * interface.
  */
 public class NoteListFragment extends ListFragment implements AdapterView.OnItemLongClickListener, AbsListView.MultiChoiceModeListener {
+    public static final String TAG_PREFIX = "tag:";
 
     /**
      * The preferences key representing the activated item position. Only used on tablets.
@@ -618,7 +619,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     }
 
     private String queryTags(Query<Note> query, String searchString) {
-        Pattern pattern = Pattern.compile("tag:(.*?)( |$)");
+        Pattern pattern = Pattern.compile(TAG_PREFIX + "(.*?)( |$)");
         Matcher matcher = pattern.matcher(searchString);
         while (matcher.find()) {
             query.where(TAGS_PROPERTY, Query.ComparisonType.LIKE, matcher.group(1));
@@ -988,7 +989,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                     holder.mButtonDelete.setVisibility(View.GONE);
                     break;
                 case TAG:
-                    holder.mSuggestionText.setText("tag:" + mSuggestions.get(position).getName());
+                    holder.mSuggestionText.setText(TAG_PREFIX + mSuggestions.get(position).getName());
                     holder.mSuggestionIcon.setImageResource(R.drawable.ic_tag_24dp);
                     holder.mButtonDelete.setVisibility(View.GONE);
                     break;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -743,7 +743,9 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     private void getTagSuggestions(String query) {
         ArrayList<Suggestion> suggestions = new ArrayList<>();
         suggestions.add(new Suggestion(query, QUERY));
-        Query<Tag> tags = Tag.all(mBucket).reorder().orderByKey().where(NAME_PROPERTY, Query.ComparisonType.LIKE, "%" + query + "%");
+        Query<Tag> tags = Tag.all(mBucket)
+                .where(NAME_PROPERTY, Query.ComparisonType.LIKE, "%" + query + "%")
+                .reorder().order(Tag.NOTE_COUNT_INDEX_NAME, Query.SortType.DESCENDING);
 
         try (ObjectCursor<Tag> cursor = tags.execute()) {
             while (cursor.moveToNext()) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -14,6 +14,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.ProgressBar;
 
@@ -639,6 +640,8 @@ public class NotesActivity extends AppCompatActivity implements
 
         mSearchMenuItem = menu.findItem(R.id.menu_search);
         mSearchView = (SearchView) mSearchMenuItem.getActionView();
+        LinearLayout searchEditFrame = mSearchView.findViewById(R.id.search_edit_frame);
+        ((LinearLayout.LayoutParams) searchEditFrame.getLayoutParams()).leftMargin = 0;
 
         if (!TextUtils.isEmpty(searchQuery)) {
             mSearchView.setQuery(searchQuery, false);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -864,6 +864,12 @@ public class NotesActivity extends AppCompatActivity implements
         return super.onPrepareOptionsMenu(menu);
     }
 
+    public void submitSearch(String query) {
+        if (mSearchView != null) {
+            mSearchView.setQuery(query, true);
+        }
+    }
+
     private void updateActionsForLargeLandscape(Menu menu) {
         if (mCurrentNote != null) {
             menu.findItem(R.id.menu_checklist).setVisible(true);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -60,6 +60,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.automattic.simplenote.NoteListFragment.TAG_PREFIX;
 import static com.automattic.simplenote.NoteWidget.KEY_WIDGET_CLICK;
 import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
 import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_SIGN_IN_TAPPED;
@@ -864,9 +865,15 @@ public class NotesActivity extends AppCompatActivity implements
         return super.onPrepareOptionsMenu(menu);
     }
 
-    public void submitSearch(String query) {
+    public void submitSearch(String selection) {
         if (mSearchView != null) {
-            mSearchView.setQuery(query, true);
+            String query = mSearchView.getQuery().toString();
+
+            if (query.endsWith(TAG_PREFIX)) {
+                mSearchView.setQuery(query.substring(0, query.lastIndexOf(TAG_PREFIX)) + selection, true);
+            } else {
+                mSearchView.setQuery(selection, true);
+            }
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -656,24 +656,24 @@ public class NotesActivity extends AppCompatActivity implements
             @Override
             public boolean onQueryTextChange(String newText) {
                 if (mSearchMenuItem.isActionViewExpanded()) {
-                    getNoteListFragment().searchNotes(newText);
+                    getNoteListFragment().searchNotes(newText, false);
                 }
+
                 return true;
             }
 
             @Override
             public boolean onQueryTextSubmit(String queryText) {
-                getNoteListFragment().searchNotes(queryText);
+                getNoteListFragment().searchNotes(queryText, true);
                 return true;
             }
-
         });
 
         mSearchMenuItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
             public boolean onMenuItemActionExpand(MenuItem menuItem) {
                 mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
-                getNoteListFragment().searchNotes("");
+                getNoteListFragment().searchNotes("", false);
 
                 if (DisplayUtils.isLargeScreenLandscape(NotesActivity.this)) {
                     updateActionsForLargeLandscape(menu);

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Suggestion.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Suggestion.java
@@ -1,0 +1,46 @@
+package com.automattic.simplenote.models;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+@SuppressWarnings("unused")
+public class Suggestion {
+    @Retention(SOURCE)
+    @IntDef({
+        Type.HISTORY,
+        Type.QUERY,
+        Type.TAG
+    })
+    public @interface Type {
+        int HISTORY = 0;
+        int QUERY = 1;
+        int TAG = 2;
+    }
+
+    private String mName;
+    private @Type int mType;
+
+    public Suggestion(String name, @Type int type) {
+        mName = name;
+        mType = type;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public @Type int getType() {
+        return mType;
+    }
+
+    public void setName(String name) {
+        mName = name;
+    }
+
+    public void setType(@Type int type) {
+        mType = type;
+    }
+}

--- a/Simplenote/src/main/res/layout/fragment_notes_list.xml
+++ b/Simplenote/src/main/res/layout/fragment_notes_list.xml
@@ -42,6 +42,24 @@
 
     </LinearLayout>
 
+    <RelativeLayout
+        android:id="@+id/suggestion_layout"
+        android:background="?attr/mainBackgroundColor"
+        android:clickable="true"
+        android:focusable="true"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:visibility="gone">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/suggestion_list"
+            android:layout_height="match_parent"
+            android:layout_width="match_parent"
+            tools:listitem="@layout/search_suggestion">
+        </androidx.recyclerview.widget.RecyclerView>
+
+    </RelativeLayout>
+
     <View
         android:id="@+id/divider_line"
         android:background="?attr/dividerColor"

--- a/Simplenote/src/main/res/layout/search_suggestion.xml
+++ b/Simplenote/src/main/res/layout/search_suggestion.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="?android:attr/selectableItemBackground"
+    android:descendantFocusability="blocksDescendants"
+    android:gravity="center_vertical"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:minHeight="@dimen/minimum_target"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/suggestion_icon"
+        android:importantForAccessibility="no"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/padding_suggestion"
+        android:layout_marginStart="@dimen/padding_large"
+        android:layout_width="wrap_content"
+        android:tint="?attr/toolbarIconColor"
+        tools:src="@drawable/ic_history_24dp">
+    </ImageView>
+
+    <com.automattic.simplenote.widgets.RobotoRegularTextView
+        android:id="@+id/suggestion_text"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/padding_small"
+        android:layout_weight="1"
+        android:layout_width="0dp"
+        android:textColor="?attr/noteTitleColor"
+        android:textSize="@dimen/text_suggestion"
+        tools:text="tag:work"
+        style="?android:attr/textAppearanceMedium">
+    </com.automattic.simplenote.widgets.RobotoRegularTextView>
+
+    <ImageButton
+        android:id="@+id/suggestion_delete"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/description_delete_item"
+        android:focusable="false"
+        android:focusableInTouchMode="false"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/padding_extra_small"
+        android:layout_width="wrap_content"
+        android:minHeight="@dimen/minimum_target"
+        android:minWidth="@dimen/minimum_target"
+        android:padding="@dimen/padding_medium"
+        android:src="@drawable/ic_cross_24dp"
+        android:tint="?attr/iconTintColor">
+    </ImageButton>
+
+</LinearLayout>

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -13,6 +13,7 @@
     <dimen name="padding_extra_extra_large">24dp</dimen>
     <dimen name="padding_passcode_fingerprint">30dp</dimen>
     <dimen name="padding_passcode_keypad">30dp</dimen>
+    <dimen name="padding_suggestion">40dp</dimen>
 
     <!-- http://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-keylines-spacing -->
     <dimen name="toolbar_title_keyline">72dp</dimen>
@@ -48,6 +49,7 @@
     <dimen name="text_empty">20sp</dimen>
     <dimen name="text_passcode">18sp</dimen>
     <dimen name="text_tag">14sp</dimen>
+    <dimen name="text_suggestion">16sp</dimen>
     <dimen name="text_widget">12sp</dimen>
 
 </resources>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -200,6 +200,7 @@
     <string name="all_notes">All Notes</string>
     <string name="toggle_checklist">Toggle checklist</string>
 
+    <string name="description_delete_item">Delete item</string>
     <string name="description_down">Down</string>
     <string name="description_sort">Sort</string>
     <string name="description_up">Up</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -34,7 +34,7 @@
     <string name="note_selected">%d note selected</string>
     <string name="notes_selected">%d notes selected</string>
     <string name="note_added">Note added</string>
-    <string name="search">Search notes</string>
+    <string name="search">Search notes or tags</string>
     <string name="notes">Notes</string>
     <string name="trash">Trash</string>
     <string name="untagged_notes">Untagged Notes</string>


### PR DESCRIPTION
### Fix
Add autocomplete suggestion to the search input field to close #843.  See the screenshots and animation below for illustration.

![843_add_autocomplete_suggestions](https://user-images.githubusercontent.com/3827611/67817934-11e74e80-fa75-11e9-8858-ccf1fbd6b5e5.png)

<a href="https://user-images.githubusercontent.com/3827611/67818109-a2be2a00-fa75-11e9-9e4e-40cdc7a0f2c5.gif"><img src="https://user-images.githubusercontent.com/3827611/67818109-a2be2a00-fa75-11e9-9e4e-40cdc7a0f2c5.gif" width="320"></a>

### Test
1. Tap ***Search*** action in top app bar.
2. Notice note list is blank.
3. Enter text into search field.
4. Notice suggestions appear based on entered text.
5. Tap any suggestion.
6. Notice suggestion text is inserted into search field.
7. Notice note list is shown based on inserted text.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.