### PR TITLE
Update Search Padding

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -131,6 +131,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     private boolean mIsCondensedNoteList;
     private boolean mIsSearching;
     private ImageView mSortDirection;
+    private ListView mList;
     private RecyclerView mSuggestionList;
     private RelativeLayout mSortLayoutContent;
     private RelativeLayout mSuggestionLayout;
@@ -361,8 +362,8 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                 popup.show();
             }
         });
-        ListView list = view.findViewById(android.R.id.list);
-        list.addHeaderView(sortLayoutContainer);
+        mList = view.findViewById(android.R.id.list);
+        mList.addHeaderView(sortLayoutContainer);
 
         getListView().setOnItemLongClickListener(this);
         getListView().setMultiChoiceModeListener(this);
@@ -392,6 +393,15 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                 return true;
             }
         });
+    }
+
+    public void showListPadding(boolean show) {
+        mList.setPadding(
+            mList.getPaddingLeft(),
+            mList.getPaddingTop(),
+            mList.getPaddingRight(),
+            show ? (int) getResources().getDimension(R.dimen.note_list_item_padding_bottom_button) : 0
+        );
     }
 
     private void switchSortDirection() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -685,8 +685,10 @@ public class NotesActivity extends AppCompatActivity implements
 
                 checkEmptyListText(true);
 
+                // Hide floating action button and list bottom padding.
                 if (mNoteListFragment != null) {
                     mNoteListFragment.setFloatingActionButtonVisible(false);
+                    mNoteListFragment.showListPadding(false);
                 }
 
                 AnalyticsTracker.track(
@@ -705,9 +707,10 @@ public class NotesActivity extends AppCompatActivity implements
                     updateActionsForLargeLandscape(menu);
                 }
 
-                // Show all notes again
+                // Show floating action button and list bottom padding.
                 if (mNoteListFragment != null) {
                     mNoteListFragment.setFloatingActionButtonVisible(true);
+                    mNoteListFragment.showListPadding(true);
                 }
 
                 mTabletSearchQuery = "";


### PR DESCRIPTION
### Fix
Update the note list by hiding the bottom padding while searching and restoring the bottom padding after exiting search.  See the animation below for illustration.

<a href="https://user-images.githubusercontent.com/3827611/68516161-845be980-0240-11ea-8175-ed1881d38bfc.gif"><img src="https://user-images.githubusercontent.com/3827611/68516161-845be980-0240-11ea-8175-ed1881d38bfc.gif" width="320"></a>

### Test
1. Scroll to bottom of note list.
2. Notice bottom padding is shown.
3. Tap ***Search*** action in top app bar.
4. Enter text marching multiple notes.
5. Submit search query.
6. Scroll to bottom of note list.
7. Notice bottom padding is hidden.
8. Tap back arrow to exit search.
9. Scroll to bottom of note list.
10. Notice bottom padding is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.