### PR TITLE
Note Options Information

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.4
 -----
+* Updated note information with date modified, date created, word count, and character count
 * Fixed sync bug with deleting tags and emptying trash
 * Fixed networking bug causing interface slowness
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
@@ -1,27 +1,19 @@
 package com.automattic.simplenote;
 
 import android.content.DialogInterface;
-import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.view.HapticFeedbackConstants;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.CompoundButton;
-import android.widget.ImageButton;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.widget.SwitchCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
-import androidx.preference.PreferenceManager;
 
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.utils.DateTimeUtils;
-import com.automattic.simplenote.utils.PrefUtils;
 
 import java.text.NumberFormat;
 
@@ -29,15 +21,11 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
     private static final String TAG = InfoBottomSheetDialog.class.getSimpleName();
 
     private Fragment mFragment;
-    private ImageButton mCopyButton;
-    private ImageButton mShareButton;
     private InfoSheetListener mListener;
-    private TextView mInfoLinkTitle;
-    private TextView mInfoLinkUrl;
-    private TextView mInfoModifiedDate;
-    private TextView mInfoWords;
-    private SwitchCompat mInfoMarkdownSwitch;
-    private SwitchCompat mInfoPinSwitch;
+    private TextView mCountCharacters;
+    private TextView mCountWords;
+    private TextView mDateTimeCreated;
+    private TextView mDateTimeModified;
 
     public InfoBottomSheetDialog(@NonNull Fragment fragment, @NonNull final InfoSheetListener infoSheetListener) {
         mFragment = fragment;
@@ -48,74 +36,10 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View infoView = inflater.inflate(R.layout.bottom_sheet_info, null, false);
-        mInfoModifiedDate = infoView.findViewById(R.id.info_modified_date_text);
-        mInfoWords = infoView.findViewById(R.id.info_words_text);
-        mInfoLinkUrl = infoView.findViewById(R.id.info_public_link_url);
-        mInfoLinkTitle = infoView.findViewById(R.id.info_public_link_title);
-
-        mInfoPinSwitch = infoView.findViewById(R.id.info_pin_switch);
-        mInfoPinSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                mListener.onInfoPinSwitchChanged(isChecked);
-            }
-        });
-
-        mInfoMarkdownSwitch = infoView.findViewById(R.id.info_markdown_switch);
-        mInfoMarkdownSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                if (!mFragment.isAdded()){
-                    return;
-                }
-
-                mListener.onInfoMarkdownSwitchChanged(isChecked);
-
-                // Set preference so that next new note will have markdown enabled
-                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mFragment.getActivity());
-                SharedPreferences.Editor editor = prefs.edit();
-                editor.putBoolean(PrefUtils.PREF_MARKDOWN_ENABLED, isChecked);
-                editor.apply();
-            }
-        });
-
-        mCopyButton = infoView.findViewById(R.id.info_copy_link_button);
-        mCopyButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                mListener.onInfoCopyLinkClicked();
-            }
-        });
-        mCopyButton.setOnLongClickListener(new View.OnLongClickListener() {
-            @Override
-            public boolean onLongClick(View v) {
-                if (v.isHapticFeedbackEnabled()) {
-                    v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
-                }
-
-                Toast.makeText(getContext(), requireContext().getString(R.string.copy), Toast.LENGTH_SHORT).show();
-                return false;
-            }
-        });
-
-        mShareButton = infoView.findViewById(R.id.info_share_button);
-        mShareButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                mListener.onInfoShareLinkClicked();
-            }
-        });
-        mShareButton.setOnLongClickListener(new View.OnLongClickListener() {
-            @Override
-            public boolean onLongClick(View v) {
-                if (v.isHapticFeedbackEnabled()) {
-                    v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
-                }
-
-                Toast.makeText(getContext(), requireContext().getString(R.string.share), Toast.LENGTH_SHORT).show();
-                return false;
-            }
-        });
+        mCountCharacters = infoView.findViewById(R.id.count_characters);
+        mCountWords = infoView.findViewById(R.id.count_words);
+        mDateTimeCreated = infoView.findViewById(R.id.date_time_created);
+        mDateTimeModified = infoView.findViewById(R.id.date_time_modified);
 
         if (getDialog() != null) {
             getDialog().setOnDismissListener(new DialogInterface.OnDismissListener() {
@@ -134,25 +58,10 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
     public void show(FragmentManager manager, Note note) {
         if (mFragment.isAdded()) {
             showNow(manager, TAG);
-
-            String date = DateTimeUtils.getDateText(requireContext(), note.getModificationDate());
-            mInfoModifiedDate.setText(String.format(mFragment.getString(R.string.modified_time), date));
-            mInfoPinSwitch.setChecked(note.isPinned());
-            mInfoMarkdownSwitch.setChecked(note.isMarkdownEnabled());
-            mInfoWords.setText(getCombinedCount(note.getContent()));
-
-            if (note.isPublished()) {
-                mInfoLinkTitle.setText(mFragment.getString(R.string.public_link));
-                mInfoLinkUrl.setText(note.getPublishedUrl());
-                mInfoLinkUrl.setVisibility(View.VISIBLE);
-                mCopyButton.setVisibility(View.VISIBLE);
-                mShareButton.setVisibility(View.GONE);
-            } else {
-                mInfoLinkTitle.setText(mFragment.getString(R.string.note_not_published));
-                mInfoLinkUrl.setVisibility(View.GONE);
-                mCopyButton.setVisibility(View.GONE);
-                mShareButton.setVisibility(View.VISIBLE);
-            }
+            mCountCharacters.setText(getCharactersCount(note.getContent()));
+            mCountWords.setText(getWordCount(note.getContent()));
+            mDateTimeCreated.setText(DateTimeUtils.getDateTextString(requireContext(), note.getCreationDate()));
+            mDateTimeModified.setText(DateTimeUtils.getDateTextString(requireContext(), note.getModificationDate()));
         }
     }
 
@@ -161,17 +70,12 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
     }
 
     private String getWordCount(String content) {
-        int numWords = (content.trim().length() == 0) ? 0 : content.trim().split("([\\W]+)").length;
-        String wordCountString = mFragment.getResources().getQuantityString(R.plurals.word_count, numWords);
-        String formattedWordCount = NumberFormat.getInstance().format(numWords);
-        return String.format("%s %s", formattedWordCount, wordCountString);
+        int words = (content.trim().length() == 0) ? 0 : content.trim().split("([\\W]+)").length;
+        return NumberFormat.getInstance().format(words);
     }
 
     private String getCharactersCount(String content) {
-        int numChars = content.length();
-        String charCount = NumberFormat.getInstance().format(numChars);
-        String charCountString = mFragment.getResources().getQuantityString(R.plurals.char_count, numChars);
-        return String.format("%s %s", charCount, charCountString);
+        return NumberFormat.getInstance().format(content.length());
     }
 
     public interface InfoSheetListener {

--- a/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
@@ -55,10 +55,6 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
         }
     }
 
-    private String getCombinedCount(String content) {
-        return String.format("%s\n%s", getWordCount(content), getCharactersCount(content));
-    }
-
     private String getWordCount(String content) {
         int words = (content.trim().length() == 0) ? 0 : content.trim().split("([\\W]+)").length;
         return NumberFormat.getInstance().format(words);

--- a/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
@@ -1,6 +1,5 @@
 package com.automattic.simplenote;
 
-import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -21,15 +20,13 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
     private static final String TAG = InfoBottomSheetDialog.class.getSimpleName();
 
     private Fragment mFragment;
-    private InfoSheetListener mListener;
     private TextView mCountCharacters;
     private TextView mCountWords;
     private TextView mDateTimeCreated;
     private TextView mDateTimeModified;
 
-    public InfoBottomSheetDialog(@NonNull Fragment fragment, @NonNull final InfoSheetListener infoSheetListener) {
+    public InfoBottomSheetDialog(@NonNull Fragment fragment) {
         mFragment = fragment;
-        mListener = infoSheetListener;
     }
 
     @Nullable
@@ -42,13 +39,6 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
         mDateTimeModified = infoView.findViewById(R.id.date_time_modified);
 
         if (getDialog() != null) {
-            getDialog().setOnDismissListener(new DialogInterface.OnDismissListener() {
-                @Override
-                public void onDismiss(DialogInterface dialog) {
-                    mListener.onInfoDismissed();
-                }
-            });
-
             getDialog().setContentView(infoView);
         }
 
@@ -76,13 +66,5 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
 
     private String getCharactersCount(String content) {
         return NumberFormat.getInstance().format(content.length());
-    }
-
-    public interface InfoSheetListener {
-        void onInfoCopyLinkClicked();
-        void onInfoDismissed();
-        void onInfoMarkdownSwitchChanged(boolean isSwitchedOn);
-        void onInfoPinSwitchChanged(boolean isSwitchedOn);
-        void onInfoShareLinkClicked();
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -494,7 +494,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         inflater.inflate(R.menu.note_editor, menu);
 
         if (mNote != null) {
-            MenuItem viewPublishedNoteItem = menu.findItem(R.id.menu_view_info);
+            MenuItem viewPublishedNoteItem = menu.findItem(R.id.menu_info);
             viewPublishedNoteItem.setVisible(true);
 
             MenuItem trashItem = menu.findItem(R.id.menu_delete).setTitle(R.string.undelete);
@@ -514,14 +514,14 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
-            case R.id.menu_view_info:
-                showInfo();
-                return true;
             case R.id.menu_checklist:
                 insertChecklist();
                 return true;
             case R.id.menu_history:
                 showHistory();
+                return true;
+            case R.id.menu_info:
+                showInfo();
                 return true;
             case R.id.menu_share:
                 shareNote();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -83,7 +83,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         SimplenoteEditText.OnSelectionChangedListener,
         ShareBottomSheetDialog.ShareSheetListener,
         HistoryBottomSheetDialog.HistorySheetListener,
-        InfoBottomSheetDialog.InfoSheetListener,
         SimplenoteEditText.OnCheckboxToggledListener {
 
     public static final String ARG_ITEM_ID = "item_id";
@@ -271,7 +270,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mInfoBottomSheet = new InfoBottomSheetDialog(this, this);
+        mInfoBottomSheet = new InfoBottomSheetDialog(this);
         mShareBottomSheet = new ShareBottomSheetDialog(this, this);
         mHistoryBottomSheet = new HistoryBottomSheetDialog(this, this);
 
@@ -940,62 +939,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onHistoryUpdateNote(String content) {
         mContentEditText.setText(content);
-    }
-
-    /**
-     * Info bottom sheet listeners
-     */
-
-    @Override
-    public void onInfoPinSwitchChanged(boolean isSwitchedOn) {
-        NoteUtils.setNotePin(mNote, isSwitchedOn);
-    }
-
-    @Override
-    public void onInfoMarkdownSwitchChanged(boolean isSwitchedOn) {
-        mIsMarkdownEnabled = isSwitchedOn;
-        Activity activity = getActivity();
-
-        if (activity instanceof NoteEditorActivity) {
-
-            NoteEditorActivity editorActivity = (NoteEditorActivity) activity;
-            if (mIsMarkdownEnabled) {
-
-                editorActivity.showTabs();
-
-                if (mNoteMarkdownFragment == null) {
-                    // Get markdown fragment and update content
-                    mNoteMarkdownFragment =
-                            editorActivity.getNoteMarkdownFragment();
-                    mNoteMarkdownFragment.updateMarkdown(mContentEditText.getPlainTextContent());
-                }
-            } else {
-                editorActivity.hideTabs();
-            }
-        } else if (activity instanceof NotesActivity) {
-            setMarkdownEnabled(mIsMarkdownEnabled);
-            ((NotesActivity) getActivity()).setMarkdownShowing(false);
-        }
-
-        saveNote();
-    }
-
-    @Override
-    public void onInfoCopyLinkClicked() {
-        copyToClipboard(mNote.getPublishedUrl());
-        Toast.makeText(getActivity(), getString(R.string.link_copied), Toast.LENGTH_SHORT).show();
-    }
-
-    @Override
-    public void onInfoShareLinkClicked() {
-        if (mInfoBottomSheet != null) {
-            mInfoBottomSheet.dismiss();
-        }
-        showShareSheet();
-    }
-
-    @Override
-    public void onInfoDismissed() {
     }
 
     protected void saveNote() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -48,7 +48,7 @@ public class NoteMarkdownFragment extends Fragment {
         }
 
         if (mNote != null) {
-            MenuItem viewPublishedNoteItem = menu.findItem(R.id.menu_view_info);
+            MenuItem viewPublishedNoteItem = menu.findItem(R.id.menu_info);
             viewPublishedNoteItem.setVisible(true);
 
             MenuItem trashItem = menu.findItem(R.id.menu_delete).setTitle(R.string.undelete);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -756,7 +756,7 @@ public class NotesActivity extends AppCompatActivity implements
         } else {
             menu.findItem(R.id.menu_search).setVisible(true);
             menu.findItem(R.id.menu_share).setVisible(false);
-            menu.findItem(R.id.menu_view_info).setVisible(false);
+            menu.findItem(R.id.menu_info).setVisible(false);
             menu.findItem(R.id.menu_checklist).setVisible(false);
             menu.findItem(R.id.menu_history).setVisible(false);
             menu.findItem(R.id.menu_markdown_preview).setVisible(false);
@@ -900,7 +900,7 @@ public class NotesActivity extends AppCompatActivity implements
             menu.findItem(R.id.menu_markdown_preview).setVisible(mCurrentNote.isMarkdownEnabled());
             menu.findItem(R.id.menu_share).setVisible(true);
             menu.findItem(R.id.menu_sidebar).setVisible(true);
-            menu.findItem(R.id.menu_view_info).setVisible(true);
+            menu.findItem(R.id.menu_info).setVisible(true);
         } else {
             menu.findItem(R.id.menu_checklist).setVisible(false);
             menu.findItem(R.id.menu_delete).setVisible(false);
@@ -908,7 +908,7 @@ public class NotesActivity extends AppCompatActivity implements
             menu.findItem(R.id.menu_markdown_preview).setVisible(false);
             menu.findItem(R.id.menu_share).setVisible(false);
             menu.findItem(R.id.menu_sidebar).setVisible(false);
-            menu.findItem(R.id.menu_view_info).setVisible(false);
+            menu.findItem(R.id.menu_info).setVisible(false);
         }
 
         menu.findItem(R.id.menu_empty_trash).setVisible(false);

--- a/Simplenote/src/main/res/layout/bottom_sheet_history.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_history.xml
@@ -47,7 +47,6 @@
             android:gravity="center_vertical|start"
             android:layout_height="wrap_content"
             android:layout_width="match_parent"
-            android:minHeight="@dimen/bottom_sheet_row_height"
             tools:text="Jan 27, 2020, 13:37"
             style="@style/Theme.Simplestyle.BottomSheetDialog.Label">
         </com.automattic.simplenote.widgets.RobotoRegularTextView>

--- a/Simplenote/src/main/res/layout/bottom_sheet_history.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_history.xml
@@ -44,7 +44,6 @@
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
             android:id="@+id/history_date"
-            android:gravity="center_vertical|start"
             android:layout_height="wrap_content"
             android:layout_width="match_parent"
             tools:text="Jan 27, 2020, 13:37"

--- a/Simplenote/src/main/res/layout/bottom_sheet_info.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_info.xml
@@ -1,142 +1,112 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<RelativeLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
+    android:orientation="vertical"
     android:theme="@style/Theme.Simplestyle.BottomSheetDialog">
 
+    <com.automattic.simplenote.widgets.RobotoRegularTextView
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:padding="@dimen/padding_large"
+        android:text="@string/information"
+        android:textColor="?attr/notePreviewColor"
+        style="@style/Theme.Simplestyle.BottomSheetDialog.Label">
+    </com.automattic.simplenote.widgets.RobotoRegularTextView>
+
     <LinearLayout
-        android:id="@+id/linearDateWordCountInfo"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
         android:orientation="horizontal">
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
-            android:id="@+id/info_modified_date_text"
-            android:gravity="center_vertical"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:layout_width="wrap_content"
-            android:paddingBottom="@dimen/padding_extra_large"
-            android:paddingEnd="@dimen/padding_large"
-            android:paddingStart="@dimen/padding_large"
-            android:paddingTop="@dimen/padding_extra_large"
-            tools:text="Modified Jan 1, 2015, 8:00AM">
+            android:layout_width="0dp"
+            android:text="@string/modified"
+            style="@style/Theme.Simplestyle.BottomSheetDialog.Label">
         </com.automattic.simplenote.widgets.RobotoRegularTextView>
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
-            android:id="@+id/info_words_text"
-            android:gravity="end"
-            android:layout_gravity="end"
+            android:id="@+id/date_time_modified"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:layout_width="wrap_content"
-            android:paddingBottom="@dimen/padding_extra_large"
-            android:paddingEnd="@dimen/padding_large"
-            android:paddingStart="@dimen/padding_large"
-            android:paddingTop="@dimen/padding_extra_large"
-            tools:text="101 words\n1010 characters">
+            tools:text="Jan 13, 2020, 22:21"
+            style="@style/Theme.Simplestyle.BottomSheetDialog.Value">
         </com.automattic.simplenote.widgets.RobotoRegularTextView>
 
     </LinearLayout>
 
-    <View
-        android:id="@+id/info_divider"
-        android:background="?attr/dividerColor"
-        android:layout_below="@id/linearDateWordCountInfo"
-        android:layout_height="1dp"
-        android:layout_width="match_parent">
-    </View>
-
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/info_pin_switch"
-        android:layout_below="@+id/info_divider"
+    <LinearLayout
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:paddingBottom="@dimen/padding_extra_large"
-        android:paddingEnd="@dimen/padding_large"
-        android:paddingStart="@dimen/padding_large"
-        android:paddingTop="@dimen/padding_extra_large"
-        android:text="@string/pin_to_top">
-    </androidx.appcompat.widget.SwitchCompat>
-
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/info_markdown_switch"
-        android:layout_below="@+id/info_pin_switch"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        android:paddingBottom="@dimen/padding_extra_large"
-        android:paddingEnd="@dimen/padding_large"
-        android:paddingStart="@dimen/padding_large"
-        android:paddingTop="@dimen/padding_extra_large"
-        android:text="@string/enable_markdown">
-    </androidx.appcompat.widget.SwitchCompat>
-
-    <RelativeLayout
-        android:layout_below="@id/info_markdown_switch"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        android:paddingBottom="@dimen/padding_extra_large"
-        android:paddingEnd="@dimen/padding_large"
-        android:paddingStart="@dimen/padding_large"
-        android:paddingTop="@dimen/padding_extra_large">
+        android:orientation="horizontal">
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
-            android:id="@+id/info_public_link_title"
-            android:layout_alignEnd="@+id/info_public_link_url"
-            android:layout_alignParentStart="true"
             android:layout_height="wrap_content"
-            android:layout_toStartOf="@id/info_share_button"
-            android:layout_width="wrap_content"
-            android:text="@string/public_link"
-            style="@style/Theme.Simplestyle.BottomSheetDialogText">
+            android:layout_weight="1"
+            android:layout_width="0dp"
+            android:text="@string/created"
+            style="@style/Theme.Simplestyle.BottomSheetDialog.Label">
         </com.automattic.simplenote.widgets.RobotoRegularTextView>
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
-            android:id="@+id/info_public_link_url"
-            android:layout_alignParentStart="true"
-            android:layout_below="@+id/info_public_link_title"
+            android:id="@+id/date_time_created"
             android:layout_height="wrap_content"
-            android:layout_toStartOf="@id/info_copy_link_button"
             android:layout_width="wrap_content"
-            tools:text="http://simp.ly/publish/fsfjksjd"
-            style="@style/Theme.Simplestyle.BottomSheetDialogText">
+            tools:text="Jan 13, 2020, 17:30"
+            style="@style/Theme.Simplestyle.BottomSheetDialog.Value">
         </com.automattic.simplenote.widgets.RobotoRegularTextView>
 
-        <ImageButton
-            android:id="@+id/info_copy_link_button"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/copy"
-            android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true"
-            android:layout_gravity="center|end"
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:orientation="horizontal">
+
+        <com.automattic.simplenote.widgets.RobotoRegularTextView
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/padding_large"
-            android:layout_width="wrap_content"
-            android:paddingEnd="@dimen/padding_large"
-            android:paddingStart="@dimen/padding_large"
-            android:src="@drawable/ic_copy_24dp"
-            android:tint="?iconTintColor">
-        </ImageButton>
+            android:layout_weight="1"
+            android:layout_width="0dp"
+            android:text="@string/words"
+            style="@style/Theme.Simplestyle.BottomSheetDialog.Label">
+        </com.automattic.simplenote.widgets.RobotoRegularTextView>
 
-        <ImageButton
-            android:id="@+id/info_share_button"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/share"
-            android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true"
+        <com.automattic.simplenote.widgets.RobotoRegularTextView
+            android:id="@+id/count_words"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/padding_large"
             android:layout_width="wrap_content"
-            android:paddingEnd="@dimen/padding_large"
-            android:paddingStart="@dimen/padding_large"
-            android:src="@drawable/ic_share_24dp"
-            android:tint="?iconTintColor"
-            tools:visibility="gone">
-        </ImageButton>
+            tools:text="123"
+            style="@style/Theme.Simplestyle.BottomSheetDialog.Value">
+        </com.automattic.simplenote.widgets.RobotoRegularTextView>
 
-    </RelativeLayout>
+    </LinearLayout>
 
-</RelativeLayout>
+    <LinearLayout
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:orientation="horizontal">
+
+        <com.automattic.simplenote.widgets.RobotoRegularTextView
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_width="0dp"
+            android:text="@string/characters"
+            style="@style/Theme.Simplestyle.BottomSheetDialog.Label">
+        </com.automattic.simplenote.widgets.RobotoRegularTextView>
+
+        <com.automattic.simplenote.widgets.RobotoRegularTextView
+            android:id="@+id/count_characters"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            tools:text="4,567"
+            style="@style/Theme.Simplestyle.BottomSheetDialog.Value">
+        </com.automattic.simplenote.widgets.RobotoRegularTextView>
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/Simplenote/src/main/res/menu/note_editor.xml
+++ b/Simplenote/src/main/res/menu/note_editor.xml
@@ -27,7 +27,7 @@
     <item
         android:id="@+id/menu_view_info"
         android:icon="@drawable/ic_info_24dp"
-        android:title="@string/note_info"
+        android:title="@string/information"
         app:showAsAction="always" />
 
     <item

--- a/Simplenote/src/main/res/menu/note_editor.xml
+++ b/Simplenote/src/main/res/menu/note_editor.xml
@@ -25,7 +25,7 @@
         app:showAsAction="always" />
 
     <item
-        android:id="@+id/menu_view_info"
+        android:id="@+id/menu_info"
         android:icon="@drawable/ic_info_24dp"
         android:title="@string/information"
         app:showAsAction="always" />

--- a/Simplenote/src/main/res/menu/note_markdown.xml
+++ b/Simplenote/src/main/res/menu/note_markdown.xml
@@ -31,7 +31,7 @@
         android:id="@+id/menu_view_info"
         android:enabled="false"
         android:icon="@drawable/ic_info_24dp"
-        android:title="@string/note_info"
+        android:title="@string/information"
         app:showAsAction="always"/>
 
     <item

--- a/Simplenote/src/main/res/menu/note_markdown.xml
+++ b/Simplenote/src/main/res/menu/note_markdown.xml
@@ -28,7 +28,7 @@
         app:showAsAction="always"/>
 
     <item
-        android:id="@+id/menu_view_info"
+        android:id="@+id/menu_info"
         android:enabled="false"
         android:icon="@drawable/ic_info_24dp"
         android:title="@string/information"

--- a/Simplenote/src/main/res/menu/notes_list.xml
+++ b/Simplenote/src/main/res/menu/notes_list.xml
@@ -46,7 +46,7 @@
         app:showAsAction="always"/>
 
     <item
-        android:id="@+id/menu_view_info"
+        android:id="@+id/menu_info"
         android:icon="@drawable/ic_info_24dp"
         android:title="@string/information"
         app:showAsAction="always"/>

--- a/Simplenote/src/main/res/menu/notes_list.xml
+++ b/Simplenote/src/main/res/menu/notes_list.xml
@@ -48,7 +48,7 @@
     <item
         android:id="@+id/menu_view_info"
         android:icon="@drawable/ic_info_24dp"
-        android:title="@string/note_info"
+        android:title="@string/information"
         app:showAsAction="always"/>
 
     <item

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -85,6 +85,7 @@
 
     <style name="Theme.Simplestyle.BottomSheetDialog.Label" parent="Theme.Simplestyle.BottomSheetDialog">
         <item name="android:ellipsize">end</item>
+        <item name="android:maxLines">1</item>
         <item name="android:padding">@dimen/padding_large</item>
         <item name="android:textColor">@color/text_title_dark</item>
         <item name="android:textSize">@dimen/text_bottom_sheet</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -85,6 +85,7 @@
 
     <style name="Theme.Simplestyle.BottomSheetDialog.Label" parent="Theme.Simplestyle.BottomSheetDialog">
         <item name="android:ellipsize">end</item>
+        <item name="android:gravity">center_vertical|start</item>
         <item name="android:maxLines">1</item>
         <item name="android:minHeight">@dimen/bottom_sheet_row_height</item>
         <item name="android:padding">@dimen/padding_large</item>
@@ -93,6 +94,7 @@
     </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialog.Value" parent="Theme.Simplestyle.BottomSheetDialog">
+        <item name="android:gravity">center_vertical|end</item>
         <item name="android:minHeight">@dimen/bottom_sheet_row_height</item>
         <item name="android:paddingBottom">@dimen/padding_large</item>
         <item name="android:paddingEnd">@dimen/padding_large</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -86,12 +86,14 @@
     <style name="Theme.Simplestyle.BottomSheetDialog.Label" parent="Theme.Simplestyle.BottomSheetDialog">
         <item name="android:ellipsize">end</item>
         <item name="android:maxLines">1</item>
+        <item name="android:minHeight">@dimen/bottom_sheet_row_height</item>
         <item name="android:padding">@dimen/padding_large</item>
         <item name="android:textColor">@color/text_title_dark</item>
         <item name="android:textSize">@dimen/text_bottom_sheet</item>
     </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialog.Value" parent="Theme.Simplestyle.BottomSheetDialog">
+        <item name="android:minHeight">@dimen/bottom_sheet_row_height</item>
         <item name="android:paddingBottom">@dimen/padding_large</item>
         <item name="android:paddingEnd">@dimen/padding_large</item>
         <item name="android:paddingTop">@dimen/padding_large</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -90,6 +90,14 @@
         <item name="android:textSize">@dimen/text_bottom_sheet</item>
     </style>
 
+    <style name="Theme.Simplestyle.BottomSheetDialog.Value" parent="Theme.Simplestyle.BottomSheetDialog">
+        <item name="android:paddingBottom">@dimen/padding_large</item>
+        <item name="android:paddingEnd">@dimen/padding_large</item>
+        <item name="android:paddingTop">@dimen/padding_large</item>
+        <item name="android:textColor">@color/text_content_dark</item>
+        <item name="android:textSize">@dimen/text_bottom_sheet</item>
+    </style>
+
     <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.Simplestyle.BottomSheetDialog">
         <item name="android:textColor">@android:color/white</item>
     </style>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -35,13 +35,15 @@
     <string name="untagged_notes">Untagged Notes</string>
     <string name="today">Today</string>
     <string name="yesterday">Yesterday</string>
-    <string name="note_info">Info</string>
+    <string name="information">Information</string>
     <string name="toggle_sidebar">Toggle sidebar</string>
     <string name="tags">Tags</string>
     <string name="edit">Edit</string>
     <string name="enable_markdown">Enable markdown</string>
     <string name="pin_to_top">Pin to top</string>
     <string name="unpin_from_top">Unpin from top</string>
+    <string name="created">Created</string>
+    <string name="modified">Modified</string>
     <string name="modified_time">Modified %s</string>
     <string name="tab_edit">Edit</string>
     <string name="tab_preview">Preview</string>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -115,12 +115,14 @@
     <style name="Theme.Simplestyle.BottomSheetDialog.Label" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
         <item name="android:ellipsize">end</item>
         <item name="android:maxLines">1</item>
+        <item name="android:minHeight">@dimen/bottom_sheet_row_height</item>
         <item name="android:padding">@dimen/padding_large</item>
         <item name="android:textColor">@color/text_title_light</item>
         <item name="android:textSize">@dimen/text_bottom_sheet</item>
     </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialog.Value" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
+        <item name="android:minHeight">@dimen/bottom_sheet_row_height</item>
         <item name="android:paddingBottom">@dimen/padding_large</item>
         <item name="android:paddingEnd">@dimen/padding_large</item>
         <item name="android:paddingTop">@dimen/padding_large</item>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -114,8 +114,17 @@
 
     <style name="Theme.Simplestyle.BottomSheetDialog.Label" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
         <item name="android:ellipsize">end</item>
+        <item name="android:maxLines">1</item>
         <item name="android:padding">@dimen/padding_large</item>
         <item name="android:textColor">@color/text_title_light</item>
+        <item name="android:textSize">@dimen/text_bottom_sheet</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog.Value" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
+        <item name="android:paddingBottom">@dimen/padding_large</item>
+        <item name="android:paddingEnd">@dimen/padding_large</item>
+        <item name="android:paddingTop">@dimen/padding_large</item>
+        <item name="android:textColor">@color/text_content_light</item>
         <item name="android:textSize">@dimen/text_bottom_sheet</item>
     </style>
 

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -114,6 +114,7 @@
 
     <style name="Theme.Simplestyle.BottomSheetDialog.Label" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
         <item name="android:ellipsize">end</item>
+        <item name="android:gravity">center_vertical|start</item>
         <item name="android:maxLines">1</item>
         <item name="android:minHeight">@dimen/bottom_sheet_row_height</item>
         <item name="android:padding">@dimen/padding_large</item>
@@ -122,6 +123,7 @@
     </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialog.Value" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
+        <item name="android:gravity">center_vertical|end</item>
         <item name="android:minHeight">@dimen/bottom_sheet_row_height</item>
         <item name="android:paddingBottom">@dimen/padding_large</item>
         <item name="android:paddingEnd">@dimen/padding_large</item>


### PR DESCRIPTION
### Fix
Update the ***Info*** bottom sheet to ***Information*** and shown only date modified, date created, word count, and character count.  The order and format of the items in the date follow the device's locale. The time of the date follows the device's setting for 12-hour or 24-hour time.  These changes remove the ***Pin to top***, ***Enable markdown***, ***Share***, and ***Copy*** functionality pervious included in the ***Info*** bottom sheet.  Those features are being moved and will be included in a subsequent pull request, which is why this pull request targets the `feature/move-note-options` feature branch.  See the screenshots below for illustration.

![note_options_info_light](https://user-images.githubusercontent.com/3827611/73788004-80fdce80-4759-11ea-9ece-a77bdd43de98.png)

![note_options_info_dark](https://user-images.githubusercontent.com/3827611/73788010-83602880-4759-11ea-8b04-2c14dc8ccc75.png)

#### Note
***Information***, ***Modified***, and ***Created*** in the screenshots above using German are shown in English since those are new string resources and haven't gone through the translation process.

### Test
The ***Languages*** and ***User 24-hour format*** settings on the device will produce different results.  Try changing those settings while following the steps below.
1. Tap any note in list.
2. Tap ***Information*** action in app bar.
3. Notice only ***Modified***, ***Created***, ***Words***, and ***Characters*** shown.
4. Notice date format based on ***Languages*** and ***User 24-hour format*** settings.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in c1ccced6 with:
> Updated note information with date modified, date created, word count, and character count