### PR TITLE
Crash Markdown Options

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1340,7 +1340,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
             try {
                 fragment.mNote = notesBucket.get(noteID);
-                fragment.requireActivity().invalidateOptionsMenu();
 
                 // Set the current note in NotesActivity when on a tablet
                 if (fragment.getActivity() instanceof NotesActivity) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1340,6 +1340,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
             try {
                 fragment.mNote = notesBucket.get(noteID);
+                fragment.requireActivity().invalidateOptionsMenu();
 
                 // Set the current note in NotesActivity when on a tablet
                 if (fragment.getActivity() instanceof NotesActivity) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -226,7 +226,6 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
 
             try {
                 fragment.mNote = notesBucket.get(noteID);
-                fragment.requireActivity().invalidateOptionsMenu();
             } catch (BucketObjectMissingException exception) {
                 // TODO: Handle a missing note
             }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -237,12 +237,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
         protected void onPostExecute(Void nada) {
             NoteMarkdownFragment fragment = mNoteMarkdownFragmentReference.get();
             fragment.mIsLoadingNote = false;
-
-            if (fragment.mNote != null) {
-                if (fragment.getActivity() != null) {
-                    fragment.getActivity().invalidateOptionsMenu();
-                }
-            }
+            fragment.requireActivity().invalidateOptionsMenu();
         }
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -226,6 +226,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
 
             try {
                 fragment.mNote = notesBucket.get(noteID);
+                fragment.requireActivity().invalidateOptionsMenu();
             } catch (BucketObjectMissingException exception) {
                 // TODO: Handle a missing note
             }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -130,9 +130,11 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
         MenuItem copyLinkItem = menu.findItem(R.id.menu_copy);
         MenuItem markdownItem = menu.findItem(R.id.menu_markdown);
 
-        pinItem.setChecked(mNote.isPinned());
-        publishItem.setChecked(mNote.isPublished());
-        markdownItem.setChecked(mNote.isMarkdownEnabled());
+        if (mNote != null) {
+            pinItem.setChecked(mNote.isPinned());
+            publishItem.setChecked(mNote.isPublished());
+            markdownItem.setChecked(mNote.isMarkdownEnabled());
+        }
 
         pinItem.setEnabled(false);
         publishItem.setEnabled(false);


### PR DESCRIPTION
### Fix
Add a null check for the `mNote` object in the `onPrepareOptionsMenu` method in the `NoteMarkdownFragment` class to avoid the `NullPointerException` shown in the stack trace below, which we received in our automated crash reporting.

<details>
<summary>Stack Trace</summary>
<pre>
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean com.automattic.simplenote.models.Note.isPinned()' on a null object reference
    at com.automattic.simplenote.NoteMarkdownFragment.onPrepareOptionsMenu
    at androidx.fragment.app.Fragment.performPrepareOptionsMenu
    at androidx.fragment.app.FragmentManagerImpl.dispatchPrepareOptionsMenu
    at androidx.fragment.app.FragmentController.dispatchPrepareOptionsMenu
    at androidx.fragment.app.FragmentActivity.onPreparePanel
    at androidx.appcompat.view.WindowCallbackWrapper.onPreparePanel
    at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.onPreparePanel
    at androidx.appcompat.view.WindowCallbackWrapper.onPreparePanel
    at androidx.appcompat.app.ToolbarActionBar$ToolbarCallbackWrapper.onPreparePanel
    at androidx.appcompat.app.ToolbarActionBar.populateOptionsMenu
    at androidx.appcompat.app.ToolbarActionBar$1.run
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:949)
    at android.view.Choreographer.doCallbacks(Choreographer.java:750)
    at android.view.Choreographer.doFrame(Choreographer.java:666)
    at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:932)
    at android.os.Handler.handleCallback(Handler.java:751)
    at android.os.Handler.dispatchMessage(Handler.java:95)
    at android.os.Looper.loop(Looper.java:154)
    at android.app.ActivityThread.main(ActivityThread.java:6124)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:926)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:788)
</pre>
</details>

I'm not able to reproduce the crash so I can't completely confirm this fix, but looking at the stack trace and the `NoteMarkdownFragment` code makes be confident of these changes.  The `mNote` object is assigned either after the note is saved due to edits _or_ in `LoadNoteTask`.  It's possible that `LoadNoteTask` is not completed and `mNote` is assigned before the `mNote.isPinned()` usage in `onPrepareOptionsMenu` causing the `NullPointerException`, which the null check will fix.  If that occurs, then the `pinItem`, `publishItem`, and `markdownItem` menu items will not be properly set.  To fix that, the `fragment.requireActivity().invalidateOptionsMenu()` statement was added in `LoadNoteTask.onPostExecute`.

### Test
1. Tap note in list with markdown enabled and ***Edit*** tab last shown.
2. Notice app does not crash.
3. Tap back arrow in app bar.
4. Tap note in list with markdown enabled and ***Preview*** tab last shown.
5. Notice app does not crash.
6. Tap back arrow in app bar.
7. Tap note in list without markdown enabled.
8. Notice app does not crash.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.