### PR TITLE
Update Date Format

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/HistoryBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/HistoryBottomSheetDialog.java
@@ -114,7 +114,7 @@ public class HistoryBottomSheetDialog extends BottomSheetDialogBase {
                     mListener.onHistoryUpdateNote(revisedNote.getContent());
                 }
 
-                mHistoryDate.setText(DateTimeUtils.getDateText(mFragment.getActivity(), noteDate));
+                mHistoryDate.setText(DateTimeUtils.getDateText(requireContext(), noteDate));
             }
 
             @Override
@@ -188,7 +188,7 @@ public class HistoryBottomSheetDialog extends BottomSheetDialogBase {
         if (totalRevs > 0) {
             mHistorySeekBar.setMax(totalRevs);
             mHistorySeekBar.setProgress(totalRevs);
-            mHistoryDate.setText(DateTimeUtils.getDateText(mFragment.getActivity(), mNote.getModificationDate()));
+            mHistoryDate.setText(DateTimeUtils.getDateText(requireContext(), mNote.getModificationDate()));
             mLoadingView.setVisibility(View.GONE);
             mSliderView.setVisibility(View.VISIBLE);
         } else {

--- a/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
@@ -135,7 +135,7 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
         if (mFragment.isAdded()) {
             showNow(manager, TAG);
 
-            String date = DateTimeUtils.getDateText(mFragment.getActivity(), note.getModificationDate());
+            String date = DateTimeUtils.getDateText(requireContext(), note.getModificationDate());
             mInfoModifiedDate.setText(String.format(mFragment.getString(R.string.modified_time), date));
             mInfoPinSwitch.setChecked(note.isPinned());
             mInfoMarkdownSwitch.setChecked(note.isMarkdownEnabled());

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -1039,7 +1039,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             mCursor.moveToPosition(position);
             holder.setNoteId(mCursor.getSimperiumKey());
             Calendar date = getDateByPreference(mCursor.getObject());
-            holder.mDate.setText(date != null ? DateTimeUtils.getDateTextShort(date) : "");
+            holder.mDate.setText(date != null ? DateTimeUtils.getDateTextNumeric(date) : "");
             holder.mDate.setVisibility(mIsSearching && date != null ? View.VISIBLE : View.GONE);
             boolean isPinned = mCursor.getObject().isPinned();
             holder.mPinned.setVisibility(!isPinned || mIsSearching ? View.GONE : View.VISIBLE);

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
@@ -9,14 +9,14 @@ import java.util.Calendar;
 import java.util.Locale;
 
 public class DateTimeUtils {
-    public static String getDateText(Context context, Calendar noteDate) {
-        if (noteDate == null) {
+    public static String getDateText(Context context, Calendar calendar) {
+        if (calendar == null) {
             return "";
         }
 
         CharSequence dateText = DateUtils.getRelativeDateTimeString(
                 context,
-                noteDate.getTimeInMillis(),
+                calendar.getTimeInMillis(),
                 Calendar.getInstance().getTimeInMillis(),
                 0L,
                 DateUtils.FORMAT_ABBREV_ALL

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
@@ -2,6 +2,7 @@ package com.automattic.simplenote.utils;
 
 import android.app.Activity;
 import android.text.format.DateFormat;
+import android.text.format.DateUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -14,12 +15,12 @@ public class DateTimeUtils {
         }
 
         long now = Calendar.getInstance().getTimeInMillis();
-        CharSequence dateText = android.text.format.DateUtils.getRelativeDateTimeString(
+        CharSequence dateText = DateUtils.getRelativeDateTimeString(
                 activity,
                 noteDate.getTimeInMillis(),
                 now,
                 0L,
-                android.text.format.DateUtils.FORMAT_ABBREV_ALL
+                DateUtils.FORMAT_ABBREV_ALL
         );
 
         return dateText.toString();

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
@@ -1,6 +1,6 @@
 package com.automattic.simplenote.utils;
 
-import android.app.Activity;
+import android.content.Context;
 import android.text.format.DateFormat;
 import android.text.format.DateUtils;
 
@@ -9,14 +9,14 @@ import java.util.Calendar;
 import java.util.Locale;
 
 public class DateTimeUtils {
-    public static String getDateText(Activity activity, Calendar noteDate) {
+    public static String getDateText(Context context, Calendar noteDate) {
         if (noteDate == null) {
             return "";
         }
 
         long now = Calendar.getInstance().getTimeInMillis();
         CharSequence dateText = DateUtils.getRelativeDateTimeString(
-                activity,
+                context,
                 noteDate.getTimeInMillis(),
                 now,
                 0L,

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
@@ -14,11 +14,10 @@ public class DateTimeUtils {
             return "";
         }
 
-        long now = Calendar.getInstance().getTimeInMillis();
         CharSequence dateText = DateUtils.getRelativeDateTimeString(
                 context,
                 noteDate.getTimeInMillis(),
-                now,
+                Calendar.getInstance().getTimeInMillis(),
                 0L,
                 DateUtils.FORMAT_ABBREV_ALL
         );

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
@@ -1,6 +1,7 @@
 package com.automattic.simplenote.utils;
 
 import android.app.Activity;
+import android.text.format.DateFormat;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -24,8 +25,8 @@ public class DateTimeUtils {
         return dateText.toString();
     }
 
-    public static String getDateTextShort(Calendar date) {
-        SimpleDateFormat formatter = new SimpleDateFormat("MMM d", Locale.getDefault());
-        return formatter.format(date.getTime());
+    public static String getDateTextNumeric(Calendar date) {
+        String pattern = DateFormat.getBestDateTimePattern(Locale.getDefault(), "MM/dd/YYYY");
+        return new SimpleDateFormat(pattern, Locale.getDefault()).format(date.getTime());
     }
 }


### PR DESCRIPTION
### Fix
Update the date format from `MMM d` to `MM/dd/YYYY` used in the note list during search.  The updated format switches `MM`/`dd`/`YYYY` and replaces `/` with `.` based on locale.  See the screenshots below for illustration.

![update_date_format](https://user-images.githubusercontent.com/3827611/70479073-d68b6700-1a99-11ea-85e2-c43cd7e6843d.png)

### Test
1. Set device locale to ***English (United States)***.
2. Tap ***Search*** in top app bar.
3. Enter text in search field or tap recent search in list.
4. Notice date format is `MM/dd/YYYY`.
5. Set device locale to ***Deutsch (Deutschland)***.
6. Tap ***Notizen durchsuchen*** in top app bar.
7. Enter text in search field or tap recent search in list.
8. Notice date format is `dd.MM.YYYY`.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.