### PR TITLE
Update Widget Checklist

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDark.java
@@ -131,6 +131,7 @@ public class NoteWidgetDark extends AppWidgetProvider {
 
                     // Prepare bundle for NoteEditorActivity
                     Bundle arguments = new Bundle();
+                    arguments.putBoolean(NoteEditorFragment.ARG_IS_FROM_WIDGET, true);
                     arguments.putString(NoteEditorFragment.ARG_ITEM_ID, updatedNote.getSimperiumKey());
                     arguments.putBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED, updatedNote.isMarkdownEnabled());
                     arguments.putBoolean(NoteEditorFragment.ARG_PREVIEW_ENABLED, updatedNote.isPreviewEnabled());

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDark.java
@@ -6,11 +6,13 @@ import android.appwidget.AppWidgetProvider;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.SpannableStringBuilder;
 import android.view.View;
 import android.widget.RemoteViews;
 
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
+import com.automattic.simplenote.utils.ChecklistUtils;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.simperium.Simperium;
 import com.simperium.client.Bucket;
@@ -155,7 +157,12 @@ public class NoteWidgetDark extends AppWidgetProvider {
                     views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_dark, context.getTheme()));
                     views.setTextViewText(R.id.widget_text_title, title);
                     views.setTextColor(R.id.widget_text_title, context.getResources().getColor(R.color.text_title_dark, context.getTheme()));
