### PR TITLE
Issue/884 app starts with white background in dark theme

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -18,6 +18,7 @@ import com.automattic.simplenote.models.Preferences;
 import com.automattic.simplenote.models.Tag;
 import com.automattic.simplenote.utils.CrashUtils;
 import com.automattic.simplenote.utils.PrefUtils;
+import com.automattic.simplenote.utils.ThemeUtils;
 import com.simperium.Simperium;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketNameInvalid;
@@ -49,6 +50,8 @@ public class Simplenote extends Application {
         super.onCreate();
 
         CrashUtils.initWithContext(this);
+    
+        ThemeUtils.setNightMode(getApplicationContext());
 
         AppLockManager.getInstance().enableDefaultAppLockIfAvailable(this);
 
@@ -67,7 +70,7 @@ public class Simplenote extends Application {
             mTagsBucket = mSimperium.bucket(tagSchema);
             mPreferencesBucket = mSimperium.bucket(new Preferences.Schema());
             mPreferencesBucket.start();
-
+            
             // Every time a note changes or is deleted we need to reindex the tag counts
             mNotesBucket.addListener(new NoteTagger(mTagsBucket));
         } catch (BucketNameInvalid e) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -47,8 +47,8 @@ public class ThemeUtils {
             }
         }
         
-        // Don't need to call this from `setTheme` since NightMode is being set at the Application level in `Simplenote`
-        // setNightMode(activity);
+        // Kept here because PreferencesFragment applies theme using Activity.recreate() which calls setTheme in PreferencesActivity.onCreate()
+        setNightMode(activity);
     }
     
     public static void setNightMode(Context context) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -46,8 +46,13 @@ public class ThemeUtils {
                 }
             }
         }
-
-        switch (PrefUtils.getIntPref(activity, PrefUtils.PREF_THEME, THEME_LIGHT)) {
+        
+        // Don't need to call this from `setTheme` since NightMode is being set at the Application level in `Simplenote`
+        // setNightMode(activity);
+    }
+    
+    public static void setNightMode(Context context) {
+        switch (PrefUtils.getIntPref(context, PrefUtils.PREF_THEME, THEME_LIGHT)) {
             case THEME_AUTO:
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
                 break;


### PR DESCRIPTION
### Fix

Potential fix for #884 .
- Extracted the call to `AppCompatDelegate.setDefaultNightMode` from `ThemeUtils.setTheme` into a new static method `ThemeUtils.setNightMode`.
- `ThemeUtils.setNightMode` is now called from the Application class `Simplenote`.

Discussed in [comment here](https://github.com/Automattic/simplenote-android/issues/884#issuecomment-588291188).

### Test

> 1. Set the app theme to `Dark`, or set it to `System default` and set the device in night mode.  
> 2. Close the app, and remove it from recent apps to force system to stop and destroy the app.  
> 3. Open the app again. 

The app should reopen with a dark splash screen before displaying contents. If the app briefly shows a white splash screen before opening in dark mode, the bug is still not fixed.

### Review
A developer is required to review the changes. 

Specifically, someone needs to confirm the placement of call to `ThemeUtils.setNightMode` in `Simplenote.onCreate`. I have placed it as early as possible—right after CrashUtils initialisation, though it may be safely moved anywhere within the `onCreate` method.

### Release
These changes do not require release notes.
