### PR TITLE
Support the unicode bullet as a list item bullet in unordered lists

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.3
 -----
 * Added search sorting by relevance, date created, date modified, and alphabetically
+* Added support for the unicode bullet • in list items
 
 2.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,6 @@
 2.3
 -----
 * Added search sorting by relevance, date created, date modified, and alphabetically
-* Added support for the unicode bullet • in list items
 
 2.2
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/AutoBullet.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/AutoBullet.java
@@ -10,7 +10,8 @@ import java.util.regex.Pattern;
 
 public class AutoBullet {
 
-    private static final String PATTERN_BULLET = "^([\\s]*)([-*+])[\\s]+(.*)$";
+    // \u2022 is the unicode bullet character
+    private static final String PATTERN_BULLET = "^([\\s]*)([-*+\u2022])[\\s]+(.*)$";
     private static final String STR_LINE_BREAK = System.getProperty("line.separator");
     private static final String STR_SPACE = " ";
 


### PR DESCRIPTION
### Fix

Support the unicode bullet character `•` as a list item bullet because lists copied from HTML or word documents may contain this character.

### Test

1. Open Simplenote
2. Create an unordered list with unicode bullets
```
  • list item a
  • list item b
```
3. Press enter after the first item
4. A new list item should be opened, starting with a unicode bullet •


### Review

Everyone can review this if they want :)

### Release

`RELEASE-NOTES.txt` was updated in 9b9b644 with:
> Added support for the unicode bullet • in list items