### PR TITLE
Issue/907 Restore sort order from Settings after app closed

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -561,13 +561,14 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mBucketPreferences.removeOnNetworkChangeListener(this);
         mBucketPreferences.removeOnSaveObjectListener(this);
         mBucketPreferences.stop();
+
+        // Restore sort order from Settings.
+        mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER, String.valueOf(mPreferenceSortOrder)).apply();
     }
 
     @Override
     public void onDetach() {
         super.onDetach();
-        // Restore sort order from Settings.
-        mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER, String.valueOf(mPreferenceSortOrder)).apply();
         // Reset the active callbacks interface to the dummy implementation.
         mCallbacks = sCallbacks;
     }


### PR DESCRIPTION
### Fix
The note list sort order is not affected by the search sort order to close #907. The line to restore the sort order from Settings was moved from **onDetach** to **onPause()** because onDetach is never called in any of this cases (Test 1, Test 2 and Test3).  With this change, the behavior that the app had in the case of Test 1 and Test 2 changes. Now it does not show the order the user chose before pause the app but instead shows the original order that comes from Settings.

### Test 1

1. Open the app and confirm the note sort order (under Settings > Sort order).
2. Start a new search.
3. Enter any text to search your notes.
4. Notice that the search results use the same sort order as your notes list.
5. Change the sort order and/or direction for the search.
6. Tap the back arrow to go back to the notes list and notice that it has the original note sort order.
7. Start another new search.
8. Enter any text to search your notes.
9. Change the sort order and/or direction for the search.
10. **Force close the app.**
11. Reopen the app and notice that the notes list is using the selected sort order and direction from Settings > Sort order.

### Test 2

1. Open the app and confirm the note sort order (under Settings > Sort order).
2. Start a new search.
3. Enter any text to search your notes.
4. Notice that the search results use the same sort order as your notes list.
5. Change the sort order and/or direction for the search.
6. Tap the back arrow to go back to the notes list and notice that it has the original note sort order.
7. Start another new search.
8. Enter any text to search your notes.
9. Change the sort order and/or direction for the search.
10. **Press Home Button.**
11. Reopen the app and notice that the search result changed again to the sort order and direction from Settings > Sort order.
12. Tap the back arrow to go back to the notes list and notice that it has the original note sort order.


### Test 3

1. Open the app and confirm the note sort order (under Settings > Sort order).
2. Start a new search.
3. Enter any text to search your notes.
4. Notice that the search results use the same sort order as your notes list.
5. Change the sort order and/or direction for the search.
6. Tap the back arrow to go back to the notes list and notice that it has the original note sort order.
7. Start another new search.
8. Enter any text to search your notes.
9. Change the sort order and/or direction for the search.
10. **Press Overview Button.**
11. Press the Simple Note window to show the search results.
11. Notice that the search result changed again to the sort order and direction from Settings > Sort order.
12. Tap the back arrow to go back to the notes list and notice that it has the original note sort order.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
