### PR TITLE
List Widget Padding

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
@@ -34,7 +34,7 @@ public class NoteListWidgetDark extends AppWidgetProvider {
     @Override
     public void onAppWidgetOptionsChanged(Context context, AppWidgetManager appWidgetManager, int appWidgetId, Bundle newOptions) {
         RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.note_list_widget_dark);
-        resizeWidget(newOptions, views);
+        resizeWidget(context, newOptions, views);
         appWidgetManager.updateAppWidget(appWidgetId, views);
     }
 
@@ -83,19 +83,21 @@ public class NoteListWidgetDark extends AppWidgetProvider {
         }
     }
 
-    private void resizeWidget(Bundle appWidgetOptions, RemoteViews views) {
+    private void resizeWidget(Context context, Bundle appWidgetOptions, RemoteViews views) {
         // Show/Hide add button based on widget height and width
         if (appWidgetOptions.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT) > MINIMUM_HEIGHT_FOR_BUTTON &&
             appWidgetOptions.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH) > MINIMUM_WIDTH_FOR_BUTTON) {
+            views.setViewPadding(R.id.widget_list, 0, 0, 0, context.getResources().getDimensionPixelSize(R.dimen.note_list_item_padding_bottom_button_widget));
             views.setViewVisibility(R.id.widget_button, View.VISIBLE);
         } else {
+            views.setViewPadding(R.id.widget_list, 0, 0, 0, 0);
             views.setViewVisibility(R.id.widget_button, View.GONE);
         }
     }
 
     private void updateWidget(Context context, AppWidgetManager appWidgetManager, int appWidgetId, Bundle appWidgetOptions) {
         RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.note_list_widget_dark);
-        resizeWidget(appWidgetOptions, views);
+        resizeWidget(context, appWidgetOptions, views);
 
         // Verify user authentication
         Simplenote currentApp = (Simplenote) context.getApplicationContext();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
@@ -34,7 +34,7 @@ public class NoteListWidgetLight extends AppWidgetProvider {
     @Override
     public void onAppWidgetOptionsChanged(Context context, AppWidgetManager appWidgetManager, int appWidgetId, Bundle newOptions) {
         RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.note_list_widget_light);
-        resizeWidget(newOptions, views);
+        resizeWidget(context, newOptions, views);
         appWidgetManager.updateAppWidget(appWidgetId, views);
     }
 
@@ -83,19 +83,21 @@ public class NoteListWidgetLight extends AppWidgetProvider {
         }
     }
 
-    private void resizeWidget(Bundle appWidgetOptions, RemoteViews views) {
+    private void resizeWidget(Context context, Bundle appWidgetOptions, RemoteViews views) {
         // Show/Hide add button based on widget height and width
         if (appWidgetOptions.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT) > MINIMUM_HEIGHT_FOR_BUTTON &&
             appWidgetOptions.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH) > MINIMUM_WIDTH_FOR_BUTTON) {
+            views.setViewPadding(R.id.widget_list, 0, 0, 0, context.getResources().getDimensionPixelSize(R.dimen.note_list_item_padding_bottom_button_widget));
             views.setViewVisibility(R.id.widget_button, View.VISIBLE);
         } else {
+            views.setViewPadding(R.id.widget_list, 0, 0, 0, 0);
             views.setViewVisibility(R.id.widget_button, View.GONE);
         }
     }
 
     private void updateWidget(Context context, AppWidgetManager appWidgetManager, int appWidgetId, Bundle appWidgetOptions) {
         RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.note_list_widget_light);
-        resizeWidget(appWidgetOptions, views);
+        resizeWidget(context, appWidgetOptions, views);
 
         // Verify user authentication
         Simplenote currentApp = (Simplenote) context.getApplicationContext();

--- a/Simplenote/src/main/res/layout/note_list_widget_dark.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_dark.xml
@@ -30,6 +30,7 @@
         android:divider="@null"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
+        android:paddingBottom="@dimen/note_list_item_padding_bottom_button_widget"
         android:scrollbarStyle="outsideOverlay"
         android:visibility="gone"
         tools:listitem="@layout/note_list_widget_item_dark"

--- a/Simplenote/src/main/res/layout/note_list_widget_light.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_light.xml
@@ -30,6 +30,7 @@
         android:divider="@null"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
+        android:paddingBottom="@dimen/note_list_item_padding_bottom_button_widget"
         android:scrollbarStyle="outsideOverlay"
         android:visibility="gone"
         tools:listitem="@layout/note_list_widget_item_light"

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -22,6 +22,7 @@
 
     <dimen name="note_list_item_padding_bottom">@dimen/padding_medium</dimen>
     <dimen name="note_list_item_padding_bottom_button">88dp</dimen>
+    <dimen name="note_list_item_padding_bottom_button_widget">64dp</dimen>
     <dimen name="note_list_item_padding_top">@dimen/padding_medium</dimen>
 
     <!-- https://support.google.com/accessibility/android/answer/7101858 -->


### PR DESCRIPTION
### Fix
Add padding to the bottom of the note list widget to avoid obscuring the last item in the list with the note button.  When the widget is resized and the note button is shown, the padding is shown.  When the widget is resized and the note button is hidden, the padding is hidden.  See the screenshots below for illustration.

![widget_note_list_padding](https://user-images.githubusercontent.com/3827611/75558139-94b9ef00-59fe-11ea-9a29-dd79081935da.png)

### Test
These steps assume the AOSP launcher (i.e. Nexus/Pixel launcher). The steps to add the widget to the home screen may be slightly different based on the launcher used. Other steps should be the same regardless of launcher.
1. Long-press home screen.
2. Tap ***Widgets*** option.
3. Scroll to ***Simplenote*** widget.
4. Notice ***Note List (Dark)*** and ***Note List (Light)*** widgets.
5. Long-press either widget.
6. Place widget on home screen.
7. Notice note list shown in widget.
8. Notice note button is not shown.
8. Scroll to bottom of list.
10. Notice bottom padding is not shown.
11. Long-press widget.
12. Notice circular handles are shown.
13. Drag circular handles horizontally and vertically.
14. Notice note button is shown.
15. Scroll to bottom of list.
16. Notice bottom padding is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.