### PR TITLE
Issue/956 disable hiding bar

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -36,7 +36,6 @@ import android.webkit.WebView;
 import android.widget.CompoundButton;
 import android.widget.CursorAdapter;
 import android.widget.LinearLayout;
-import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -402,15 +401,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                     // Calculate how far to scroll to bring the match into view
                     Layout layout = mContentEditText.getLayout();
                     int lineTop = layout.getLineTop(layout.getLineForOffset(matchLocation));
-
-                    // We use different scroll views in the root of the layout files... yuck.
-                    // So we have to cast appropriately to do a smooth scroll
-                    if (mRootView instanceof NestedScrollView) {
-                        ((NestedScrollView)mRootView).smoothScrollTo(0, lineTop);
-                    } else {
-                        ((ScrollView)mRootView).smoothScrollTo(0, lineTop);
-                    }
-
+                    ((NestedScrollView) mRootView).smoothScrollTo(0, lineTop);
                     mShouldScrollToSearchMatch = false;
                 }
             }

--- a/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScrollView
+<androidx.core.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/note_editor"
@@ -140,4 +140,4 @@
 
     </FrameLayout>
 
-</ScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/Simplenote/src/main/res/layout/activity_note_editor.xml
+++ b/Simplenote/src/main/res/layout/activity_note_editor.xml
@@ -19,7 +19,6 @@
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/toolbarColor"
             app:contentInsetStart="@dimen/toolbar_title_keyline"
-            app:layout_scrollFlags="scroll|enterAlways"
             app:popupTheme="?attr/toolbarPopupTheme"
             style="@style/ToolbarTheme">
         </androidx.appcompat.widget.Toolbar>


### PR DESCRIPTION
### Fix
Remove the `app:layout_scrollFlags` attribute from the `Toolbar` in order to disable hiding/showing on scrolling up/down to close https://github.com/Automattic/simplenote-android/issues/956 and close https://github.com/Automattic/simplenote-android/issues/442.  The parent view in the `layout-large-land/fragment_note_editor` layout was also updated from `ScrollView` to `NestedScrollView` to allow for smooth scrolling with flinging.  See the animations and screenshots below for illustration.

Before|After
-|-
![956_disable_hiding_bar_before](https://user-images.githubusercontent.com/3827611/75055748-d5f84f00-5492-11ea-8d11-9616a0a5c9ee.gif)|![956_disable_hiding_bar_after](https://user-images.githubusercontent.com/3827611/75055765-db559980-5492-11ea-850f-05d757e3e91c.gif)
![956_disable_hiding_bar_tabs_before](https://user-images.githubusercontent.com/3827611/75057102-836c6200-5495-11ea-90f6-fdacb9c8a2fd.gif)|![956_disable_hiding_bar_tabs_after](https://user-images.githubusercontent.com/3827611/75057004-4acc8880-5495-11ea-9376-63d1be468f82.gif)

![956_disable_hiding_bar_tabs](https://user-images.githubusercontent.com/3827611/75056830-00e3a280-5495-11ea-91eb-c78892dfa915.png)

### Test
The hiding/showing on scrolling up/down only existed in the `layout/activity_note_editor` layout, which means that behavior will only change for phone-sized devices.  Since the `layout-large-land/fragment_note_editor` layout was edited too, testing on a tablet-sized device is required also.
1. Tap any note in list with markdown disabled.
2. If note content does not overflow screen, notice ***Add tag...*** field is shown.
3. If note content does overflow screen, notice ***Add tag...*** field is not shown.
4. If note content does overflow screen, scroll up/down.
5. Notice top app bar is not hidden/shown on scrolling up/down.
6. Tap back arrow in top app bar.
7. Tap any note in list with markdown enabled.
8. Notice ***Edit*** and ***Preview*** tabs are shown.
9. If note content does overflow screen, scroll up/down.
10. Notice top app bar is not hidden/shown on scrolling up/down.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.