### PR TITLE
Update Keypad Layout

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     // Automattic and WordPress dependencies
     implementation 'com.simperium.android:simperium:0.9.5'
     implementation 'com.automattic:tracks:1.2'
-    implementation 'org.wordpress:passcodelock:2.0.1'
+    implementation 'org.wordpress:passcodelock:2.0.2'
 
     // Google Support
     implementation 'androidx.appcompat:appcompat:1.1.0'

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     // Automattic and WordPress dependencies
     implementation 'com.simperium.android:simperium:0.9.5'
     implementation 'com.automattic:tracks:1.2'
-    implementation 'org.wordpress:passcodelock:2.0.0'
+    implementation 'org.wordpress:passcodelock:2.0.1'
 
     // Google Support
     implementation 'androidx.appcompat:appcompat:1.1.0'

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -194,7 +194,7 @@
         <item name="android:textSize">@dimen/passcodelock_pin_text_size</item>
     </style>
 
-    <style name="PasscodeKeyboardButtonStyle" parent="Widget.MaterialComponents.Button">
+    <style name="PasscodeKeyboardButtonStyle" parent="@android:style/Widget.Button">
         <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
         <item name="android:layout_marginBottom">@dimen/padding_large</item>
         <item name="android:layout_marginLeft">@dimen/padding_extra_extra_large</item>


### PR DESCRIPTION
### Fix
Update the `passcodelock` dependency from `2.0.0` to `2.0.2`, which includes updating the numeric keypad in the passcode layout to be centered as described in https://github.com/wordpress-mobile/PasscodeLock-Android/pull/62 to close https://github.com/Automattic/simplenote-android/issues/925.  See the screenshots below for illustration.

![update_passcode_center_](https://user-images.githubusercontent.com/3827611/73460129-2d444d00-4335-11ea-9408-15e2e02e7658.png)

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item.
3. Tap ***Turn PIN lock on*** under ***PIN Lock*** section.
4. Notice updated layout with keypad centered.
5. Enter PIN lock passcode.
6. Reenter PIN lock passcode.
7. Exit app.
8. Wait five seconds.
9. Open app.
10. Notice updated layout with keypad centered.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.