### PR TITLE
Navigation Locked Search

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -779,6 +779,13 @@ public class NotesActivity extends AppCompatActivity implements
 
         DrawableUtils.tintMenuWithAttribute(this, menu, R.attr.toolbarIconColor);
 
+        if (mDrawerLayout != null && mSearchMenuItem != null) {
+            mDrawerLayout.setDrawerLockMode(mSearchMenuItem.isActionViewExpanded() ?
+                DrawerLayout.LOCK_MODE_LOCKED_CLOSED :
+                DrawerLayout.LOCK_MODE_UNLOCKED
+            );
+        }
+
         return true;
     }
 


### PR DESCRIPTION
### Fix
Add locking and unlocking the navigation drawer based on whether the search view is expanded or collapsed, respectively, when the options menu is created.  This is necessary when the activity containing the search field is destroyed before the search field is collapsed.  That could occur when tapping a note in the search results then sending the app into the background for an indeterminate amount of time or using the ***Don't keep activities*** setting, which will kill the search activity as soon as the note in the search results is tapped.

### Test
The easiest way to test this is to enable/disable the ***Don't keep activities*** setting under the ***Apps*** section of ***Developer options***.
#### Enable ***Don't keep activities***
1. Notice navigation drawer is unlocked.
2. Tap ***Search*** in top app bar.
3. Notice navigation drawer is locked.
4. Enter text to search.
5. Notice navigation drawer is locked.
6. Tap any note in search results.
7. Notice note editor is shown.
8. Tap back arrow in top app bar.
9. Notice search is hidden.
10. Notice navigation drawer is unlocked.

#### Disable ***Don't keep activities***
1. Notice navigation drawer is unlocked.
2. Tap ***Search*** in top app bar.
3. Notice navigation drawer is locked.
4. Enter text to search.
5. Notice navigation drawer is locked.
6. Tap any note in search results.
7. Notice note editor is shown.
8. Tap back arrow in top app bar.
9. Notice search is shown.
10. Notice navigation drawer is locked.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.