### PR TITLE
Remove Passcode Logout

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1089,6 +1089,9 @@ public class NotesActivity extends AppCompatActivity implements
         editor.remove(PrefUtils.PREF_WORDPRESS_SITES);
         editor.apply();
 
+        // Remove Passcode Lock password
+        AppLockManager.getInstance().getAppLock().setPassword("");
+
         Intent intent = new Intent(NotesActivity.this, SimplenoteAuthenticationActivity.class);
         startActivityForResult(intent, Simperium.SIGNUP_SIGNIN_REQUEST);
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -31,6 +31,8 @@ import com.simperium.client.BucketObjectMissingException;
 import com.simperium.client.BucketObjectNameInvalid;
 import com.simperium.client.User;
 
+import org.wordpress.passcodelock.AppLockManager;
+
 import java.lang.ref.WeakReference;
 
 import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
@@ -258,6 +260,9 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
         // Remove WordPress sites
         editor.remove(PrefUtils.PREF_WORDPRESS_SITES);
         editor.apply();
+
+        // Remove Passcode Lock password
+        AppLockManager.getInstance().getAppLock().setPassword("");
 
         WidgetUtils.updateNoteWidgets(getActivity());
 


### PR DESCRIPTION
### Fix
Add removing the passcode if it is set when a user logs out.  Currently, the passcode is retained after logout causing the user to enter the passcode while logging in or immediately after login.

### Test
There are two scenarios when a user would be logged out when the passcode lock is enabled; manual logout from ***Settings*** and automatic logout from a password change.
#### Logout from Settings
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Tap ***Turn passcode lock on*** item under ***Passcode Lock*** section.
5. Enter passcode.
6. Enter passcode again.
7. Tap recents/overview system navigation button.
8. Wait two seconds.
9. Tap Simplenote app preview in recents/overview.
10. Notice passcode lock is shown.
11. Enter passcode.
12. Tap ***Log out*** item under ***Account*** section.
13. Notice login/signup is shown.
14. Tap recents/overview system navigation button.
15. Wait two seconds.
16. Tap Simplenote app preview in recents/overview.
17. Notice login/signup is shown.

#### Logout from Password
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Tap ***Turn passcode lock on*** item under ***Passcode Lock*** section.
5. Enter passcode.
6. Enter passcode again.
7. Tap recents/overview system navigation button.
8. Wait two seconds.
9. Tap Simplenote app preview in recents/overview.
10. Notice passcode lock is shown.
11. Enter passcode.
12. Tap recents/overview system navigation button.
13. Remove Simplenote app from recents/overview.
14. Change password at https://app.simplenote.com/settings.
15. Launch Simplenote app.
16. Notice login/signup is shown.
17. Tap recents/overview system navigation button.
18. Wait two seconds.
19. Tap Simplenote app preview in recents/overview.
20. Notice login/signup is shown.
21. Log in with new password.
22. Notice note list is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.