### PR TITLE
Update Preference Manager

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
@@ -3,7 +3,6 @@ package com.automattic.simplenote;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.view.HapticFeedbackConstants;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -18,6 +17,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
+import androidx.preference.PreferenceManager;
 
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.utils.DateTimeUtils;

--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTrackerNosara.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTrackerNosara.java
@@ -2,8 +2,9 @@ package com.automattic.simplenote.analytics;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 import android.text.TextUtils;
+
+import androidx.preference.PreferenceManager;
 
 import com.automattic.android.tracks.TracksClient;
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -7,9 +7,9 @@ package com.automattic.simplenote.utils;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 
 import androidx.annotation.IntDef;
+import androidx.preference.PreferenceManager;
 
 import com.automattic.simplenote.BuildConfig;
 import com.automattic.simplenote.R;

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -7,11 +7,11 @@ import android.content.res.Configuration;
 import android.content.res.TypedArray;
 import android.graphics.Point;
 import android.net.Uri;
-import android.preference.PreferenceManager;
 
 import androidx.annotation.AttrRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.preference.PreferenceManager;
 
 import com.automattic.simplenote.R;
 


### PR DESCRIPTION
### Fix
Update the deprecated `android.preference.PreferenceManager` references to `androidx.preference.PreferenceManager`.

### Test
Since these changes have no user-facing aspect, smoke testing is all that is required.  Opening the ***Info*** bottom sheet (i.e. tap any note then tap the ***Info*** icon in the top app bar) and changing the ***Theme*** option in ***Settings*** will prove the `PreferenceManager` is working.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.