### PR TITLE
Update Tablet Selection

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -610,7 +610,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
      */
     public void selectFirstNote() {
         if (mNotesAdapter.getCount() > 0) {
-            Note selectedNote = mNotesAdapter.getItem(0);
+            Note selectedNote = mNotesAdapter.getItem(mList.getHeaderViewsCount());
             mCallbacks.onNoteSelected(selectedNote.getSimperiumKey(), 0, null, selectedNote.isMarkdownEnabled(), selectedNote.isPreviewEnabled());
         }
     }
@@ -807,7 +807,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                 cursor.moveToPosition(i);
                 String noteKey = cursor.getSimperiumKey();
                 if (noteKey != null && noteKey.equals(selectedNoteID)) {
-                    setActivatedPosition(i);
+                    setActivatedPosition(i + mList.getHeaderViewsCount());
                     return;
                 }
             }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -997,7 +997,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
         @Override
         public Note getItem(int position) {
-            mCursor.moveToPosition(position - 1);  // Minus one due to sort view header.
+            mCursor.moveToPosition(position - mList.getHeaderViewsCount());
             return mCursor.getObject();
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -253,8 +253,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         super.onCreate(savedInstanceState);
         mBucketPreferences = ((Simplenote) requireActivity().getApplication()).getPreferencesBucket();
         mBucketTag = ((Simplenote) requireActivity().getApplication()).getTagsBucket();
-        mNotesAdapter = new NotesCursorAdapter(requireActivity().getBaseContext(), null, 0);
-        setListAdapter(mNotesAdapter);
     }
 
     protected void getPrefs() {
@@ -401,6 +399,9 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         });
         mList = view.findViewById(android.R.id.list);
         mList.addHeaderView(sortLayoutContainer);
+
+        mNotesAdapter = new NotesCursorAdapter(requireActivity().getBaseContext(), null, 0);
+        setListAdapter(mNotesAdapter);
 
         getListView().setOnItemLongClickListener(this);
         getListView().setMultiChoiceModeListener(this);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -126,7 +126,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         }
 
         @Override
-        public void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled, boolean isPreviewEnabled) {
+        public void onNoteSelected(String noteID, String matchOffsets, boolean isMarkdownEnabled, boolean isPreviewEnabled) {
         }
     };
     protected NotesCursorAdapter mNotesAdapter;
@@ -599,7 +599,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
         if (noteID != null) {
             Note note = mNotesAdapter.getItem(position);
-            mCallbacks.onNoteSelected(noteID, position, holder.mMatchOffsets, note.isMarkdownEnabled(), note.isPreviewEnabled());
+            mCallbacks.onNoteSelected(noteID, holder.mMatchOffsets, note.isMarkdownEnabled(), note.isPreviewEnabled());
         }
 
         mActivatedPosition = position;
@@ -611,7 +611,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     public void selectFirstNote() {
         if (mNotesAdapter.getCount() > 0) {
             Note selectedNote = mNotesAdapter.getItem(mList.getHeaderViewsCount());
-            mCallbacks.onNoteSelected(selectedNote.getSimperiumKey(), 0, null, selectedNote.isMarkdownEnabled(), selectedNote.isPreviewEnabled());
+            mCallbacks.onNoteSelected(selectedNote.getSimperiumKey(), null, selectedNote.isMarkdownEnabled(), selectedNote.isPreviewEnabled());
         }
     }
 
@@ -782,7 +782,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             new Handler().postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    mCallbacks.onNoteSelected(note.getSimperiumKey(), 0, null, note.isMarkdownEnabled(), note.isPreviewEnabled());
+                    mCallbacks.onNoteSelected(note.getSimperiumKey(), null, note.isMarkdownEnabled(), note.isPreviewEnabled());
                 }
             }, 50);
         } else {
@@ -956,7 +956,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         /**
          * Callback for when a note has been selected.
          */
-        void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled, boolean isPreviewEnabled);
+        void onNoteSelected(String noteID, String matchOffsets, boolean isMarkdownEnabled, boolean isPreviewEnabled);
     }
 
     // view holder for NotesCursorAdapter

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -244,7 +244,7 @@ public class NotesActivity extends AppCompatActivity implements
         }
 
         if (mCurrentNote != null && mShouldSelectNewNote) {
-            onNoteSelected(mCurrentNote.getSimperiumKey(), 0, null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
+            onNoteSelected(mCurrentNote.getSimperiumKey(), null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
             mShouldSelectNewNote = false;
         }
 
@@ -968,7 +968,7 @@ public class NotesActivity extends AppCompatActivity implements
      * the item with the given ID was selected. Used for tablets only.
      */
     @Override
-    public void onNoteSelected(String noteID, int position, String matchOffsets, boolean isMarkdownEnabled, boolean isPreviewEnabled) {
+    public void onNoteSelected(String noteID, String matchOffsets, boolean isMarkdownEnabled, boolean isPreviewEnabled) {
         if (!DisplayUtils.isLargeScreenLandscape(this)) {
             // Launch the editor activity
             Bundle arguments = new Bundle();
@@ -1191,7 +1191,7 @@ public class NotesActivity extends AppCompatActivity implements
 
                 // Select the current note on a tablet
                 if (mCurrentNote != null) {
-                    onNoteSelected(mCurrentNote.getSimperiumKey(), 0, null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
+                    onNoteSelected(mCurrentNote.getSimperiumKey(), null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
                 } else {
                     mNoteEditorFragment.setPlaceholderVisible(true);
                     mNoteListFragment.getListView().clearChoices();
@@ -1200,7 +1200,7 @@ public class NotesActivity extends AppCompatActivity implements
                 invalidateOptionsMenu();
             // Go to NoteEditorActivity if note editing was fullscreen and orientation was switched to portrait
             } else if (mNoteListFragment.isHidden() && mCurrentNote != null) {
-                onNoteSelected(mCurrentNote.getSimperiumKey(), 0, null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
+                onNoteSelected(mCurrentNote.getSimperiumKey(), null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
             }
         }
 


### PR DESCRIPTION
### Fix
Update the note list selection for large screen devices (e.g. tablets) to highlight the correct note shown in the editor.  These changes also avoid crashes when selecting ***Trash***, ***Untagged Notes***, and user-defined tags under the ***Tags*** section.  Both issues were a consequence of adding the list view header used during search.  See the screenshots below for illustration.

![update-tablet-selection](https://user-images.githubusercontent.com/3827611/70098798-58871600-15ea-11ea-9f00-2f86803f6189.png)

### Test
These changes only affect the two-pane layout on large screen devices (e.g. tablets). When performing the test steps below, be sure to use a large screen device.
1. Rotate device into landscape orientation.
2. Tap any note in list.
3. Notice note highlighted in list matches note shown in editor/preview.
4. Open navigation drawer.
5. Tap ***Trash*** item in navigation drawer.
6. Notice app doesn't crash.
7. Notice trashed notes are shown.
8. Open navigation drawer.
9. Tap ***Untagged Notes*** item in navigation drawer.
10. Notice app doesn't crash.
11. Notice untagged notes are shown.
12. Open navigation drawer.
13. Tap any tag under ***Tags*** section.
14. Notice app doesn't crash.
15. Notice notes with tag from Step 13 are shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.