### PR TITLE
Update Bottom Sheet

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -68,7 +68,7 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Automattic and WordPress dependencies
-    implementation 'com.simperium.android:simperium:0.9.5'
+    implementation 'com.simperium.android:simperium:0.9.6'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.2'
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/BottomSheetDialogBase.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/BottomSheetDialogBase.java
@@ -2,9 +2,12 @@ package com.automattic.simplenote;
 
 import android.app.Dialog;
 import android.os.Bundle;
-import android.view.WindowManager;
+import android.view.Gravity;
+import android.view.ViewParent;
+import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
@@ -31,11 +34,22 @@ public class BottomSheetDialogBase extends BottomSheetDialogFragment {
             int dp = (int) getDialog().getContext().getResources().getDimension(R.dimen.width_layout);
 
             if (dp > 0) {
-                WindowManager.LayoutParams layoutParams = new WindowManager.LayoutParams();
-                layoutParams.copyFrom(getDialog().getWindow() != null ? getDialog().getWindow().getAttributes() : null);
-                layoutParams.width = dp;
-                layoutParams.height = WindowManager.LayoutParams.MATCH_PARENT;
-                getDialog().getWindow().setAttributes(layoutParams);
+                FrameLayout bottomSheetLayout = getDialog().findViewById(com.google.android.material.R.id.design_bottom_sheet);
+
+                if (bottomSheetLayout != null) {
+                    ViewParent bottomSheetParent = bottomSheetLayout.getParent();
+
+                    if (bottomSheetParent instanceof CoordinatorLayout) {
+                        CoordinatorLayout.LayoutParams coordinatorLayoutParams = (CoordinatorLayout.LayoutParams) bottomSheetLayout.getLayoutParams();
+                        coordinatorLayoutParams.width = dp;
+                        bottomSheetLayout.setLayoutParams(coordinatorLayoutParams);
+
+                        CoordinatorLayout coordinatorLayout = (CoordinatorLayout) bottomSheetParent;
+                        FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) coordinatorLayout.getLayoutParams();
+                        layoutParams.gravity = Gravity.CENTER_HORIZONTAL;
+                        coordinatorLayout.setLayoutParams(layoutParams);
+                    }
+                }
             }
         }
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/HistoryBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/HistoryBottomSheetDialog.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
@@ -15,6 +16,8 @@ import androidx.fragment.app.FragmentManager;
 
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.utils.DateTimeUtils;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.simperium.client.Bucket;
 
 import org.json.JSONObject;
@@ -158,6 +161,22 @@ public class HistoryBottomSheetDialog extends BottomSheetDialogBase {
                 public void onDismiss(DialogInterface dialog) {
                     mListener.onHistoryDismissed();
                     mNote = null;
+                }
+            });
+
+            // Set peek height to full height of view (i.e. set STATE_EXPANDED) to avoid buttons
+            // being off screen when bottom sheet is shown.
+            getDialog().setOnShowListener(new DialogInterface.OnShowListener() {
+                @Override
+                public void onShow(DialogInterface dialogInterface) {
+                    BottomSheetDialog bottomSheetDialog = (BottomSheetDialog) dialogInterface;
+                    FrameLayout bottomSheet = bottomSheetDialog.findViewById(com.google.android.material.R.id.design_bottom_sheet);
+
+                    if (bottomSheet != null) {
+                        BottomSheetBehavior behavior = BottomSheetBehavior.from(bottomSheet);
+                        behavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+                        behavior.setSkipCollapsed(true);
+                    }
                 }
             });
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
@@ -8,6 +8,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CompoundButton;
+import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -22,6 +23,8 @@ import androidx.preference.PreferenceManager;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.utils.DateTimeUtils;
 import com.automattic.simplenote.utils.PrefUtils;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
 
 import java.text.NumberFormat;
 
