### PR TITLE
Note Options Menu

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.4
 -----
 * Updated note information with date modified, date created, word count, and character count
+* Moved note options from the action bar to the ellipsis menu
 * Fixed sync bug with deleting tags and emptying trash
 * Fixed networking bug causing interface slowness
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -568,7 +568,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             publishItem.setChecked(mNote.isPublished());
             markdownItem.setChecked(mNote.isMarkdownEnabled());
 
-            if (mNote.isDeleted()) {
+            // Disable actions when note is in Trash or markdown view is shown on large device.
+            if (mNote.isDeleted() || (mMarkdown != null && mMarkdown.getVisibility() == View.VISIBLE)) {
                 pinItem.setEnabled(false);
                 shareItem.setEnabled(false);
                 historyItem.setEnabled(false);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -43,6 +43,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.view.ActionMode;
+import androidx.core.view.MenuCompat;
 import androidx.core.widget.NestedScrollView;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
@@ -494,6 +495,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         }
 
         inflater.inflate(R.menu.note_editor, menu);
+        MenuCompat.setGroupDividerEnabled(menu, true);
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -559,7 +559,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             MenuItem publishItem = menu.findItem(R.id.menu_publish);
             MenuItem copyLinkItem = menu.findItem(R.id.menu_copy);
             MenuItem markdownItem = menu.findItem(R.id.menu_markdown);
-            MenuItem trashItem = menu.findItem(R.id.menu_trash).setTitle(R.string.undelete);
+            MenuItem trashItem = menu.findItem(R.id.menu_trash);
 
             pinItem.setChecked(mNote.isPinned());
             publishItem.setChecked(mNote.isPublished());
@@ -570,7 +570,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 publishItem.setEnabled(false);
                 copyLinkItem.setEnabled(false);
                 markdownItem.setEnabled(false);
-                trashItem.setTitle(R.string.undelete);
+                trashItem.setTitle(R.string.restore);
             } else {
                 pinItem.setEnabled(true);
                 publishItem.setEnabled(true);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -557,6 +557,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             menu.findItem(R.id.menu_info).setVisible(true);
             MenuItem pinItem = menu.findItem(R.id.menu_pin);
             MenuItem shareItem = menu.findItem(R.id.menu_share);
+            MenuItem historyItem = menu.findItem(R.id.menu_history);
             MenuItem publishItem = menu.findItem(R.id.menu_publish);
             MenuItem copyLinkItem = menu.findItem(R.id.menu_copy);
             MenuItem markdownItem = menu.findItem(R.id.menu_markdown);
@@ -569,6 +570,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             if (mNote.isDeleted()) {
                 pinItem.setEnabled(false);
                 shareItem.setEnabled(false);
+                historyItem.setEnabled(false);
                 publishItem.setEnabled(false);
                 copyLinkItem.setEnabled(false);
                 markdownItem.setEnabled(false);
@@ -576,6 +578,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             } else {
                 pinItem.setEnabled(true);
                 shareItem.setEnabled(true);
+                historyItem.setEnabled(true);
                 publishItem.setEnabled(true);
                 copyLinkItem.setEnabled(mNote.isPublished());
                 markdownItem.setEnabled(true);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -576,7 +576,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 publishItem.setEnabled(true);
                 copyLinkItem.setEnabled(mNote.isPublished());
                 markdownItem.setEnabled(true);
-                trashItem.setTitle(R.string.delete);
+                trashItem.setTitle(R.string.trash);
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -576,7 +576,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 copyLinkItem.setEnabled(false);
                 markdownItem.setEnabled(false);
                 trashItem.setTitle(R.string.restore);
-                checklistItem.setVisible(false);
+                checklistItem.setEnabled(false);
             } else {
                 pinItem.setEnabled(true);
                 shareItem.setEnabled(true);
@@ -585,7 +585,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 copyLinkItem.setEnabled(mNote.isPublished());
                 markdownItem.setEnabled(true);
                 trashItem.setTitle(R.string.trash);
-                checklistItem.setVisible(true);
+                checklistItem.setEnabled(true);
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -577,6 +577,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 markdownItem.setEnabled(false);
                 trashItem.setTitle(R.string.restore);
                 checklistItem.setEnabled(false);
+                DrawableUtils.setMenuItemAlpha(checklistItem, 0.3);  // 0.3 is 30% opacity.
             } else {
                 pinItem.setEnabled(true);
                 shareItem.setEnabled(true);
@@ -586,6 +587,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 markdownItem.setEnabled(true);
                 trashItem.setTitle(R.string.trash);
                 checklistItem.setEnabled(true);
+                DrawableUtils.setMenuItemAlpha(checklistItem, 1.0);  // 1.0 is 100% opacity.
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -562,6 +562,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             MenuItem copyLinkItem = menu.findItem(R.id.menu_copy);
             MenuItem markdownItem = menu.findItem(R.id.menu_markdown);
             MenuItem trashItem = menu.findItem(R.id.menu_trash);
+            MenuItem checklistItem = menu.findItem(R.id.menu_checklist);
 
             pinItem.setChecked(mNote.isPinned());
             publishItem.setChecked(mNote.isPublished());
@@ -575,6 +576,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 copyLinkItem.setEnabled(false);
                 markdownItem.setEnabled(false);
                 trashItem.setTitle(R.string.restore);
+                checklistItem.setVisible(false);
             } else {
                 pinItem.setEnabled(true);
                 shareItem.setEnabled(true);
@@ -583,6 +585,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 copyLinkItem.setEnabled(mNote.isPublished());
                 markdownItem.setEnabled(true);
                 trashItem.setTitle(R.string.trash);
+                checklistItem.setVisible(true);
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -576,7 +576,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 publishItem.setEnabled(false);
                 copyLinkItem.setEnabled(false);
                 markdownItem.setEnabled(false);
-                trashItem.setTitle(R.string.restore);
                 checklistItem.setEnabled(false);
                 DrawableUtils.setMenuItemAlpha(checklistItem, 0.3);  // 0.3 is 30% opacity.
             } else {
@@ -586,9 +585,14 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 publishItem.setEnabled(true);
                 copyLinkItem.setEnabled(mNote.isPublished());
                 markdownItem.setEnabled(true);
-                trashItem.setTitle(R.string.trash);
                 checklistItem.setEnabled(true);
                 DrawableUtils.setMenuItemAlpha(checklistItem, 1.0);  // 1.0 is 100% opacity.
+            }
+
+            if (mNote.isDeleted()) {
+                trashItem.setTitle(R.string.restore);
+            } else {
+                trashItem.setTitle(R.string.trash);
             }
         }
 
