### PR TITLE
Issue/881 remove relevance sorting

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 2.3
 -----
-* Added search sorting by relevance, date created, date modified, and alphabetically
+* Added search sorting by date created, date modified, and alphabetically
 * Added search history and suggestions
 
 2.2

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -154,7 +154,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     private int mPreferenceSortOrder;
     private int mTitleFontSize;
     private int mPreviewFontSize;
-    private boolean mIsSortDown;
+    private boolean mIsSortDown = true;
     /**
      * The fragment's current callback object, which is notified of list item
      * clicks.
@@ -374,8 +374,8 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         sortDirectionSwitch.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                float startRotate = mIsSortDown ? -180f : 0f;
-                float endRotate = mIsSortDown ? 0f : -180f;
+                float startRotate = mIsSortDown ? 0f : -180f;
+                float endRotate = mIsSortDown ? -180f : 0f;
                 int duration = getResources().getInteger(android.R.integer.config_shortAnimTime);
                 ObjectAnimator.ofFloat(mSortDirection, View.ROTATION, startRotate, endRotate).setDuration(duration).start();
                 mIsSortDown = !mIsSortDown;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -334,6 +334,11 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                 popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                     @Override
                     public boolean onMenuItemClick(MenuItem item) {
+                        // Do nothing when same sort is selected.
+                        if (mSortOrder.getText().equals(item.getTitle())) {
+                            return false;
+                        }
+
                         mSortOrder.setText(item.getTitle());
 
                         switch (item.getItemId()) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -339,20 +339,50 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                         switch (item.getItemId()) {
                             case R.id.search_alphabetically:
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
-                                    String.valueOf(mIsSortDown ? ALPHABETICAL_DESCENDING : ALPHABETICAL_ASCENDING)
+                                    String.valueOf(ALPHABETICAL_ASCENDING)
                                 ).apply();
+
+                                // If arrow is down, rotate it up for ascending direction.
+                                if (mIsSortDown && !mIsSortReverse) {
+                                    mSortDirectionAnimation.start();
+                                    mIsSortReverse = true;
+                                } else if (!mIsSortDown && mIsSortReverse) {
+                                    mSortDirectionAnimation.reverse();
+                                    mIsSortReverse = false;
+                                }
+
                                 refreshListForSearch();
                                 return true;
                             case R.id.search_created:
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
-                                    String.valueOf(mIsSortDown ? DATE_CREATED_DESCENDING : DATE_CREATED_ASCENDING)
+                                    String.valueOf(DATE_CREATED_DESCENDING)
                                 ).apply();
+
+                                // If arrow is up, rotate it down for descending direction.
+                                if (mIsSortDown && mIsSortReverse) {
+                                    mSortDirectionAnimation.reverse();
+                                    mIsSortReverse = false;
+                                } else if (!mIsSortDown && !mIsSortReverse) {
+                                    mSortDirectionAnimation.start();
+                                    mIsSortReverse = true;
+                                }
+
                                 refreshListForSearch();
                                 return true;
                             case R.id.search_modified:
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
-                                    String.valueOf(mIsSortDown ? DATE_MODIFIED_DESCENDING : DATE_MODIFIED_ASCENDING)
+                                    String.valueOf(DATE_MODIFIED_DESCENDING)
                                 ).apply();
+
+                                // If arrow is up, rotate it down for descending direction.
+                                if (mIsSortDown && mIsSortReverse) {
+                                    mSortDirectionAnimation.reverse();
+                                    mIsSortReverse = false;
+                                } else if (!mIsSortDown && !mIsSortReverse) {
+                                    mSortDirectionAnimation.start();
+                                    mIsSortReverse = true;
+                                }
+
                                 refreshListForSearch();
                                 return true;
                             default:

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -41,6 +41,7 @@ import android.widget.Toast;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.fragment.app.ListFragment;
 import androidx.preference.PreferenceManager;
@@ -253,8 +254,8 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         setListAdapter(mNotesAdapter);
     }
 
-    // nbradbury - load values from preferences
     protected void getPrefs() {
+        mPreferenceSortOrder = PrefUtils.getIntPref(requireContext(), PrefUtils.PREF_SORT_ORDER);
         mIsCondensedNoteList = PrefUtils.getBoolPref(getActivity(), PrefUtils.PREF_CONDENSED_LIST, false);
         mTitleFontSize = PrefUtils.getFontSize(getActivity());
         mPreviewFontSize = mTitleFontSize - 2;
@@ -312,7 +313,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             }
         });
 
-        mPreferenceSortOrder = PrefUtils.getIntPref(requireContext(), PrefUtils.PREF_SORT_ORDER);
         mSuggestionLayout = view.findViewById(R.id.suggestion_layout);
         mSuggestionList = view.findViewById(R.id.suggestion_list);
         mSuggestionAdapter = new SuggestionAdapter(new ArrayList<Suggestion>());
@@ -401,6 +401,21 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             mList.getPaddingRight(),
             show ? (int) getResources().getDimension(R.dimen.note_list_item_padding_bottom_button) : 0
         );
+    }
+
+    private @StringRes int getSortOrderText() {
+        switch (PrefUtils.getIntPref(requireContext(), PrefUtils.PREF_SORT_ORDER)) {
+            case ALPHABETICAL_ASCENDING:
+            case ALPHABETICAL_DESCENDING:
+                return R.string.sort_search_alphabetically;
+            case DATE_CREATED_ASCENDING:
+            case DATE_CREATED_DESCENDING:
+                return R.string.sort_search_created;
+            case DATE_MODIFIED_ASCENDING:
+            case DATE_MODIFIED_DESCENDING:
+            default:
+                return R.string.sort_search_modified;
+        }
     }
 
     private void switchSortDirection() {
@@ -573,6 +588,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     }
 
     public void refreshList() {
+        mSortOrder.setText(getSortOrderText());
         refreshList(false);
     }
 
@@ -729,11 +745,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mIsSearching = true;
         mSortLayoutContent.setVisibility(View.VISIBLE);
         mSuggestionLayout.setVisibility(View.VISIBLE);
-        // Start search with Relevance sort order selected.
-        mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
-            String.valueOf(mIsSortDown ? DATE_MODIFIED_DESCENDING : DATE_MODIFIED_ASCENDING)
-        ).apply();
-        mSortOrder.setText(R.string.sort_search_relevance);
+        mSortOrder.setText(getSortOrderText());
 
         if (!searchString.equals(mSearchString)) {
             mSearchString = searchString;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -539,7 +539,13 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     public void onResume() {
         super.onResume();
         getPrefs();
-        refreshList();
+
+        if (mIsSearching) {
+            refreshListForSearch();
+        } else {
+            refreshList();
+        }
+
         mBucketPreferences.start();
         mBucketPreferences.addOnDeleteObjectListener(this);
         mBucketPreferences.addOnNetworkChangeListener(this);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -323,7 +323,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mSortLayoutContent = sortLayoutContainer.findViewById(R.id.sort_content);
         mSortLayoutContent.setVisibility(mIsSearching ? View.VISIBLE : View.GONE);
         mSortOrder = sortLayoutContainer.findViewById(R.id.sort_order);
-        mSortOrder.setText(R.string.sort_search_relevance);
         mSortLayoutContent.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -349,7 +348,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                                 refreshListForSearch();
                                 return true;
                             case R.id.search_modified:
-                            case R.id.search_relevance:
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
                                     String.valueOf(mIsSortDown ? DATE_MODIFIED_DESCENDING : DATE_MODIFIED_ASCENDING)
                                 ).apply();

--- a/Simplenote/src/main/res/drawable/ic_arrow_up_16dp.xml
+++ b/Simplenote/src/main/res/drawable/ic_arrow_up_16dp.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="16dp"
+    android:width="16dp"
+    android:viewportHeight="16"
+    android:viewportWidth="16">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,5.8L3.8,9.1L2.3,7.6L8,2l5.7,5.6l-1.5,1.5L9,5.8l0,8.6H7L7,5.8z">
+    </path>
+
+</vector>

--- a/Simplenote/src/main/res/layout/search_sort.xml
+++ b/Simplenote/src/main/res/layout/search_sort.xml
@@ -25,7 +25,7 @@
             android:layout_marginStart="@dimen/padding_large"
             android:layout_width="wrap_content"
             android:textSize="@dimen/text_content_title"
-            tools:text="@string/sort_search_relevance">
+            tools:text="@string/sort_search_modified">
         </com.automattic.simplenote.widgets.RobotoMediumTextView>
 
         <ImageView

--- a/Simplenote/src/main/res/menu/search_sort.xml
+++ b/Simplenote/src/main/res/menu/search_sort.xml
@@ -4,11 +4,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:id="@+id/search_relevance"
-        android:title="@string/sort_search_relevance">
-    </item>
-
-    <item
         android:id="@+id/search_alphabetically"
         android:title="@string/sort_search_alphabetically">
     </item>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -81,7 +81,6 @@
     <string name="sort_search_alphabetically">Alphabetically</string>
     <string name="sort_search_created">Created</string>
     <string name="sort_search_modified">Modified</string>
-    <string name="sort_search_relevance">Relevance</string>
     <string name="sort_search_reverse_order">Reverse order</string>
 
     <!-- Editor link options -->


### PR DESCRIPTION
### Fix
Remove references to the ***Relevance*** sorting option to close #881.  These changes follow the logic below.
- Sort order and direction from note list is shown when ***Search*** is initialized.
- Default sort direction is shown when selecting different sort item after ***Search*** is initialized.
  - Alphabetically A-Z is default.
  - Newest created date is default.
  - Newest modified date is default.
- Ascending sort direction shows arrow up.
  - Alphabetically A-Z is ascending.
  - Oldest created date is ascending.
  - Oldest modified date is ascending.
- Descending sort direction shows arrow down.
  - Alphabetically Z-A is descending.
  - Newest created date is descending.
  - Newest modified date is descending.

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Notice selected item in ***Sort order*** setting.
4. Notice sort direction arrow for selected item in list above.
5. Tap back arrow in top app bar.
6. Tap ***Search*** action in top app bar.
7. Enter any text or tap recent search from list.
8. Notice sort order and direction match selected item in ***Settings*** and follow list above.
9. Tap sort order filter.
10. Tap same sort order as currently selected.
11. Notice nothing happens.
12. Tap sort order filter.
13. Tap  different sort order than currently selected.
14. Notice sort order and direction follow default from list above.
15. Tap any note in list.
16. Notice note is shown.
17. Tap back arrow in top app bar.
18. Notice search results remain unchanged.
19. Tap back arrow in top app bar.
20. Notice note list returns to original sort order.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 865969f with:
> Added search sorting by date created, date modified, and alphabetically