### PR TITLE
Update Background Shades

### DIFF
--- a/Simplenote/src/main/assets/dark.css
+++ b/Simplenote/src/main/assets/dark.css
@@ -20,7 +20,7 @@ img {
 html {
     margin: 0;
     padding: 0;
-    background: #141617;
+    background: #1f2123;
     color: #dbdee0;
     text-rendering: optimizeLegibility;
 }

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -20,7 +20,7 @@
     <color name="background_dark_6">#2f3133</color>
     <color name="background_dark_8">#323436</color>
     <color name="background_dark_12">#37393b</color>
-    <color name="background_dark_16">#35393b</color>
+    <color name="background_dark_16">#3a3c3e</color>
     <color name="background_dark_24">#363b3c</color>
 
     <!-- PASSCODE -->

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -15,7 +15,7 @@
     <color name="background_dark_0">#121416</color>
     <color name="background_dark_1">#1f2123</color>
     <color name="background_dark_2">#242628</color>
-    <color name="background_dark_3">#262829</color>
+    <color name="background_dark_3">#27292b</color>
     <color name="background_dark_4">#282a2b</color>
     <color name="background_dark_6">#2d3030</color>
     <color name="background_dark_8">#2f3233</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -17,7 +17,7 @@
     <color name="background_dark_2">#242628</color>
     <color name="background_dark_3">#27292b</color>
     <color name="background_dark_4">#2a2c2e</color>
-    <color name="background_dark_6">#2d3030</color>
+    <color name="background_dark_6">#2f3133</color>
     <color name="background_dark_8">#2f3233</color>
     <color name="background_dark_12">#333638</color>
     <color name="background_dark_16">#35393b</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -12,7 +12,7 @@
     <color name="yellow">@color/yellow_20</color>
 
     <!-- ELEVATION -->
-    <color name="background_dark_0">#141617</color>
+    <color name="background_dark_0">#121416</color>
     <color name="background_dark_1">#202324</color>
     <color name="background_dark_2">#242626</color>
     <color name="background_dark_3">#262829</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -21,7 +21,7 @@
     <color name="background_dark_8">#323436</color>
     <color name="background_dark_12">#37393b</color>
     <color name="background_dark_16">#3a3c3e</color>
-    <color name="background_dark_24">#363b3c</color>
+    <color name="background_dark_24">#3d3f41</color>
 
     <!-- PASSCODE -->
     <color name="passcodelock_background">@color/blue</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -19,7 +19,7 @@
     <color name="background_dark_4">#2a2c2e</color>
     <color name="background_dark_6">#2f3133</color>
     <color name="background_dark_8">#323436</color>
-    <color name="background_dark_12">#333638</color>
+    <color name="background_dark_12">#37393b</color>
     <color name="background_dark_16">#35393b</color>
     <color name="background_dark_24">#363b3c</color>
 

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -14,7 +14,7 @@
     <!-- ELEVATION -->
     <color name="background_dark_0">#121416</color>
     <color name="background_dark_1">#1f2123</color>
-    <color name="background_dark_2">#242626</color>
+    <color name="background_dark_2">#242628</color>
     <color name="background_dark_3">#262829</color>
     <color name="background_dark_4">#282a2b</color>
     <color name="background_dark_6">#2d3030</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -29,7 +29,7 @@
     <color name="passcodelock_prompt_text_color">@android:color/white</color>
 
     <!-- SEMANTIC -->
-    <color name="background_dark">@color/background_dark_0</color>
+    <color name="background_dark">@color/background_dark_1</color>
     <color name="background_dark_highlight">@color/background_dark_8</color>
     <color name="background_dark_highlight_drawer">#4d5152</color>
     <color name="background_light">@android:color/white</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -18,7 +18,7 @@
     <color name="background_dark_3">#27292b</color>
     <color name="background_dark_4">#2a2c2e</color>
     <color name="background_dark_6">#2f3133</color>
-    <color name="background_dark_8">#2f3233</color>
+    <color name="background_dark_8">#323436</color>
     <color name="background_dark_12">#333638</color>
     <color name="background_dark_16">#35393b</color>
     <color name="background_dark_24">#363b3c</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -13,7 +13,7 @@
 
     <!-- ELEVATION -->
     <color name="background_dark_0">#121416</color>
-    <color name="background_dark_1">#202324</color>
+    <color name="background_dark_1">#1f2123</color>
     <color name="background_dark_2">#242626</color>
     <color name="background_dark_3">#262829</color>
     <color name="background_dark_4">#282a2b</color>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -16,7 +16,7 @@
     <color name="background_dark_1">#1f2123</color>
     <color name="background_dark_2">#242628</color>
     <color name="background_dark_3">#27292b</color>
-    <color name="background_dark_4">#282a2b</color>
+    <color name="background_dark_4">#2a2c2e</color>
     <color name="background_dark_6">#2d3030</color>
     <color name="background_dark_8">#2f3233</color>
     <color name="background_dark_12">#333638</color>


### PR DESCRIPTION
### Fix
Update the color shades for `background_dark_` resources as well as the navigation and note list selected background color.  See the screenshots below for illustration.

![update_background_shades](https://user-images.githubusercontent.com/3827611/68427511-81d99100-0167-11ea-884b-665de8d919f4.png)

### Test
0. Set theme to ***Dark***.
1. Long-press any note in list.
2. Notice selected background color as shown above.
3. Tap back arrow in app bar.
4. Open navigation drawer.
5. Notice select background color as shown above.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.