### PR TITLE
Stop Splitting Surrogates

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -68,7 +68,7 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Automattic and WordPress dependencies
-    implementation 'com.simperium.android:simperium:0.9.1'
+    implementation 'com.simperium.android:simperium:0.9.2'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:1.7.0'
 


### PR DESCRIPTION
### Fix
Update the `simperium` dependency, which includes changes to stop the splitting of surrogate pairs that resulted in corrupted data in note content as described in https://github.com/Simperium/simperium-android/pull/213.

### Test
1. Tap ***New note*** floating action button.
2. Insert `🙂🙁` in note.
3. Insert `😱` between `🙂` and `🙁` in note.
4. Notice emojis appear as `🙂😱🙁` in note.
5. Tap back arrow in top app bar.
6. Notice emojis appear as `🙂😱🙁` in note list.
7. Tap note from Step 1.
8. Notice emojis appear as `🙂😱🙁` in note.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.