### PR TITLE
Crash Date Pattern

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
@@ -26,7 +26,7 @@ public class DateTimeUtils {
     }
 
     public static String getDateTextNumeric(Calendar date) {
-        String pattern = DateFormat.getBestDateTimePattern(Locale.getDefault(), "MM/dd/YYYY");
+        String pattern = DateFormat.getBestDateTimePattern(Locale.getDefault(), "MM/dd/yyyy");
         return new SimpleDateFormat(pattern, Locale.getDefault()).format(date.getTime());
     }
 }


### PR DESCRIPTION
### Fix
Update the year character in the numeric date pattern from `Y` to `y`.  `SimpleDateFormat` does not support `Y` below Java 8.  Android does not support Java 8 until API 24.  Therefore, devices running API 23 crash due to the `Y` character.  Changing to `y` supports all API versions allowed by Simplenote.

### Test
1. Launch app with device on API 23 (Android 6.0).
2. Notice app does not crash.
3. Tap ***Search*** in top app bar.
4. Notice year is shown in date for each note.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.