### PR TITLE
Queued Local Deletion

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.4
 -----
- 
+* Fixed sync bug with deleting tags and emptying trash
+
 2.3
 -----
 * Added search sorting by date created, date modified, and alphabetically

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -68,7 +68,7 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Automattic and WordPress dependencies
-    implementation 'com.simperium.android:simperium:0.9.2'
+    implementation 'com.simperium.android:simperium:0.9.3'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.0'
 


### PR DESCRIPTION
### Fix
Update the `simperium` dependency, which includes changes to notes and tags that are queued for local deletion so they are removed and a change event is sent to the server as described in https://github.com/Simperium/simperium-android/pull/214.  These changes close https://github.com/Automattic/simplenote-android/issues/279 and close https://github.com/Automattic/simplenote-android/issues/340.

### Test
#### Empty Trash
1. Web: Send one or more notes to ***Trash***.
2. App: Open navigation drawer.
3. App: Tap ***Trash*** in navigation drawer.
4. App: Tap ***Empty trash*** action in top app bar.
5. App: Tap ***Yes*** button in ***Empty trash*** dialog.
6. Notice ***Trash*** is emptied on app and web.

#### Delete Tag
1. Web: Create tag.
2. App: Open navigation drawer.
3. App: Tap ***Edit*** button in ***Tags*** header.
4. App: Tap ***Delete tag*** button next to tag from Step 1.
5. App: Tap ***Yes*** button in ***Delete tag*** dialog.
6. Notice tag is deleted on app and web.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 29ba5bb4 with:
> Fixed sync bug with deleting tags and emptying trash