-                    views.setTextViewText(R.id.widget_text_content, content);
+                    SpannableStringBuilder contentSpan = new SpannableStringBuilder(content);
+                    contentSpan = (SpannableStringBuilder) ChecklistUtils.addChecklistUnicodeSpansForRegex(
+                            contentSpan,
+                            ChecklistUtils.CHECKLIST_REGEX
+                    );
+                    views.setTextViewText(R.id.widget_text_content, contentSpan);
                 } catch (BucketObjectMissingException e) {
                     // Create intent to navigate to widget configure activity on widget click
                     Intent intent = new Intent(context, NoteWidgetDarkConfigureActivity.class);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.os.Bundle;
+import android.text.SpannableStringBuilder;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -25,6 +26,7 @@ import androidx.preference.PreferenceManager;
 
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
+import com.automattic.simplenote.utils.ChecklistUtils;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.simperium.Simperium;
 import com.simperium.client.Bucket;
@@ -168,7 +170,13 @@ public class NoteWidgetDarkConfigureActivity extends AppCompatActivity {
 
             // Populate fields with extracted properties
             titleTextView.setText(title);
-            contentTextView.setText(snippet);
+            SpannableStringBuilder snippetSpan = new SpannableStringBuilder(snippet);
+            snippetSpan = (SpannableStringBuilder) ChecklistUtils.addChecklistSpansForRegexAndColor(
+                    context,
+                    snippetSpan,
+                    ChecklistUtils.CHECKLIST_REGEX,
+                    R.color.text_title_disabled);
+            contentTextView.setText(snippetSpan);
 
             view.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -206,7 +214,12 @@ public class NoteWidgetDarkConfigureActivity extends AppCompatActivity {
                     mRemoteViews.setTextColor(R.id.widget_text, getResources().getColor(R.color.text_title_dark, context.getTheme()));
                     mRemoteViews.setTextViewText(R.id.widget_text_title, title);
                     mRemoteViews.setTextColor(R.id.widget_text_title, context.getResources().getColor(R.color.text_title_dark, context.getTheme()));
-                    mRemoteViews.setTextViewText(R.id.widget_text_content, content);
+                    SpannableStringBuilder contentSpan = new SpannableStringBuilder(content);
+                    contentSpan = (SpannableStringBuilder) ChecklistUtils.addChecklistUnicodeSpansForRegex(
+                            contentSpan,
+                            ChecklistUtils.CHECKLIST_REGEX
+                    );
+                    mRemoteViews.setTextViewText(R.id.widget_text_content, contentSpan);
                     mWidgetManager.updateAppWidget(mAppWidgetId, mRemoteViews);
 
                     // Set the result as successful

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
@@ -184,6 +184,7 @@ public class NoteWidgetDarkConfigureActivity extends AppCompatActivity {
                     arguments.putBoolean(NoteEditorFragment.ARG_IS_FROM_WIDGET, true);
                     arguments.putString(NoteEditorFragment.ARG_ITEM_ID, note.getSimperiumKey());
                     arguments.putBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED, note.isMarkdownEnabled());
+                    arguments.putBoolean(NoteEditorFragment.ARG_PREVIEW_ENABLED, note.isPreviewEnabled());
 
                     // Create intent to navigate to selected note on widget click
                     Intent intent = new Intent(context, NoteEditorActivity.class);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
@@ -34,6 +34,7 @@ import com.simperium.client.User;
 
 import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
 import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_TAPPED;
 import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
 
 public class NoteWidgetDarkConfigureActivity extends AppCompatActivity {
@@ -189,6 +190,7 @@ public class NoteWidgetDarkConfigureActivity extends AppCompatActivity {
                     // Create intent to navigate to selected note on widget click
                     Intent intent = new Intent(context, NoteEditorActivity.class);
                     intent.putExtras(arguments);
+                    intent.putExtra(KEY_WIDGET_CLICK, NOTE_WIDGET_NOTE_TAPPED);
                     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
                     PendingIntent pendingIntent = PendingIntent.getActivity(context, mAppWidgetId, intent, 0);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLight.java
@@ -6,11 +6,13 @@ import android.appwidget.AppWidgetProvider;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.SpannableStringBuilder;
 import android.view.View;
 import android.widget.RemoteViews;
 
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
+import com.automattic.simplenote.utils.ChecklistUtils;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.simperium.Simperium;
 import com.simperium.client.Bucket;
@@ -155,7 +157,12 @@ public class NoteWidgetLight extends AppWidgetProvider {
                     views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_light, context.getTheme()));
                     views.setTextViewText(R.id.widget_text_title, title);
                     views.setTextColor(R.id.widget_text_title, context.getResources().getColor(R.color.text_title_light, context.getTheme()));
-                    views.setTextViewText(R.id.widget_text_content, content);
+                    SpannableStringBuilder contentSpan = new SpannableStringBuilder(content);
+                    contentSpan = (SpannableStringBuilder) ChecklistUtils.addChecklistUnicodeSpansForRegex(
+                            contentSpan,
+                            ChecklistUtils.CHECKLIST_REGEX
+                    );
+                    views.setTextViewText(R.id.widget_text_content, contentSpan);
                 } catch (BucketObjectMissingException e) {
                     // Create intent to navigate to widget configure activity on widget click
                     Intent intent = new Intent(context, NoteWidgetLightConfigureActivity.class);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLightConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLightConfigureActivity.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.os.Bundle;
+import android.text.SpannableStringBuilder;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -25,6 +26,7 @@ import androidx.preference.PreferenceManager;
 
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
+import com.automattic.simplenote.utils.ChecklistUtils;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.simperium.Simperium;
 import com.simperium.client.Bucket;
@@ -168,7 +170,13 @@ public class NoteWidgetLightConfigureActivity extends AppCompatActivity {
 
             // Populate fields with extracted properties
             titleTextView.setText(title);
-            contentTextView.setText(snippet);
+            SpannableStringBuilder snippetSpan = new SpannableStringBuilder(snippet);
+            snippetSpan = (SpannableStringBuilder) ChecklistUtils.addChecklistSpansForRegexAndColor(
+                    context,
+                    snippetSpan,
+                    ChecklistUtils.CHECKLIST_REGEX,
+                    R.color.text_title_disabled);
+            contentTextView.setText(snippetSpan);
 
             view.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -206,7 +214,12 @@ public class NoteWidgetLightConfigureActivity extends AppCompatActivity {
                     mRemoteViews.setTextColor(R.id.widget_text, getResources().getColor(R.color.text_title_light, context.getTheme()));
                     mRemoteViews.setTextViewText(R.id.widget_text_title, title);
                     mRemoteViews.setTextColor(R.id.widget_text_title, context.getResources().getColor(R.color.text_title_light, context.getTheme()));
-                    mRemoteViews.setTextViewText(R.id.widget_text_content, content);
+                    SpannableStringBuilder contentSpan = new SpannableStringBuilder(content);
+                    contentSpan = (SpannableStringBuilder) ChecklistUtils.addChecklistUnicodeSpansForRegex(
+                            contentSpan,
+                            ChecklistUtils.CHECKLIST_REGEX
+                    );
+                    mRemoteViews.setTextViewText(R.id.widget_text_content, contentSpan);
                     mWidgetManager.updateAppWidget(mAppWidgetId, mRemoteViews);
 
                     // Set the result as successful

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ChecklistUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ChecklistUtils.java
@@ -15,7 +15,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ChecklistUtils {
-
     public static String CHECKLIST_REGEX = "(\\s+)?(-[ \\t]+\\[[xX\\s]?\\])";
     public static String CHECKLIST_REGEX_LINES = "^(\\s+)?(-[ \\t]+\\[[xX\\s]?\\])";
     public static String CHECKED_MARKDOWN = "- [x]";
@@ -81,6 +80,48 @@ public class ChecklistUtils {
 
         return editable;
     }
+
+    /***
+     * Adds CheckableSpans for matching markdown formatted checklists.
+     * @param editable the spannable string to run the regex against.
+     * @param regex the regex pattern, use either CHECKLIST_REGEX or CHECKLIST_REGEX_LINES
+     * @return Editable - resulting spannable string
+     */
+    public static Editable addChecklistUnicodeSpansForRegex(Editable editable, String regex) {
+        if (editable == null) {
+            return new SpannableStringBuilder("");
+        }
+
+        Pattern p = Pattern.compile(regex, Pattern.MULTILINE);
+        Matcher m = p.matcher(editable);
+
+        int positionAdjustment = 0;
+        while(m.find()) {
+            int start = m.start() - positionAdjustment;
+            int end = m.end() - positionAdjustment;
+
+            // Safety first!
+            if (end > editable.length()) {
+                continue;
+            }
+
+            String leadingSpaces = m.group(1);
+            if (!TextUtils.isEmpty(leadingSpaces)) {
+                start += leadingSpaces.length();
+            }
+
+            String match = m.group(2);
+            if (match == null) {
+                continue;
+            }
+
+            CheckableSpan checkableSpan = new CheckableSpan();
+            checkableSpan.setChecked(match.contains("x") || match.contains("X"));
+            editable.replace(start, end, checkableSpan.isChecked() ? "\u2611" : "\u2610");
+            editable.setSpan(checkableSpan, start, start + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+            positionAdjustment += (end - start) - 1;
+        }
+
+        return editable;
+    }
 }
-
-


### PR DESCRIPTION
### Fix
Update the note widgets to show Unicode characters for checked and unchecked items and the note widget configure interfaces to show the checked or unchecked `Drawable` in the ***Select Note*** dialog list.  Unfortunately, widgets do not support an `ImageSpan`  in a `TextView` so we are unable to show a custom `Drawable` as shown in the note list and note editor within the app.  As a workaround, I chose to use the `ballot box with check` (`\u2611`) and `ballot box` (`\u2610`) Unicode characters to represent checked and unchecked items, respectively.  See the screenshots below for illustration.

![widget_checklist_note](https://user-images.githubusercontent.com/3827611/74392679-35849980-4dc5-11ea-8fb0-d2c8aaec164b.png)

![widget_checklist_list](https://user-images.githubusercontent.com/3827611/74392685-37e6f380-4dc5-11ea-9c42-2575821b1cfa.png)

### Test
These steps assume the AOSP launcher (i.e. Nexus/Pixel launcher). The steps to add the widget to the home screen may be slightly different based on the launcher used. Other steps should be the same regardless of launcher.

0. Create note with checked and unchecked items.
1. Long-press home screen.
2. Tap ***Widgets*** option.
3. Scroll to ***Simplenote*** widget.
4. Notice ***Note (Dark)*** and ***Note (Light)*** widgets with ***To-Do List*** preview images.
5. Long-press ***Note (Dark)*** or ***Note (Light)*** widget.
6. Place widget on home screen.
7. Notice ***Select Note*** dialog with note list.
8. Notice note with checked and unchecked items.
9. Tap note with checked and unchecked items in list.
10. Notice note title shown in widget.
11. Long-press widget.
12. Notice circular handles are shown.
13. Drag circular handles horizontally and vertically.
14. Notice note title and content are shown in widget with checked and unchecked items when large enough.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.