### PR TITLE
Issue/893 add global search

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -722,9 +722,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             return null;
         }
 
-        NotesActivity notesActivity = (NotesActivity) requireActivity();
-        Query<Note> query = notesActivity.getSelectedTag().query();
-
+        Query<Note> query = Note.all(((Simplenote) requireActivity().getApplication()).getNotesBucket());
         String searchString = mSearchString;
 
         if (hasSearchQuery()) {


### PR DESCRIPTION
### Fix
Add the ability to search globally (i.e. all notes) regardless of what tag is selected when tapping the ***Search*** action in the top app bar to close #893.

### Test
1. Open navigation drawer.
2. Tap ***All Notes*** item in navigation drawer.
3. Tap ***Search*** action in top app bar.
4. Enter text to search.
5. Notice all notes matching text from Step 4 are shown.
6. Tap back arrow in top app bar.
7. Open navigation drawer.
8. Tap tag under ***Tags*** section.
9. Notice note matching tag from Step 8 are shown.
10. Tap ***Search*** action in top app bar.
11. Enter same text as Step 4 to search.
12. Notice notes in search results match Step 5.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.