@@ -636,6 +640,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     protected void showMarkdown() {
         loadMarkdownData();
         mMarkdown.setVisibility(View.VISIBLE);
+        requireActivity().invalidateOptionsMenu();
     }
 
     private void shareNote() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -556,6 +556,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         if (mNote != null) {
             menu.findItem(R.id.menu_info).setVisible(true);
             MenuItem pinItem = menu.findItem(R.id.menu_pin);
+            MenuItem shareItem = menu.findItem(R.id.menu_share);
             MenuItem publishItem = menu.findItem(R.id.menu_publish);
             MenuItem copyLinkItem = menu.findItem(R.id.menu_copy);
             MenuItem markdownItem = menu.findItem(R.id.menu_markdown);
@@ -567,12 +568,14 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
             if (mNote.isDeleted()) {
                 pinItem.setEnabled(false);
+                shareItem.setEnabled(false);
                 publishItem.setEnabled(false);
                 copyLinkItem.setEnabled(false);
                 markdownItem.setEnabled(false);
                 trashItem.setTitle(R.string.restore);
             } else {
                 pinItem.setEnabled(true);
+                shareItem.setEnabled(true);
                 publishItem.setEnabled(true);
                 copyLinkItem.setEnabled(mNote.isPublished());
                 markdownItem.setEnabled(true);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -207,7 +207,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         if (getListView().getCheckedItemIds().length > 0) {
 
             switch (item.getItemId()) {
-                case R.id.menu_delete:
+                case R.id.menu_trash:
                     new TrashNotesTask(this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
                     break;
                 case R.id.menu_pin:
@@ -1380,7 +1380,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                         note.save();
                         refreshList();
                         return true;
-                    case R.id.menu_delete:
+                    case R.id.menu_trash:
                         note.setDeleted(!note.isDeleted());
                         note.setModificationDate(Calendar.getInstance());
                         note.save();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -52,10 +52,10 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
         if (mNote != null) {
             MenuItem viewPublishedNoteItem = menu.findItem(R.id.menu_info);
             viewPublishedNoteItem.setVisible(true);
-            MenuItem trashItem = menu.findItem(R.id.menu_trash).setTitle(R.string.undelete);
+            MenuItem trashItem = menu.findItem(R.id.menu_trash);
 
             if (mNote.isDeleted()) {
-                trashItem.setTitle(R.string.undelete);
+                trashItem.setTitle(R.string.restore);
             } else {
                 trashItem.setTitle(R.string.trash);
             }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -54,10 +54,8 @@ public class NoteMarkdownFragment extends Fragment {
 
             if (mNote.isDeleted()) {
                 trashItem.setTitle(R.string.undelete);
-                trashItem.setIcon(R.drawable.ic_trash_restore_24dp);
             } else {
                 trashItem.setTitle(R.string.delete);
-                trashItem.setIcon(R.drawable.ic_trash_24dp);
             }
 
             DrawableUtils.tintMenuItemWithAttribute(getActivity(), trashItem, R.attr.toolbarIconColor);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -50,8 +50,7 @@ public class NoteMarkdownFragment extends Fragment {
         if (mNote != null) {
             MenuItem viewPublishedNoteItem = menu.findItem(R.id.menu_info);
             viewPublishedNoteItem.setVisible(true);
-
-            MenuItem trashItem = menu.findItem(R.id.menu_delete).setTitle(R.string.undelete);
+            MenuItem trashItem = menu.findItem(R.id.menu_trash).setTitle(R.string.undelete);
 
             if (mNote.isDeleted()) {
                 trashItem.setTitle(R.string.undelete);
@@ -71,10 +70,12 @@ public class NoteMarkdownFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         // Load note if we were passed an ID.
         Bundle arguments = getArguments();
+
         if (arguments != null && arguments.containsKey(ARG_ITEM_ID)) {
             String key = arguments.getString(ARG_ITEM_ID);
             new LoadNoteTask(this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, key);
         }
+
         setHasOptionsMenu(true);
         mCss = ThemeUtils.isLightTheme(requireContext())
                 ? ContextUtils.readCssFile(requireContext(), "light.css")
@@ -87,12 +88,18 @@ public class NoteMarkdownFragment extends Fragment {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
-            case R.id.menu_delete:
-                if (!isAdded()) return false;
+            case R.id.menu_trash:
+                if (!isAdded()) {
+                    return false;
+                }
+
                 deleteNote();
                 return true;
             case android.R.id.home:
-                if (!isAdded()) return false;
+                if (!isAdded()) {
+                    return false;
+                }
+
                 requireActivity().finish();
                 return true;
             default:
@@ -109,10 +116,24 @@ public class NoteMarkdownFragment extends Fragment {
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
         // Disable share and delete actions until note is loaded.
         if (mIsLoadingNote) {
-            menu.findItem(R.id.menu_delete).setEnabled(false);
+            menu.findItem(R.id.menu_trash).setEnabled(false);
         } else {
-            menu.findItem(R.id.menu_delete).setEnabled(true);
+            menu.findItem(R.id.menu_trash).setEnabled(true);
         }
+
+        MenuItem pinItem = menu.findItem(R.id.menu_pin);
+        MenuItem publishItem = menu.findItem(R.id.menu_publish);
+        MenuItem copyLinkItem = menu.findItem(R.id.menu_copy);
+        MenuItem markdownItem = menu.findItem(R.id.menu_markdown);
+
+        pinItem.setChecked(mNote.isPinned());
+        publishItem.setChecked(mNote.isPublished());
+        markdownItem.setChecked(mNote.isMarkdownEnabled());
+
+        pinItem.setEnabled(false);
+        publishItem.setEnabled(false);
+        copyLinkItem.setEnabled(false);
+        markdownItem.setEnabled(false);
 
         super.onPrepareOptionsMenu(menu);
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -25,8 +25,10 @@ import com.simperium.client.BucketObjectMissingException;
 
 import java.lang.ref.SoftReference;
 
-public class NoteMarkdownFragment extends Fragment {
+public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<Note> {
     public static final String ARG_ITEM_ID = "item_id";
+
+    private Bucket<Note> mNotesBucket;
     private Note mNote;
     private String mCss;
     private WebView mMarkdown;
@@ -66,6 +68,8 @@ public class NoteMarkdownFragment extends Fragment {
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        mNotesBucket = ((Simplenote) requireActivity().getApplication()).getNotesBucket();
+
         // Load note if we were passed an ID.
         Bundle arguments = getArguments();
 
@@ -134,6 +138,40 @@ public class NoteMarkdownFragment extends Fragment {
         markdownItem.setEnabled(false);
 
         super.onPrepareOptionsMenu(menu);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        mNotesBucket.removeListener(this);
+        mNotesBucket.stop();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        mNotesBucket.start();
+        mNotesBucket.addListener(this);
+    }
+
+    @Override
+    public void onBeforeUpdateObject(Bucket<Note> bucket, Note note) {
+    }
+
+    @Override
+    public void onDeleteObject(Bucket<Note> bucket, Note note) {
+    }
+
+    @Override
+    public void onNetworkChange(Bucket<Note> bucket, Bucket.ChangeType type, String key) {
+    }
+
+    @Override
+    public void onSaveObject(Bucket<Note> bucket, Note note) {
+        if (note.equals(mNote)) {
+            mNote = note;
+            requireActivity().invalidateOptionsMenu();
+        }
     }
 
     public void updateMarkdown(String text) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
+import androidx.core.view.MenuCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
@@ -37,6 +38,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
     @Override
     public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.note_markdown, menu);
+        MenuCompat.setGroupDividerEnabled(menu, true);
 
         DrawableUtils.tintMenuWithAttribute(
             requireContext(),

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -57,7 +57,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
             if (mNote.isDeleted()) {
                 trashItem.setTitle(R.string.undelete);
             } else {
-                trashItem.setTitle(R.string.delete);
+                trashItem.setTitle(R.string.trash);
             }
 
             DrawableUtils.tintMenuItemWithAttribute(getActivity(), trashItem, R.attr.toolbarIconColor);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -735,7 +735,8 @@ public class NotesActivity extends AppCompatActivity implements
             }
         });
 
-        MenuItem trashItem = menu.findItem(R.id.menu_delete).setTitle(R.string.undelete);
+        MenuItem trashItem = menu.findItem(R.id.menu_trash).setTitle(R.string.undelete);
+
         if (mCurrentNote != null && mCurrentNote.isDeleted()) {
             trashItem.setTitle(R.string.undelete);
             trashItem.setIcon(R.drawable.ic_trash_restore_24dp);
@@ -758,11 +759,12 @@ public class NotesActivity extends AppCompatActivity implements
             menu.findItem(R.id.menu_share).setVisible(false);
             menu.findItem(R.id.menu_info).setVisible(false);
             menu.findItem(R.id.menu_checklist).setVisible(false);
-            menu.findItem(R.id.menu_history).setVisible(false);
             menu.findItem(R.id.menu_markdown_preview).setVisible(false);
             menu.findItem(R.id.menu_sidebar).setVisible(false);
             trashItem.setVisible(false);
             menu.findItem(R.id.menu_empty_trash).setVisible(false);
+            menu.setGroupVisible(R.id.group_1, false);
+            menu.setGroupVisible(R.id.group_2, false);
         }
 
         if (mSelectedTag != null && mSelectedTag.id == TRASH_ID) {
@@ -772,8 +774,6 @@ public class NotesActivity extends AppCompatActivity implements
             updateTrashMenuItem();
 
             menu.findItem(R.id.menu_search).setVisible(false);
-            menu.findItem(R.id.menu_share).setVisible(false);
-            menu.findItem(R.id.menu_history).setVisible(false);
             menu.findItem(R.id.menu_checklist).setVisible(false);
         }
 
@@ -822,7 +822,7 @@ public class NotesActivity extends AppCompatActivity implements
                 DrawableUtils.tintMenuItemWithAttribute(this, item, R.attr.toolbarIconColor);
 
                 return true;
-            case R.id.menu_delete:
+            case R.id.menu_trash:
                 if (mNoteEditorFragment != null) {
                     if (mCurrentNote != null) {
                         mCurrentNote.setDeleted(!mCurrentNote.isDeleted());
@@ -865,18 +865,45 @@ public class NotesActivity extends AppCompatActivity implements
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
-        MenuItem markdownItem = menu.findItem(R.id.menu_markdown_preview);
+        MenuItem pinItem = menu.findItem(R.id.menu_pin);
+        MenuItem shareItem = menu.findItem(R.id.menu_share);
+        MenuItem historyItem = menu.findItem(R.id.menu_history);
+        MenuItem publishItem = menu.findItem(R.id.menu_publish);
+        MenuItem copyLinkItem = menu.findItem(R.id.menu_copy);
+        MenuItem markdownItem = menu.findItem(R.id.menu_markdown);
+        MenuItem markdownPreviewItem = menu.findItem(R.id.menu_markdown_preview);
 
         if (mIsShowingMarkdown) {
-            markdownItem.setIcon(R.drawable.ic_visibility_off_24dp);
-            markdownItem.setTitle(getString(R.string.markdown_hide));
+            markdownPreviewItem.setIcon(R.drawable.ic_visibility_off_24dp);
+            markdownPreviewItem.setTitle(getString(R.string.markdown_hide));
         } else {
-            markdownItem.setIcon(R.drawable.ic_visibility_on_24dp);
-            markdownItem.setTitle(getString(R.string.markdown_show));
+            markdownPreviewItem.setIcon(R.drawable.ic_visibility_on_24dp);
+            markdownPreviewItem.setTitle(getString(R.string.markdown_show));
         }
 
-        DrawableUtils.tintMenuItemWithAttribute(this, markdownItem, R.attr.toolbarIconColor);
+        if (mCurrentNote != null) {
+            pinItem.setChecked(mCurrentNote.isPinned());
+            publishItem.setChecked(mCurrentNote.isPublished());
+            markdownItem.setChecked(mCurrentNote.isMarkdownEnabled());
 
+            if (mCurrentNote.isDeleted()) {
+                pinItem.setEnabled(false);
+                shareItem.setEnabled(false);
+                historyItem.setEnabled(false);
+                publishItem.setEnabled(false);
+                copyLinkItem.setEnabled(false);
+                markdownItem.setEnabled(false);
+            } else {
+                pinItem.setEnabled(true);
+                shareItem.setEnabled(true);
+                historyItem.setEnabled(true);
+                publishItem.setEnabled(true);
+                copyLinkItem.setEnabled(mCurrentNote.isPublished());
+                markdownItem.setEnabled(true);
+            }
+        }
+
+        DrawableUtils.tintMenuItemWithAttribute(this, markdownPreviewItem, R.attr.toolbarIconColor);
         return super.onPrepareOptionsMenu(menu);
     }
 
@@ -895,20 +922,18 @@ public class NotesActivity extends AppCompatActivity implements
     private void updateActionsForLargeLandscape(Menu menu) {
         if (mCurrentNote != null) {
             menu.findItem(R.id.menu_checklist).setVisible(true);
-            menu.findItem(R.id.menu_delete).setVisible(true);
-            menu.findItem(R.id.menu_history).setVisible(true);
             menu.findItem(R.id.menu_markdown_preview).setVisible(mCurrentNote.isMarkdownEnabled());
-            menu.findItem(R.id.menu_share).setVisible(true);
             menu.findItem(R.id.menu_sidebar).setVisible(true);
             menu.findItem(R.id.menu_info).setVisible(true);
+            menu.setGroupVisible(R.id.group_1, true);
+            menu.setGroupVisible(R.id.group_2, true);
         } else {
             menu.findItem(R.id.menu_checklist).setVisible(false);
-            menu.findItem(R.id.menu_delete).setVisible(false);
-            menu.findItem(R.id.menu_history).setVisible(false);
             menu.findItem(R.id.menu_markdown_preview).setVisible(false);
-            menu.findItem(R.id.menu_share).setVisible(false);
             menu.findItem(R.id.menu_sidebar).setVisible(false);
             menu.findItem(R.id.menu_info).setVisible(false);
+            menu.setGroupVisible(R.id.group_1, false);
+            menu.setGroupVisible(R.id.group_2, false);
         }
 
         menu.findItem(R.id.menu_empty_trash).setVisible(false);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -739,10 +739,8 @@ public class NotesActivity extends AppCompatActivity implements
 
         if (mCurrentNote != null && mCurrentNote.isDeleted()) {
             trashItem.setTitle(R.string.undelete);
-            trashItem.setIcon(R.drawable.ic_trash_restore_24dp);
         } else {
             trashItem.setTitle(R.string.delete);
-            trashItem.setIcon(R.drawable.ic_trash_24dp);
         }
 
         if (DisplayUtils.isLargeScreenLandscape(NotesActivity.this)) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -27,6 +27,7 @@ import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.view.GravityCompat;
+import androidx.core.view.MenuCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
@@ -636,6 +637,7 @@ public class NotesActivity extends AppCompatActivity implements
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.notes_list, menu);
+        MenuCompat.setGroupDividerEnabled(menu, true);
 
         // restore the search query if on a landscape tablet
         String searchQuery = null;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1336,13 +1336,18 @@ public class NotesActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onSaveObject(Bucket<Note> bucket, Note object) {
+    public void onSaveObject(Bucket<Note> bucket, Note note) {
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 mNoteListFragment.refreshList();
             }
         });
+
+        if (note.equals(mCurrentNote)) {
+            mCurrentNote = note;
+            invalidateOptionsMenu();
+        }
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -737,10 +737,10 @@ public class NotesActivity extends AppCompatActivity implements
             }
         });
 
-        MenuItem trashItem = menu.findItem(R.id.menu_trash).setTitle(R.string.undelete);
+        MenuItem trashItem = menu.findItem(R.id.menu_trash);
 
         if (mCurrentNote != null && mCurrentNote.isDeleted()) {
-            trashItem.setTitle(R.string.undelete);
+            trashItem.setTitle(R.string.restore);
         } else {
             trashItem.setTitle(R.string.trash);
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -742,7 +742,7 @@ public class NotesActivity extends AppCompatActivity implements
         if (mCurrentNote != null && mCurrentNote.isDeleted()) {
             trashItem.setTitle(R.string.undelete);
         } else {
-            trashItem.setTitle(R.string.delete);
+            trashItem.setTitle(R.string.trash);
         }
 
         if (DisplayUtils.isLargeScreenLandscape(NotesActivity.this)) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
@@ -128,7 +128,7 @@ public class TagsListFragment extends Fragment implements ActionMode.Callback, B
 
     @Override
     public boolean onActionItemClicked(ActionMode actionMode, MenuItem menuItem) {
-        if (menuItem.getItemId() == R.id.menu_delete) {
+        if (menuItem.getItemId() == R.id.menu_trash) {
             actionMode.finish(); // Action picked, so close the CAB
             return true;
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DrawableUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DrawableUtils.java
@@ -19,9 +19,11 @@ import androidx.core.graphics.drawable.DrawableCompat;
 public class DrawableUtils {
     public static Drawable setMenuItemAlpha(MenuItem menuItem, @FloatRange(from=0,to=1) double alpha) {
         Drawable drawable = menuItem.getIcon();
-        drawable = DrawableCompat.wrap(drawable).mutate();
-        drawable.setAlpha((int) (alpha * 255));  // 255 is 100% opacity.
-        return drawable;
+
+        if (drawable != null) {
+            drawable = DrawableCompat.wrap(drawable).mutate();
+            drawable.setAlpha((int) (alpha * 255));  // 255 is 100% opacity.
+        }
     }
 
     public static Drawable tintDrawableWithResource(Context context, @DrawableRes int drawableRes, @ColorRes int colorRes) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DrawableUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DrawableUtils.java
@@ -17,7 +17,7 @@ import androidx.core.graphics.drawable.DrawableCompat;
 
 @SuppressWarnings("unused")
 public class DrawableUtils {
-    public static Drawable setMenuItemAlpha(MenuItem menuItem, @FloatRange(from=0,to=1) double alpha) {
+    public static void setMenuItemAlpha(MenuItem menuItem, @FloatRange(from=0,to=1) double alpha) {
         Drawable drawable = menuItem.getIcon();
 
         if (drawable != null) {

--- a/Simplenote/src/main/res/layout/activity_note_editor.xml
+++ b/Simplenote/src/main/res/layout/activity_note_editor.xml
@@ -7,10 +7,11 @@
     android:layout_height="match_parent">
 
     <com.google.android.material.appbar.AppBarLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:animateLayoutChanges="true"
-        android:background="?attr/mainBackgroundColor">
+        android:background="?attr/mainBackgroundColor"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:theme="@style/ToolbarTheme.AppBarOverlay">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"

--- a/Simplenote/src/main/res/menu/bulk_edit.xml
+++ b/Simplenote/src/main/res/menu/bulk_edit.xml
@@ -13,7 +13,7 @@
         app:showAsAction="always"/>
 
     <item
-        android:id="@+id/menu_delete"
+        android:id="@+id/menu_trash"
         android:icon="@drawable/ic_trash_24dp"
         android:title="@string/trash"
         app:showAsAction="always"/>

--- a/Simplenote/src/main/res/menu/bulk_edit.xml
+++ b/Simplenote/src/main/res/menu/bulk_edit.xml
@@ -15,7 +15,7 @@
     <item
         android:id="@+id/menu_delete"
         android:icon="@drawable/ic_trash_24dp"
-        android:title="@string/delete"
+        android:title="@string/trash"
         app:showAsAction="always"/>
 
 </menu>

--- a/Simplenote/src/main/res/menu/note_editor.xml
+++ b/Simplenote/src/main/res/menu/note_editor.xml
@@ -13,27 +13,65 @@
         app:showAsAction="always" />
 
     <item
-        android:id="@+id/menu_history"
-        android:icon="@drawable/ic_history_24dp"
-        android:title="@string/history"
-        app:showAsAction="always" />
-
-    <item
-        android:id="@+id/menu_share"
-        android:icon="@drawable/ic_share_24dp"
-        android:title="@string/share"
-        app:showAsAction="always" />
-
-    <item
         android:id="@+id/menu_info"
         android:icon="@drawable/ic_info_24dp"
         android:title="@string/information"
         app:showAsAction="always" />
 
-    <item
-        android:id="@+id/menu_delete"
-        android:icon="@drawable/ic_trash_24dp"
-        android:title="@string/delete"
-        app:showAsAction="always" />
+    <group
+        android:id="@+id/group_1">
+
+        <item
+            android:id="@+id/menu_pin"
+            android:checkable="true"
+            android:title="@string/pin"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_markdown"
+            android:checkable="true"
+            android:title="@string/markdown"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_share"
+            android:title="@string/share"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_history"
+            android:title="@string/history"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_trash"
+            android:title="@string/trash"
+            app:showAsAction="never">
+        </item>
+
+    </group>
+
+    <group
+        android:id="@+id/group_2">
+
+        <item
+            android:id="@+id/menu_publish"
+            android:checkable="true"
+            android:title="@string/publish"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_copy"
+            android:enabled="false"
+            android:title="@string/copy_link"
+            app:showAsAction="never">
+        </item>
+
+    </group>
 
 </menu>

--- a/Simplenote/src/main/res/menu/note_markdown.xml
+++ b/Simplenote/src/main/res/menu/note_markdown.xml
@@ -14,30 +14,71 @@
         app:showAsAction="always" />
 
     <item
-        android:id="@+id/menu_history"
-        android:enabled="false"
-        android:icon="@drawable/ic_history_24dp"
-        android:title="@string/history"
-        app:showAsAction="always"/>
-
-    <item
-        android:id="@+id/menu_share"
-        android:enabled="false"
-        android:icon="@drawable/ic_share_24dp"
-        android:title="@string/share"
-        app:showAsAction="always"/>
-
-    <item
         android:id="@+id/menu_info"
         android:enabled="false"
         android:icon="@drawable/ic_info_24dp"
         android:title="@string/information"
         app:showAsAction="always"/>
 
-    <item
-        android:id="@+id/menu_delete"
-        android:icon="@drawable/ic_trash_24dp"
-        android:title="@string/delete"
-        app:showAsAction="always"/>
+    <group
+        android:id="@+id/group_1">
+
+        <item
+            android:id="@+id/menu_pin"
+            android:checkable="true"
+            android:enabled="false"
+            android:title="@string/pin"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_markdown"
+            android:checkable="true"
+            android:enabled="false"
+            android:title="@string/markdown"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_share"
+            android:enabled="false"
+            android:title="@string/share"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_history"
+            android:enabled="false"
+            android:title="@string/history"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_trash"
+            android:title="@string/trash"
+            app:showAsAction="never">
+        </item>
+
+    </group>
+
+    <group
+        android:id="@+id/group_2">
+
+        <item
+            android:id="@+id/menu_publish"
+            android:checkable="true"
+            android:enabled="false"
+            android:title="@string/publish"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_copy"
+            android:enabled="false"
+            android:title="@string/copy_link"
+            app:showAsAction="never">
+        </item>
+
+    </group>
 
 </menu>

--- a/Simplenote/src/main/res/menu/notes_list.xml
+++ b/Simplenote/src/main/res/menu/notes_list.xml
@@ -7,6 +7,13 @@
     tools:ignore="AlwaysShowAction">
 
     <item
+        android:id="@+id/menu_search"
+        android:icon="@drawable/ic_search_24dp"
+        android:title="@string/search"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:showAsAction="always|collapseActionView"/>
+
+    <item
         android:id="@+id/menu_sidebar"
         android:icon="@drawable/ic_tags_close_24dp"
         android:title="@string/toggle_sidebar"
@@ -19,13 +26,6 @@
         android:title="@string/markdown_show"
         android:visible="false"
         app:showAsAction="always"/>
-
-    <item
-        android:id="@+id/menu_search"
-        android:icon="@drawable/ic_search_24dp"
-        android:title="@string/search"
-        app:actionViewClass="androidx.appcompat.widget.SearchView"
-        app:showAsAction="always|collapseActionView"/>
 
     <item
         android:id="@+id/menu_checklist"

--- a/Simplenote/src/main/res/menu/notes_list.xml
+++ b/Simplenote/src/main/res/menu/notes_list.xml
@@ -34,27 +34,9 @@
         app:showAsAction="always"/>
 
     <item
-        android:id="@+id/menu_history"
-        android:icon="@drawable/ic_history_24dp"
-        android:title="@string/history"
-        app:showAsAction="always"/>
-
-    <item
-        android:id="@+id/menu_share"
-        android:icon="@drawable/ic_share_24dp"
-        android:title="@string/share"
-        app:showAsAction="always"/>
-
-    <item
         android:id="@+id/menu_info"
         android:icon="@drawable/ic_info_24dp"
         android:title="@string/information"
-        app:showAsAction="always"/>
-
-    <item
-        android:id="@+id/menu_delete"
-        android:icon="@drawable/ic_trash_24dp"
-        android:title="@string/delete"
         app:showAsAction="always"/>
 
     <item
@@ -62,5 +44,61 @@
         android:icon="@drawable/ic_trash_selector"
         android:title="@string/empty_trash"
         app:showAsAction="ifRoom"/>
+
+    <group
+        android:id="@+id/group_1">
+
+        <item
+            android:id="@+id/menu_pin"
+            android:checkable="true"
+            android:title="@string/pin"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_markdown"
+            android:checkable="true"
+            android:title="@string/markdown"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_share"
+            android:title="@string/share"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_history"
+            android:title="@string/history"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_trash"
+            android:title="@string/trash"
+            app:showAsAction="never">
+        </item>
+
+    </group>
+
+    <group
+        android:id="@+id/group_2">
+
+        <item
+            android:id="@+id/menu_publish"
+            android:checkable="true"
+            android:title="@string/publish"
+            app:showAsAction="never">
+        </item>
+
+        <item
+            android:id="@+id/menu_copy"
+            android:enabled="false"
+            android:title="@string/copy_link"
+            app:showAsAction="never">
+        </item>
+
+    </group>
 
 </menu>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -49,7 +49,7 @@
         <item name="settingsTextColor">@android:color/white</item>
         <item name="toolbarColor">@color/background_dark_4</item>
         <item name="toolbarIconColor">@color/gray_20</item>
-        <item name="toolbarPopupTheme">@style/ThemeOverlay.MaterialComponents</item>
+        <item name="toolbarPopupTheme">@style/ToolbarTheme.Popup</item>
         <item name="windowActionModeOverlay">true</item>
     </style>
 
@@ -105,6 +105,10 @@
 
     <style name="Theme.Simplestyle.BottomSheetDialogText" parent="Theme.Simplestyle.BottomSheetDialog">
         <item name="android:textColor">@android:color/white</item>
+    </style>
+
+    <style name="ToolbarTheme.Popup" parent="ThemeOverlay.MaterialComponents">
+        <item name="android:backgroundTint">@color/background_dark_8</item>
     </style>
 
 </resources>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -6,7 +6,6 @@
     <string name="tag_hint">Add tag&#8230;</string>
     <string name="settings">Settings</string>
     <string name="share">Share</string>
-    <string name="delete">Trash</string>
     <string name="undelete">Restore</string>
     <string name="new_note">New note</string>
     <string name="account">Account</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -6,8 +6,8 @@
     <string name="tag_hint">Add tag&#8230;</string>
     <string name="settings">Settings</string>
     <string name="share">Share</string>
-    <string name="delete">Move to trash</string>
-    <string name="undelete">Restore note</string>
+    <string name="delete">Trash</string>
+    <string name="undelete">Restore</string>
     <string name="new_note">New note</string>
     <string name="account">Account</string>
     <string name="log_in">Log in</string>
@@ -40,6 +40,7 @@
     <string name="tags">Tags</string>
     <string name="edit">Edit</string>
     <string name="enable_markdown">Enable markdown</string>
+    <string name="pin">Pin</string>
     <string name="pin_to_top">Pin to top</string>
     <string name="unpin_from_top">Unpin from top</string>
     <string name="created">Created</string>
@@ -47,11 +48,13 @@
     <string name="modified_time">Modified %s</string>
     <string name="tab_edit">Edit</string>
     <string name="tab_preview">Preview</string>
+    <string name="markdown">Markdown</string>
     <string name="markdown_hide">Hide Markdown</string>
     <string name="markdown_show">Show Markdown</string>
     <string name="character">Character</string>
     <string name="characters">Characters</string>
     <string name="logo">Logo</string>
+    <string name="copy_link">Copy link</string>
 
     <!-- Preferences -->
     <string name="editor">Editor</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -37,13 +37,11 @@
     <string name="toggle_sidebar">Toggle sidebar</string>
     <string name="tags">Tags</string>
     <string name="edit">Edit</string>
-    <string name="enable_markdown">Enable markdown</string>
     <string name="pin">Pin</string>
     <string name="pin_to_top">Pin to top</string>
     <string name="unpin_from_top">Unpin from top</string>
     <string name="created">Created</string>
     <string name="modified">Modified</string>
-    <string name="modified_time">Modified %s</string>
     <string name="tab_edit">Edit</string>
     <string name="tab_preview">Preview</string>
     <string name="markdown">Markdown</string>
@@ -125,7 +123,6 @@
     <string name="delete_notes">Delete notes</string>
 
     <!-- Note publishing -->
-    <string name="public_link">Public link</string>
     <string name="publish">Publish</string>
     <string name="unpublish">Remove public link</string>
     <string name="published">Published</string>
@@ -137,7 +134,6 @@
     <string name="unpublishing">Removing public link&#8230;</string>
     <string name="collaborate">Collaborate</string>
     <string name="collaborate_message">Add an email in the tag field to collaborate with other users.</string>
-    <string name="note_not_published">Note not published</string>
 
     <!-- Font Sizes -->
     <string name="font_size">Font size</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -6,7 +6,6 @@
     <string name="tag_hint">Add tag&#8230;</string>
     <string name="settings">Settings</string>
     <string name="share">Share</string>
-    <string name="undelete">Restore</string>
     <string name="new_note">New note</string>
     <string name="account">Account</string>
     <string name="log_in">Log in</string>


### PR DESCRIPTION
### Fix
Move the ***History***, ***Share***, and ***Trash***/***Restore*** actions from the top app bar as well as the ***Pin***, ***Markdown***, ***Publish***, and ***Copy link*** actions from the ***Information*** bottom sheet to the overflow menu.  Also, move ***Search*** to  the first/leftmost action in the app bar.  Note the ***Copy link*** action will only be enabled when the ***Publish*** action is enabled and checked.  These changes do no include updates to the snackbar color and text.  Those will be included in a subsequent pull request.  See the screenshots below for illustration.

![note_options_menu_phone](https://user-images.githubusercontent.com/3827611/74001733-f4563a80-4929-11ea-828d-9b9dadcbf7d8.png)

![note_options_menu_tablet](https://user-images.githubusercontent.com/3827611/74001737-f6b89480-4929-11ea-90c9-e649cdddd2a9.png)

### Test
Since the actions are different on phones and tablets, it's best to test both device form factors to verify the correct actions are enabled/disabled and visible/invisible as shown in the screenshots above.
1. Tap any note in list.
2. Notice ***History***, ***Share***, and ***Trash*** actions in overflow menu.
3. Notice ***Pin***, ***Markdown***, ***Publish***, and ***Copy link*** actions in overflow menu.
4. Tap ***Pin*** action in overflow menu.
5. Notice note is pinned to top of list.
7. Tap ***Markdown*** action in overflow menu.
8. Notice markdown is enabled for note.
9. Tap overflow menu action.
10. Notice ***Pin***, ***Markdown***, ***Share***, ***History***, and ***Publish*** actions enabled.
11. Notice ***Trash*** action enabled.
12. Show markdown view of note.
    a. Tap ***Preview*** tab on phone.
    b. Tap ***Show Markdown*** action on tablet.
13. Tap overflow menu action.
14. Notice ***Pin***, ***Markdown***, ***Share***, ***History***, ***Publish***, and ***Copy link*** actions disabled.
15. Notice ***Trash*** action enabled.
16. Tap ***Publish*** action in overflow menu.
17. Notice ***Copy link*** action enabled after publish succeeds.
18. Open navigation drawer.
19. Tap ***Trash*** item in navigation drawer.
20. Tap any note in list.
21. Tap overflow menu action.
22. Notice ***Pin***, ***Markdown***, ***Share***, ***History***, ***Publish***, and ***Copy link*** actions disabled.
23. Notice ***Restore*** action enabled.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 06fa4ad with:
> Moved note options from the action bar to the ellipsis menu