### PR TITLE
Diff Match Patch

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -68,7 +68,7 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Automattic and WordPress dependencies
-    implementation 'com.simperium.android:simperium:0.9.2'
+    implementation 'com.simperium.android:simperium:0.9.4'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.0'
 


### PR DESCRIPTION
### Fix
Update the `simperium` dependency, which includes updating the `diff_match_patch` class as described in https://github.com/Simperium/simperium-android/pull/215 and ignoring corrupted ghost objects as described in https://github.com/Simperium/simperium-android/pull/216.

### Test
The test requires corrupting a note to see if Simplenote Android can handle it.  In order to corrupt a note, checkout commit `9361b81` in the `simplenote-ios` repository to use for the Simplenote iOS steps below.  The steps for Simplenote Web can be performed at https://app.simplenote.com.
1. Android: Open app.
2. iOS: Open app.
3. Web: Open app.
4. iOS: Tap ***New note*** action in top app bar.
5. iOS: Insert `🙂🙁` in note.
6. Android: Notice `🙂🙁` in note list.
7. iOS: Insert `😱` between `🙂` and `🙁` in note.
8. iOS: Notice app crashes.
9. Android: Notice `🙂🐨null)�` in note list.
10. Web: Notice `🙂�(null)�` in note list.
11. Web: Open `🙂�(null)�` note.
12. Web: Add "test" to end of `🙂�(null)�` note.
13. Android: Open `🙂🐨null)�` note.
14. Android: Notice `🙂(null)🙁test` in note.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.