### PR TITLE
Issue/890 add tag selected

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -86,6 +86,7 @@ public class NotesActivity extends AppCompatActivity implements
     private boolean mShouldSelectNewNote;
     private boolean mIsSettingsClicked;
     private boolean mIsTabetFullscreen;
+    private boolean mIsTagSelected;
 
     private String mTabletSearchQuery;
     private UndoBarController mUndoBarController;
@@ -663,8 +664,10 @@ public class NotesActivity extends AppCompatActivity implements
         mSearchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
             public boolean onQueryTextChange(String newText) {
-                if (mSearchMenuItem.isActionViewExpanded()) {
+                if (mSearchMenuItem.isActionViewExpanded() && !mIsTagSelected) {
                     getNoteListFragment().searchNotes(newText, false);
+                } else if (mIsTagSelected) {
+                    mIsTagSelected = false;
                 }
 
                 return true;
@@ -695,12 +698,13 @@ public class NotesActivity extends AppCompatActivity implements
                     new Handler().postDelayed(new Runnable() {
                         @Override
                         public void run() {
+                            mIsTagSelected = true;
                             mSearchView.setQuery(TAG_PREFIX + mSelectedTag.name + SPACE, false);
                         }
                     }, 10);
-                } else {
-                    getNoteListFragment().searchNotes("", false);
                 }
+
+                getNoteListFragment().searchNotes("", false);
 
                 if (DisplayUtils.isLargeScreenLandscape(NotesActivity.this)) {
                     updateActionsForLargeLandscape(menu);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -66,6 +66,7 @@ import static com.automattic.simplenote.NoteWidget.KEY_WIDGET_CLICK;
 import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
 import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_SIGN_IN_TAPPED;
 import static com.automattic.simplenote.utils.DisplayUtils.disableScreenshotsIfLocked;
+import static com.automattic.simplenote.utils.SearchTokenizer.SPACE;
 import static com.automattic.simplenote.utils.TagsAdapter.ALL_NOTES_ID;
 import static com.automattic.simplenote.utils.TagsAdapter.DEFAULT_ITEM_POSITION;
 import static com.automattic.simplenote.utils.TagsAdapter.SETTINGS_ID;
@@ -682,7 +683,24 @@ public class NotesActivity extends AppCompatActivity implements
             @Override
             public boolean onMenuItemActionExpand(MenuItem menuItem) {
                 mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
-                getNoteListFragment().searchNotes("", false);
+
+                if (mSelectedTag.id != ALL_NOTES_ID && mSelectedTag.id != TRASH_ID && mSelectedTag.id != UNTAGGED_NOTES_ID) {
+                    /*
+                     * This is a hack.  Since onQueryTextChange is being triggered after
+                     * onMenuItemActionExpand and the first time onQueryTextChange is run
+                     * with an empty newText value, removing the post delay will clear the
+                     * search field.  Any post delay value, even 1ms, will workaround the
+                     * issue.
+                     */
+                    new Handler().postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            mSearchView.setQuery(TAG_PREFIX + mSelectedTag.name + SPACE, true);
+                        }
+                    }, 10);
+                } else {
+                    getNoteListFragment().searchNotes("", false);
+                }
 
                 if (DisplayUtils.isLargeScreenLandscape(NotesActivity.this)) {
                     updateActionsForLargeLandscape(menu);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -695,7 +695,7 @@ public class NotesActivity extends AppCompatActivity implements
                     new Handler().postDelayed(new Runnable() {
                         @Override
                         public void run() {
-                            mSearchView.setQuery(TAG_PREFIX + mSelectedTag.name + SPACE, true);
+                            mSearchView.setQuery(TAG_PREFIX + mSelectedTag.name + SPACE, false);
                         }
                     }, 10);
                 } else {


### PR DESCRIPTION
### Fix
When a tag (e.g. `work`) is selected from the navigation drawer and the _*Search*_ action is tapped, add the `tag:` prefix with the tag name to the search input field (e.g. `tag:work`) to close #890.  A space was also added after the tag prefix and tag name so that the user can start typing additional search criteria without entering a space first.

### Test
1. Open navigation drawer.
2. Tap ***All Notes*** or ***Untagged Notes*** item in navigation drawer.
3. Tap ***Search*** action in top app bar.
4. Notice search field is empty.
5. Notice recently submitted searches are shown.
6. Tap back arrow in top app bar.
7. Open navigation drawer.
8. Tap any tag under ***Tags*** section.
9. Tap ***Search*** action in top app bar.
10. Notice search field contains `tag:` followed by tag name from Step 7 and a space.
11. Notice recently submitted searches are shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.