### PR TITLE
Update Link Actions

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1049,7 +1049,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 mLinkText = noteContent.subSequence(noteContent.getSpanStart(urlSpan), noteContent.getSpanEnd(urlSpan)).toString();
                 if (mActionMode != null) {
                     mActionMode.setSubtitle(mLinkText);
-                    setLinkMenuItem();
+                    updateMenuItems();
                     return;
                 }
 
@@ -1060,7 +1060,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                         mActionMode.setSubtitle(mLinkText);
                     }
 
-                    setLinkMenuItem();
+                    updateMenuItems();
                 }
             } else if (mActionMode != null) {
                 mActionMode.finish();
@@ -1072,7 +1072,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         }
     }
 
-    private void setLinkMenuItem() {
+    private void updateMenuItems() {
         mCopyMenuItem.setIcon(mCopyIcon);
         mShareMenuItem.setIcon(mShareIcon);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -129,7 +129,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private Drawable mEmailIcon;
     private Drawable mMapIcon;
     private Drawable mShareIcon;
-    private Drawable mWebIcon;
+    private Drawable mBrowserIcon;
     private MatchOffsetHighlighter.SpanFactory mMatchHighlighter;
     private String mMatchOffsets;
     private int mCurrentCursorPosition;
@@ -281,7 +281,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mCallIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_call_white_24dp, R.attr.actionModeTextColor);
         mEmailIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_email_24dp, R.attr.actionModeTextColor);
         mMapIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_map_24dp, R.attr.actionModeTextColor);
-        mWebIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_web_24dp, R.attr.actionModeTextColor);
+        mBrowserIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_browser_24dp, R.attr.actionModeTextColor);
         mCopyIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_copy_24dp, R.attr.actionModeTextColor);
         mShareIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_share_24dp, R.attr.actionModeTextColor);
 
@@ -1087,7 +1087,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 mViewLinkMenuItem.setIcon(mMapIcon);
                 mViewLinkMenuItem.setTitle(getString(R.string.view_map));
             } else {
-                mViewLinkMenuItem.setIcon(mWebIcon);
+                mViewLinkMenuItem.setIcon(mBrowserIcon);
                 mViewLinkMenuItem.setTitle(getString(R.string.view_in_browser));
             }
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -118,11 +118,18 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private boolean mIsPreviewEnabled;
     private boolean mShouldScrollToSearchMatch;
     private ActionMode mActionMode;
+    private MenuItem mCopyMenuItem;
+    private MenuItem mShareMenuItem;
     private MenuItem mViewLinkMenuItem;
     private String mLinkUrl;
     private String mLinkText;
     private MatchOffsetHighlighter mHighlighter;
-    private Drawable mEmailIcon, mWebIcon, mMapIcon, mCallIcon;
+    private Drawable mCallIcon;
+    private Drawable mCopyIcon;
+    private Drawable mEmailIcon;
+    private Drawable mMapIcon;
+    private Drawable mShareIcon;
+    private Drawable mWebIcon;
     private MatchOffsetHighlighter.SpanFactory mMatchHighlighter;
     private String mMatchOffsets;
     private int mCurrentCursorPosition;
@@ -159,6 +166,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
             if (inflater != null) {
                 inflater.inflate(R.menu.view_link, menu);
+                mCopyMenuItem = menu.findItem(R.id.menu_copy);
+                mShareMenuItem = menu.findItem(R.id.menu_share);
                 mViewLinkMenuItem = menu.findItem(R.id.menu_view_link);
                 mode.setTitle(getString(R.string.link));
                 mode.setTitleOptionalHint(false);
@@ -273,6 +282,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mEmailIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_email_24dp, R.attr.actionModeTextColor);
         mMapIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_map_24dp, R.attr.actionModeTextColor);
         mWebIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_web_24dp, R.attr.actionModeTextColor);
+        mCopyIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_copy_24dp, R.attr.actionModeTextColor);
+        mShareIcon = DrawableUtils.tintDrawableWithAttribute(getActivity(), R.drawable.ic_share_24dp, R.attr.actionModeTextColor);
 
         mAutoSaveHandler = new Handler();
         mPublishTimeoutHandler = new Handler();
@@ -1062,6 +1073,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     private void setLinkMenuItem() {
+        mCopyMenuItem.setIcon(mCopyIcon);
+        mShareMenuItem.setIcon(mShareIcon);
+
         if (mViewLinkMenuItem != null && mLinkUrl != null) {
             if (mLinkUrl.startsWith("tel:")) {
                 mViewLinkMenuItem.setIcon(mCallIcon);

--- a/Simplenote/src/main/res/drawable/ic_browser_24dp.xml
+++ b/Simplenote/src/main/res/drawable/ic_browser_24dp.xml
@@ -9,7 +9,7 @@
 
     <path
         android:fillColor="@android:color/white"
-        android:pathData="M20,4L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM15,18L4,18v-4h11v4zM15,13L4,13L4,9h11v4zM20,18h-4L16,9h4v9z">
+        android:pathData="M19,4L5,4c-1.11,0 -2,0.9 -2,2v12c0,1.1 0.89,2 2,2h4v-2L5,18L5,8h14v10h-4v2h4c1.1,0 2,-0.9 2,-2L21,6c0,-1.1 -0.89,-2 -2,-2zM12,10l-4,4h3v6h2v-6h3l-4,-4z">
     </path>
 
 </vector>

--- a/Simplenote/src/main/res/menu/view_link.xml
+++ b/Simplenote/src/main/res/menu/view_link.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/menu_view_link"
-        android:icon="@drawable/ic_web_24dp"
+        android:icon="@drawable/ic_browser_24dp"
         android:title="@string/view_in_browser"
         app:showAsAction="ifRoom"/>
     <item


### PR DESCRIPTION
### Fix
Update the color of the action icons when a link is selected in the note editor to match the rest of the app bar style.  See the screenshots below for illustration.

![update_link_actions](https://user-images.githubusercontent.com/3827611/70100428-eb29b400-15ee-11ea-9d75-3c9660dd5e18.png)

### Test
1. Tap any note in list with link.
2. Tap link in note.
3. Notice all text and icons are blue in top app bar.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.