### PR TITLE
Set image resource from Fragment

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -408,6 +408,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
         mSortDirection = sortLayoutContainer.findViewById(R.id.sort_direction);
         ImageView sortDirectionSwitch = sortLayoutContainer.findViewById(R.id.sort_direction_switch);
+        sortDirectionSwitch.setImageResource(R.drawable.ic_sort_order_24dp);
         sortDirectionSwitch.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {


### PR DESCRIPTION
### Fix
When the user searches for a note or tag, the sort icon no longer has a cut in the upper left corner to close #911 .

![Captura de Pantalla 2020-01-14 a la(s) 16 24 43](https://user-images.githubusercontent.com/2581647/72375829-926c3180-36eb-11ea-8a97-2126008896e7.png)

This is an example with a **Pixel 2 API 28**  and **Nexus 5 API 23**

### Test
1. Tap **All Notes** in navigation drawer.
2. Tap **Search** action in top app bar.
3. Enter text marching multiple notes.
4. **Submit** search query.
5. Notice sort image is not cutting off

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
