### PR TITLE
Crash Tablet Widget

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -72,6 +72,8 @@ public class NoteEditorActivity extends AppCompatActivity {
             // Create the note editor fragment
             Bundle arguments = new Bundle();
             arguments.putString(NoteEditorFragment.ARG_ITEM_ID, mNoteId);
+            arguments.putBoolean(NoteEditorFragment.ARG_IS_FROM_WIDGET,
+                    intent.getBooleanExtra(NoteEditorFragment.ARG_IS_FROM_WIDGET, false));
 
             boolean isNewNote = intent.getBooleanExtra(NoteEditorFragment.ARG_NEW_NOTE, false);
             arguments.putBoolean(NoteEditorFragment.ARG_NEW_NOTE, isNewNote);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -138,6 +138,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private int mCurrentCursorPosition;
     private HistoryBottomSheetDialog mHistoryBottomSheet;
     private boolean mIsPaused;
+    private boolean mIsFromWidget;
+
     // Hides the history bottom sheet if no revisions are loaded
     private final Runnable mHistoryTimeoutRunnable = new Runnable() {
         @Override
@@ -346,8 +348,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mTagInput.setOnFocusChangeListener(this);
         mTagChips = mRootView.findViewById(R.id.tag_chips);
         mHighlighter = new MatchOffsetHighlighter(mMatchHighlighter, mContentEditText);
-
         mPlaceholderView = mRootView.findViewById(R.id.placeholder);
+
         if (DisplayUtils.isLargeScreenLandscape(getActivity()) && mNote == null) {
             mPlaceholderView.setVisibility(View.VISIBLE);
             requireActivity().invalidateOptionsMenu();
@@ -358,18 +360,22 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         }
 
         mTagInput.setAdapter(mAutocompleteAdapter);
-
         Bundle arguments = getArguments();
+
         if (arguments != null && arguments.containsKey(ARG_ITEM_ID)) {
             // Load note if we were passed a note Id
             String key = arguments.getString(ARG_ITEM_ID);
+
             if (arguments.containsKey(ARG_MATCH_OFFSETS)) {
                 mMatchOffsets = arguments.getString(ARG_MATCH_OFFSETS);
             }
+
+            mIsFromWidget = arguments.getBoolean(ARG_IS_FROM_WIDGET);
             new LoadNoteTask(this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, key);
-        } else if (DisplayUtils.isLargeScreenLandscape(getActivity()) && savedInstanceState != null ) {
+        } else if (DisplayUtils.isLargeScreenLandscape(getActivity()) && savedInstanceState != null) {
             // Restore selected note when in dual pane mode
             String noteId = savedInstanceState.getString(STATE_NOTE_ID);
+
             if (noteId != null) {
                 setNote(noteId);
             }
@@ -491,7 +497,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
-        if (!isAdded() || DisplayUtils.isLargeScreenLandscape(getActivity()) && mNoteMarkdownFragment == null) {
+
+        if (!isAdded() || (!mIsFromWidget && DisplayUtils.isLargeScreenLandscape(getActivity()) && mNoteMarkdownFragment == null)) {
             return;
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -88,6 +88,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         HistoryBottomSheetDialog.HistorySheetListener,
         SimplenoteEditText.OnCheckboxToggledListener {
 
+    public static final String ARG_IS_FROM_WIDGET = "is_from_widget";
     public static final String ARG_ITEM_ID = "item_id";
     public static final String ARG_NEW_NOTE = "new_note";
     public static final String ARG_MATCH_OFFSETS = "match_offsets";

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidget.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidget.java
@@ -131,6 +131,7 @@ public class NoteWidget extends AppWidgetProvider {
 
                     // Prepare bundle for NoteEditorActivity
                     Bundle arguments = new Bundle();
+                    arguments.putBoolean(NoteEditorFragment.ARG_IS_FROM_WIDGET, true);
                     arguments.putString(NoteEditorFragment.ARG_ITEM_ID, updatedNote.getSimperiumKey());
                     arguments.putBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED, updatedNote.isMarkdownEnabled());
                     arguments.putBoolean(NoteEditorFragment.ARG_PREVIEW_ENABLED, updatedNote.isPreviewEnabled());

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetConfigureActivity.java
@@ -181,6 +181,7 @@ public class NoteWidgetConfigureActivity extends AppCompatActivity {
 
                     // Prepare bundle for NoteEditorActivity
                     Bundle arguments = new Bundle();
+                    arguments.putBoolean(NoteEditorFragment.ARG_IS_FROM_WIDGET, true);
                     arguments.putString(NoteEditorFragment.ARG_ITEM_ID, note.getSimperiumKey());
                     arguments.putBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED, note.isMarkdownEnabled());
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetConfigureActivity.java
@@ -35,6 +35,7 @@ import com.simperium.client.User;
 import static com.automattic.simplenote.NoteWidget.KEY_WIDGET_CLICK;
 import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
 import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_TAPPED;
 
 public class NoteWidgetConfigureActivity extends AppCompatActivity {
     private AppWidgetManager mWidgetManager;
@@ -189,6 +190,7 @@ public class NoteWidgetConfigureActivity extends AppCompatActivity {
                     // Create intent to navigate to selected note on widget click
                     Intent intent = new Intent(context, NoteEditorActivity.class);
                     intent.putExtras(arguments);
+                    intent.putExtra(KEY_WIDGET_CLICK, NOTE_WIDGET_NOTE_TAPPED);
                     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
                     PendingIntent pendingIntent = PendingIntent.getActivity(context, mAppWidgetId, intent, 0);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetConfigureActivity.java
@@ -184,6 +184,7 @@ public class NoteWidgetConfigureActivity extends AppCompatActivity {
                     arguments.putBoolean(NoteEditorFragment.ARG_IS_FROM_WIDGET, true);
                     arguments.putString(NoteEditorFragment.ARG_ITEM_ID, note.getSimperiumKey());
                     arguments.putBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED, note.isMarkdownEnabled());
+                    arguments.putBoolean(NoteEditorFragment.ARG_PREVIEW_ENABLED, note.isPreviewEnabled());
 
                     // Create intent to navigate to selected note on widget click
                     Intent intent = new Intent(context, NoteEditorActivity.class);


### PR DESCRIPTION
### Fix
Add a flag when the note editor is opened by tapping on a note widget so that the action menu will be inflated in `onCreateOptionsMenu` in the `NoteEditorFragment` class to avoid the `NullPointerException` in `onPrepareOptionsMenu` shown in the stack trace below.  The crash only occurs on large screen devices (e.g. tablets) in landscape orientation.

<details>
<summary>Stack Trace</summary>
<pre>
java.lang.NullPointerException: Attempt to invoke interface method 'android.view.MenuItem android.view.MenuItem.setVisible(boolean)' on a null object reference
    at com.automattic.simplenote.NoteEditorFragment.onPrepareOptionsMenu(NoteEditorFragment.java:566)
    at androidx.fragment.app.Fragment.performPrepareOptionsMenu(Fragment.java:2723)
    at androidx.fragment.app.FragmentManagerImpl.dispatchPrepareOptionsMenu(FragmentManagerImpl.java:2743)
    at androidx.fragment.app.FragmentController.dispatchPrepareOptionsMenu(FragmentController.java:398)
    at androidx.fragment.app.FragmentActivity.onPreparePanel(FragmentActivity.java:489)
    at androidx.appcompat.view.WindowCallbackWrapper.onPreparePanel(WindowCallbackWrapper.java:99)
    at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.onPreparePanel(AppCompatDelegateImpl.java:2857)
    at androidx.appcompat.view.WindowCallbackWrapper.onPreparePanel(WindowCallbackWrapper.java:99)
    at androidx.appcompat.app.ToolbarActionBar$ToolbarCallbackWrapper.onPreparePanel(ToolbarActionBar.java:522)
    at androidx.appcompat.app.ToolbarActionBar.populateOptionsMenu(ToolbarActionBar.java:456)
    at androidx.appcompat.app.ToolbarActionBar$1.run(ToolbarActionBar.java:56)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:874)
    at android.view.Choreographer.doCallbacks(Choreographer.java:686)
    at android.view.Choreographer.doFrame(Choreographer.java:618)
    at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:860)
    at android.os.Handler.handleCallback(Handler.java:751)
    at android.os.Handler.dispatchMessage(Handler.java:95)
    at android.os.Looper.loop(Looper.java:154)
    at android.app.ActivityThread.main(ActivityThread.java:6119)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:886)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:776)
</pre>
</details>

### Test
When performing the test steps below, be sure to use a large screen device (i.e. tablet) in landscape and portrait orientation.  The steps to add a widget assume the AOSP launcher (i.e. Nexus/Pixel launcher).  They may be slightly different based on the launcher used.  Other steps should be the same regardless of launcher.
1. Long-press home screen.
2. Tap ***Widgets*** option.
3. Scroll to ***Simplenote*** widget.
4. Notice ***To-Do List*** preview image.
5. Long-press ***Note*** widget.
6. Place ***Note*** widget on home screen.
7. Notice ***Select Note*** dialog with note list.
8. Tap note in list.
9. Notice note title shown in widget.
10. Tap widget.
11. Notice app does not crash.
12. Notice note is shown in app.
13. Notice actions are shown in app bar.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.