### PR TITLE
Issue/952 search highlighting checklists

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.5
 -----
 * Added a dark version of the note widget to view and open a note in the app from the home screen
+* Fixed a bug that highlighted search terms incorrectly in notes with checklists
  
 2.4
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ChecklistUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ChecklistUtils.java
@@ -20,7 +20,7 @@ public class ChecklistUtils {
     public static String CHECKLIST_REGEX_LINES = "^(\\s+)?(-[ \\t]+\\[[xX\\s]?\\])";
     public static String CHECKED_MARKDOWN = "- [x]";
     public static String UNCHECKED_MARKDOWN = "- [ ]";
-    public static final int CHECKLIST_OFFSET = 4;
+    public static final int CHECKLIST_OFFSET = 3;
 
     /***
      * Adds CheckableSpans for matching markdown formatted checklists.


### PR DESCRIPTION
### Fix
Update the `CHECKLIST_OFFSET ` constant from 4 to 3 in  `ChecklistUtils`, which is used to calculate the start and end locations of the highlighted text for matching search terms, to close https://github.com/Automattic/simplenote-android/issues/952.  See the screenshots below for illustration.

![952_search_highlighting_checklists](https://user-images.githubusercontent.com/3827611/75041046-0501c700-5479-11ea-939b-2de3e599bcba.png)

### Test
0. Create note with checklist.
1. Tap ***Search*** action in app bar.
2. Enter text from note after at least one checkbox.
3. Notice search results highlight searched term correctly.
4. Tap note in search results.
5. Notice editor highlights searched term correctly.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 4fa70cda with:
> Fixed a bug that highlighted search terms incorrectly in notes with checklists