### PR TITLE
Update Gradle Plugin

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -49,7 +49,7 @@ public class ThemeUtils {
 
         switch (PrefUtils.getIntPref(activity, PrefUtils.PREF_THEME, THEME_LIGHT)) {
             case THEME_AUTO:
-                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO_TIME);
                 break;
             case THEME_DARK:
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.google.com' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 05 09:47:38 MDT 2019
+#Wed Feb 19 17:54:16 MST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
### Fix
Update the Gradle build tools version from `3.4.1` to `3.5.3` and wrapper version from `5.1.1` to `5.4.1`.

### Test
Since these changes have no user-facing aspect, building the app and smoke testing is all that is required.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.