### PR TITLE
Issue/879 note sync pause

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -127,6 +127,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private String mMatchOffsets;
     private int mCurrentCursorPosition;
     private HistoryBottomSheetDialog mHistoryBottomSheet;
+    private boolean mIsPaused;
     // Hides the history bottom sheet if no revisions are loaded
     private final Runnable mHistoryTimeoutRunnable = new Runnable() {
         @Override
@@ -434,9 +435,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onPause() {
         super.onPause();  // Always call the superclass method first
-
-        mNotesBucket.removeListener(this);
-        mNotesBucket.stop();
+        mIsPaused = true;
 
         // Hide soft keyboard if it is showing...
         DisplayUtils.hideKeyboard(mContentEditText);
@@ -457,6 +456,13 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         mHighlighter.stop();
         saveNote();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        mNotesBucket.removeListener(this);
+        mNotesBucket.stop();
     }
 
     @Override
@@ -1234,7 +1240,10 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     @Override
     public void onSaveObject(Bucket<Note> noteBucket, Note note) {
-        // noop
+        if (mIsPaused) {
+            mNotesBucket.removeListener(this);
+            mNotesBucket.stop();
+        }
     }
 
     @Override


### PR DESCRIPTION
### Fix
Update the note editor to remove the note bucket listener after `onPause` and note save completes to close #879.  The note bucket listener was being removed before the note object was being saved when the `onPause` method was called in the `NoteEditorFragment` class.  Consequently, edits to a note were not being synced when exiting the app within two seconds of the edits.  These changes make sure the note is saved before the note bucket listener is removed.

### Test
In order to see whether the note edits are saved and synced when exiting the Android app, logging in to Simplenote on a web browser is helpful.

#### Pause
1. Tap any note in list.
2. Add text to note.
3. Notice added text appears in Android app.
4. Before two seconds pass, tap the ***Home*** button in the navigation bar.
5. Notice added text appears in web app.

#### Destroy
1. Tap any note in list.
2. Add text to note.
3. Notice added text appears in Android app.
4. Before two seconds pass, tap the ***Recent*** button in the navigation bar.
5. Swipe left or right to remove Simplenote from recent apps.
6. Notice added text appears in web app.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.