### PR TITLE
Crash Resume Filter

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -238,7 +238,9 @@ public class NotesActivity extends AppCompatActivity implements
             }
         }
 
-        filterListBySelectedTag();
+        if (mSelectedTag != null) {
+            filterListBySelectedTag();
+        }
 
         if (mCurrentNote != null && mShouldSelectNewNote) {
             onNoteSelected(mCurrentNote.getSimperiumKey(), 0, null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());


### PR DESCRIPTION
### Fix
Add a null-check for the `mSelectedTag` object before calling the `filterListBySelectedTag()` method, which uses `mSelectedTag.id` to determine the navigation drawer menu item associated with the selected tag.  This check avoids the `NullPointerException` shown below when logging out of the app in ***Settings***.

```
Caused by: java.lang.NullPointerException: Attempt to read from field 'long com.automattic.simplenote.utils.TagsAdapter$TagMenuItem.id' on a null object reference
	at com.automattic.simplenote.NotesActivity.filterListBySelectedTag(NotesActivity.java:402)
	at com.automattic.simplenote.NotesActivity.onResume(NotesActivity.java:241)
```

### Test
1. Open navigation drawer.
2. Tap any tag under ***Tags*** section in navigation drawer.
3. Open navigation drawer.
4. Tap ***Settings*** item in navigation drawer.
5. Tap ***Sign out*** item under ***Account*** section.
6. Notice login/signup screen is shown.
7. Notice app does not crash.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.