### PR TITLE
Add Tags Scrollbar

### DIFF
--- a/Simplenote/src/main/res/layout/fragment_tags_list.xml
+++ b/Simplenote/src/main/res/layout/fragment_tags_list.xml
@@ -12,7 +12,9 @@
         android:divider="?attr/listDividerDrawable"
         android:dividerHeight="@dimen/divider_height"
         android:layout_height="match_parent"
-        android:layout_width="match_parent">
+        android:layout_width="match_parent"
+        android:scrollbarStyle="outsideOverlay"
+        android:scrollbars="vertical">
     </com.automattic.simplenote.widgets.EmptyViewRecyclerView>
 
     <include


### PR DESCRIPTION
### Fix
Add a scrollbar to the list view in the ***Edit tags*** screen.

### Test
The scrollbar is only shown if the number of items in the list overflows the screen.  Rotating the device into landscape can help minimize the screen size if portrait orientation is too large.  Contact me if you would like to use a test account with many tags.
1. Open navigation drawer.
2. Tap ***Edit*** button in ***Tags*** header.
3. Scroll list up/down.
4. Notice scrollbar.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.