@@ -122,6 +125,22 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
                 @Override
                 public void onDismiss(DialogInterface dialog) {
                     mListener.onInfoDismissed();
+                }
+            });
+
+            // Set peek height to full height of view (i.e. set STATE_EXPANDED) to avoid buttons
+            // being off screen when bottom sheet is shown.
+            getDialog().setOnShowListener(new DialogInterface.OnShowListener() {
+                @Override
+                public void onShow(DialogInterface dialogInterface) {
+                    BottomSheetDialog bottomSheetDialog = (BottomSheetDialog) dialogInterface;
+                    FrameLayout bottomSheet = bottomSheetDialog.findViewById(com.google.android.material.R.id.design_bottom_sheet);
+
+                    if (bottomSheet != null) {
+                        BottomSheetBehavior behavior = BottomSheetBehavior.from(bottomSheet);
+                        behavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+                        behavior.setSkipCollapsed(true);
+                    }
                 }
             });
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/ShareBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/ShareBottomSheetDialog.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -22,6 +23,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.utils.IconResizer;
 import com.automattic.simplenote.utils.ShareButtonAdapter;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -97,6 +100,24 @@ public class ShareBottomSheetDialog extends BottomSheetDialogBase {
             mShareIntent.setType("text/plain");
 
             mShareButtons = getShareButtons(mFragment.requireActivity(), mShareIntent);
+        }
+
+        if (getDialog() != null) {
+            // Set peek height to half height of view (i.e. set STATE_HALF_EXPANDED) to show some of
+            // sharing options when bottom sheet is shown.
+            getDialog().setOnShowListener(new DialogInterface.OnShowListener() {
+                @Override
+                public void onShow(DialogInterface dialogInterface) {
+                    BottomSheetDialog bottomSheetDialog = (BottomSheetDialog) dialogInterface;
+                    FrameLayout bottomSheet = bottomSheetDialog.findViewById(com.google.android.material.R.id.design_bottom_sheet);
+
+                    if (bottomSheet != null) {
+                        BottomSheetBehavior behavior = BottomSheetBehavior.from(bottomSheet);
+                        behavior.setState(BottomSheetBehavior.STATE_HALF_EXPANDED);
+                        behavior.setSkipCollapsed(true);
+                    }
+                }
+            });
         }
 
         return super.onCreateView(inflater, container, savedInstanceState);


### PR DESCRIPTION
### Fix
All bottom sheet dialogs hide the navigation bar buttons on large screen devices (e.g. tablets). 
 These changes update the view to which the custom layout parameters are applied in the bottom sheet base class.  Consequently, the peek height must be updated and the collapsed state must be disabled in all inherited classes.  These changes include the updates in Simperium from https://github.com/Simperium/simperium-android/pull/218 associated with the authentication screen.  See the screenshots below for illustration.

![update_bottom_sheet_login_portrait](https://user-images.githubusercontent.com/3827611/73868255-608b4e00-4805-11ea-88dc-d9351be77727.png)

![update_bottom_sheet_login_landscape](https://user-images.githubusercontent.com/3827611/73868263-62551180-4805-11ea-84eb-b04c788509ac.png)

![update_bottom_sheet_history_portrait](https://user-images.githubusercontent.com/3827611/73868212-4f424180-4805-11ea-8555-5830c613e71b.png)

![update_bottom_sheet_history_landscape](https://user-images.githubusercontent.com/3827611/73868216-510c0500-4805-11ea-8953-953bebd14dda.png)

![update_bottom_sheet_share_portrait](https://user-images.githubusercontent.com/3827611/73868232-58cba980-4805-11ea-9c7c-69a21c8ecee4.png)

![update_bottom_sheet_share_landscape](https://user-images.githubusercontent.com/3827611/73868236-5a956d00-4805-11ea-8153-8de21aea57be.png)

![update_bottom_sheet_info_portrait](https://user-images.githubusercontent.com/3827611/73868222-536e5f00-4805-11ea-8b2c-e82e8b64d514.png)

![update_bottom_sheet_info_landscape](https://user-images.githubusercontent.com/3827611/73868225-55d0b900-4805-11ea-8ccc-de19776eb4ab.png)

#### Note
This pull request does not include the changes to the ***Information*** bottom sheet from https://github.com/Automattic/simplenote-android/pull/932.  Those changes are in another branch.

### Test

0. Clear app data.
1. Tap ***Log In*** button.
2. Notice navigation bar buttons are visible.
3. Log in with preferred method.
4. Tap any note in list.
5. Tap ***History*** action in app bar.
6. Notice navigation bar buttons are visible.
7.  Dismiss ***History*** bottom sheet.
8. Tap ***Share*** action in app bar.
9. Notice navigation bar buttons are visible.
10. Dismiss ***Share*** bottom sheet.
11. Tap ***Info*** action in app bar.
12. Notice navigation bar buttons are visible.
13. Dismiss ***Info*** bottom sheet.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.