### PR TITLE
Note Options History

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/HistoryBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/HistoryBottomSheetDialog.java
@@ -114,7 +114,7 @@ public class HistoryBottomSheetDialog extends BottomSheetDialogBase {
                     mListener.onHistoryUpdateNote(revisedNote.getContent());
                 }
 
-                mHistoryDate.setText(DateTimeUtils.getDateText(requireContext(), noteDate));
+                mHistoryDate.setText(DateTimeUtils.getDateTextString(requireContext(), noteDate));
             }
 
             @Override
@@ -188,7 +188,7 @@ public class HistoryBottomSheetDialog extends BottomSheetDialogBase {
         if (totalRevs > 0) {
             mHistorySeekBar.setMax(totalRevs);
             mHistorySeekBar.setProgress(totalRevs);
-            mHistoryDate.setText(DateTimeUtils.getDateText(requireContext(), mNote.getModificationDate()));
+            mHistoryDate.setText(DateTimeUtils.getDateTextString(requireContext(), mNote.getModificationDate()));
             mLoadingView.setVisibility(View.GONE);
             mSliderView.setVisibility(View.VISIBLE);
         } else {

--- a/Simplenote/src/main/java/com/automattic/simplenote/HistoryBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/HistoryBottomSheetDialog.java
@@ -32,6 +32,7 @@ public class HistoryBottomSheetDialog extends BottomSheetDialogBase {
     private Note mNote;
     private SeekBar mHistorySeekBar;
     private TextView mHistoryDate;
+    private View mButtonRestore;
     private View mErrorText;
     private View mLoadingView;
     private View mProgressBar;
@@ -108,10 +109,12 @@ public class HistoryBottomSheetDialog extends BottomSheetDialogBase {
                 if (progress == mNoteRevisionsList.size() && mNote != null) {
                     mListener.onHistoryUpdateNote(mNote.getContent());
                     noteDate = mNote.getModificationDate();
+                    mButtonRestore.setEnabled(false);
                 } else if (progress < mNoteRevisionsList.size() && mNoteRevisionsList.get(progress) != null) {
                     Note revisedNote = mNoteRevisionsList.get(progress);
                     noteDate = revisedNote.getModificationDate();
                     mListener.onHistoryUpdateNote(revisedNote.getContent());
+                    mButtonRestore.setEnabled(true);
                 }
 
                 if (noteDate != null) {
@@ -140,8 +143,8 @@ public class HistoryBottomSheetDialog extends BottomSheetDialogBase {
             }
         });
 
-        View restoreHistoryButton = history.findViewById(R.id.restore_history_button);
-        restoreHistoryButton.setOnClickListener(new View.OnClickListener() {
+        mButtonRestore = history.findViewById(R.id.restore_history_button);
+        mButtonRestore.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 mDidTapButton = true;

--- a/Simplenote/src/main/java/com/automattic/simplenote/HistoryBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/HistoryBottomSheetDialog.java
@@ -114,7 +114,12 @@ public class HistoryBottomSheetDialog extends BottomSheetDialogBase {
                     mListener.onHistoryUpdateNote(revisedNote.getContent());
                 }
 
-                mHistoryDate.setText(DateTimeUtils.getDateTextString(requireContext(), noteDate));
+                if (noteDate != null) {
+                    mHistoryDate.setText(DateTimeUtils.getDateTextString(requireContext(), noteDate));
+                    mHistoryDate.setVisibility(View.VISIBLE);
+                } else {
+                    mHistoryDate.setVisibility(View.GONE);
+                }
             }
 
             @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DateTimeUtils.java
@@ -29,4 +29,12 @@ public class DateTimeUtils {
         String pattern = DateFormat.getBestDateTimePattern(Locale.getDefault(), "MM/dd/yyyy");
         return new SimpleDateFormat(pattern, Locale.getDefault()).format(date.getTime());
     }
+
+    public static String getDateTextString(Context context, Calendar calendar) {
+        String pattern = DateFormat.getBestDateTimePattern(
+                Locale.getDefault(),
+                DateFormat.is24HourFormat(context) ? "MMM dd, yyyy, H:mm" : "MMM dd, yyyy, h:mm"
+        );
+        return new SimpleDateFormat(pattern, Locale.getDefault()).format(calendar.getTime());
+    }
 }

--- a/Simplenote/src/main/res/color/accent_text_button_disabled_selector.xml
+++ b/Simplenote/src/main/res/color/accent_text_button_disabled_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:color="@color/text_button_disabled" android:state_enabled="false"/>
+    <item android:color="?attr/colorAccent"/>
+
+</selector>

--- a/Simplenote/src/main/res/layout/bottom_sheet_history.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_history.xml
@@ -44,19 +44,13 @@
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
             android:id="@+id/history_date"
-            android:gravity="start"
+            android:gravity="center_vertical|start"
             android:layout_height="wrap_content"
             android:layout_width="match_parent"
+            android:minHeight="@dimen/bottom_sheet_row_height"
             tools:text="Jan 27, 2020, 13:37"
             style="@style/Theme.Simplestyle.BottomSheetDialog.Label">
         </com.automattic.simplenote.widgets.RobotoRegularTextView>
-
-        <View
-            android:id="@+id/info_divider"
-            android:background="?attr/dividerColor"
-            android:layout_height="1dp"
-            android:layout_width="match_parent">
-        </View>
 
         <SeekBar
             android:id="@+id/seek_bar"

--- a/Simplenote/src/main/res/layout/bottom_sheet_history.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_history.xml
@@ -47,12 +47,8 @@
             android:gravity="start"
             android:layout_height="wrap_content"
             android:layout_width="match_parent"
-            android:paddingBottom="@dimen/padding_extra_large"
-            android:paddingEnd="@dimen/padding_large"
-            android:paddingStart="@dimen/padding_large"
-            android:paddingTop="@dimen/padding_extra_large"
-            android:textSize="14sp"
-            tools:text="March 1, 2016 13:30">
+            tools:text="Jan 27, 2020, 13:37"
+            style="@style/Theme.Simplestyle.BottomSheetDialog.Label">
         </com.automattic.simplenote.widgets.RobotoRegularTextView>
 
         <View

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -83,6 +83,12 @@
         <item name="colorPrimaryDark">@color/blue_dark</item>
     </style>
 
+    <style name="Theme.Simplestyle.BottomSheetDialog.Label" parent="Theme.Simplestyle.BottomSheetDialog">
+        <item name="android:ellipsize">end</item>
+        <item name="android:padding">@dimen/padding_large</item>
+        <item name="android:textColor">@color/text_title_dark</item>
+    </style>
+
     <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.Simplestyle.BottomSheetDialog">
         <item name="android:textColor">@android:color/white</item>
     </style>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -87,6 +87,7 @@
         <item name="android:ellipsize">end</item>
         <item name="android:padding">@dimen/padding_large</item>
         <item name="android:textColor">@color/text_title_dark</item>
+        <item name="android:textSize">@dimen/text_bottom_sheet</item>
     </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.Simplestyle.BottomSheetDialog">

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -35,6 +35,7 @@
     <dimen name="passcodelock_pin_text_size">34dp</dimen>
 
     <!-- SIZE -->
+    <dimen name="bottom_sheet_row_height">56dp</dimen>
     <dimen name="card_radius">2dp</dimen>
     <dimen name="cell_widget">40dp</dimen>
     <dimen name="divider_height">1dp</dimen>
@@ -49,6 +50,7 @@
     <dimen name="passcode_width">480dp</dimen>
     <dimen name="sort_switch_width">40dp</dimen>
     <dimen name="tag_input_height">56dp</dimen>
+    <dimen name="text_bottom_sheet">16sp</dimen>
     <dimen name="text_content">14sp</dimen>
     <dimen name="text_content_title">16sp</dimen>
     <dimen name="text_date">14sp</dimen>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -116,6 +116,7 @@
         <item name="android:ellipsize">end</item>
         <item name="android:padding">@dimen/padding_large</item>
         <item name="android:textColor">@color/text_title_light</item>
+        <item name="android:textSize">@dimen/text_bottom_sheet</item>
     </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.MaterialComponents.Light.BottomSheetDialog">

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -84,7 +84,7 @@
     </style>
 
     <style name="Button.Flat" parent="Widget.MaterialComponents.Button.TextButton">
-        <item name="android:textColor">?attr/colorAccent</item>
+        <item name="android:textColor">@color/accent_text_button_disabled_selector</item>
     </style>
 
     <style name="Button.Flat.Icon" parent="Widget.MaterialComponents.Button.TextButton.Icon">

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -112,6 +112,12 @@
         <item name="colorPrimaryDark">@color/blue_dark</item>
     </style>
 
+    <style name="Theme.Simplestyle.BottomSheetDialog.Label" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
+        <item name="android:ellipsize">end</item>
+        <item name="android:padding">@dimen/padding_large</item>
+        <item name="android:textColor">@color/text_title_light</item>
+    </style>
+
     <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
         <item name="android:textColor">@color/text_title_light</item>
     </style>


### PR DESCRIPTION
### Fix
Update the history bottom sheet dialog with month, day, year, and time for the date as well as set the ***Restore*** button enabled/disabled when the selected revision is different/same as the current revision, respectively.  The order and format of the items in the date follow the device's locale.  The time of the date follows the device's setting for 12-hour or 24-hour time.  If the modification date cannot be retrieved from the note, the date view is hidden.  See the screenshots below for illustration.

![note_options_history_light](https://user-images.githubusercontent.com/3827611/73601806-46abeb80-4525-11ea-9e14-0b212eafee54.png)

![note_options_history_dark](https://user-images.githubusercontent.com/3827611/73601808-4875af00-4525-11ea-8a06-ca4f100245e5.png)

### Test
The ***Languages*** and ***User 24-hour format*** settings on the device will produce different results.  Try changing those settings while following the steps below.
1. Tap any note in list.
2. Tap ***History*** action in app bar.
3. Notice date format based on ***Languages*** and ***User 24-hour format*** settings.
4. Notice ***Restore*** button is disabled.
5. Move revision progress bar.
6. Notice ***Restore*** button is enabled.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.