### PR TITLE
Update Websocket Threading

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.4
 -----
 * Fixed sync bug with deleting tags and emptying trash
+* Fixed networking bug causing interface slowness
 
 2.3
 -----

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -68,7 +68,7 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Automattic and WordPress dependencies
-    implementation 'com.simperium.android:simperium:0.9.4'
+    implementation 'com.simperium.android:simperium:0.9.5'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.0'
 


### PR DESCRIPTION
### Fix
Update the `simperium` dependency from `0.9.4` to `0.9.5`, which includes updating the `AsyncWebSocketProvider` class to avoid ANR (i.e. app-not-responding) events as described in https://github.com/Simperium/simperium-android/pull/217.

### Test
Since these changes have no user-facing aspect, smoke testing is all that is required.  The changes affect the networking protocol class so it's best to test creating and editing notes and tags to ensure syncing is working as expected across devices.  Using two emulators side-by-side is a good way to see if syncing is working.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in be9e8254 with:
> Fixed networking bug causing interface slowness