### PR TITLE
Add Tags Search

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Added a dark version of the note widget to view and open a note in the app from the home screen
 * Added a note list widget to open any note in the app from the home screen
 * Added support for right-to-left languages and layouts
+* Added search to tags list
 * Fixed a bug that highlighted search terms incorrectly in notes with checklists
 
 2.4

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsListFragment.java
@@ -21,9 +21,12 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.appcompat.widget.SearchView;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -31,6 +34,9 @@ import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
 import com.automattic.simplenote.utils.BaseCursorAdapter;
+import com.automattic.simplenote.utils.DisplayUtils;
+import com.automattic.simplenote.utils.DrawableUtils;
+import com.automattic.simplenote.utils.HtmlCompat;
 import com.automattic.simplenote.widgets.EmptyViewRecyclerView;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObjectNameInvalid;
@@ -39,18 +45,106 @@ import com.simperium.client.Query;
 import java.lang.ref.SoftReference;
 import java.util.List;
 
-public class TagsListFragment extends Fragment implements ActionMode.Callback, Bucket.Listener<Tag> {
+import static com.automattic.simplenote.models.Tag.NAME_PROPERTY;
 
+public class TagsListFragment extends Fragment implements ActionMode.Callback, Bucket.Listener<Tag> {
     private ActionMode mActionMode;
     private Bucket<Tag> mTagsBucket;
     private Bucket<Note> mNotesBucket;
+    private EmptyViewRecyclerView mTagsList;
+    private ImageView mEmptyViewImage;
+    private MenuItem mSearchMenuItem;
+    private String mSearchQuery;
     private TagsAdapter mTagsAdapter;
+    private TextView mEmptyViewText;
+    private boolean mIsSearching;
 
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
      * fragment (e.g. upon screen orientation changes).
      */
     public TagsListFragment() {
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
+    }
+
+    @Override
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
+        super.onCreateOptionsMenu(menu, inflater);
+        inflater.inflate(R.menu.tags_list, menu);
+        DrawableUtils.tintMenuWithAttribute(getActivity(), menu, R.attr.toolbarIconColor);
+
+        mSearchMenuItem = menu.findItem(R.id.menu_search);
+        mSearchMenuItem.setOnActionExpandListener(
+            new MenuItem.OnActionExpandListener() {
+                @Override
+                public boolean onMenuItemActionCollapse(MenuItem item) {
+                    mIsSearching = false;
+                    return true;
+                }
+
+                @Override
+                public boolean onMenuItemActionExpand(MenuItem item) {
+                    mIsSearching = true;
+                    return true;
+                }
+            }
+        );
+        SearchView searchView = (SearchView) mSearchMenuItem.getActionView();
+        LinearLayout searchEditFrame = searchView.findViewById(R.id.search_edit_frame);
+        ((LinearLayout.LayoutParams) searchEditFrame.getLayoutParams()).leftMargin = 0;
+
+        // Workaround for setting the search placeholder text color.
+        @SuppressWarnings("ResourceType")
+        String hintHexColor = getString(R.color.text_title_disabled).replace("ff", "");
+        searchView.setQueryHint(
+            HtmlCompat.fromHtml(
+                String.format(
+                    "<font color=\"%s\">%s</font>",
+                    hintHexColor,
+                    getString(R.string.search_tags)
+                )
+            )
+        );
+
+        searchView.setOnQueryTextListener(
+            new SearchView.OnQueryTextListener() {
+                @Override
+                public boolean onQueryTextChange(String query) {
+                    if (mSearchMenuItem.isActionViewExpanded()) {
+                        mSearchQuery = query;
+                        refreshTagsSearch();
+                        mTagsList.scrollToPosition(0);
+                        checkEmptyList();
+                    }
+
+                    return true;
+                }
+
+                @Override
+                public boolean onQueryTextSubmit(String queryText) {
+                    return true;
+                }
+            }
+        );
+
+        searchView.setOnCloseListener(
+            new SearchView.OnCloseListener() {
+                @Override
+                public boolean onClose() {
+                    mIsSearching = false;
+                    mSearchQuery = "";
+                    refreshTags();
+                    mTagsList.scrollToPosition(0);
+                    checkEmptyList();
+                    return false;
+                }
+            }
+        );
     }
 
     @Override
@@ -68,16 +162,15 @@ public class TagsListFragment extends Fragment implements ActionMode.Callback, B
         mTagsBucket = application.getTagsBucket();
         mNotesBucket = application.getNotesBucket();
 
-        EmptyViewRecyclerView recyclerView = getActivity().findViewById(R.id.list);
+        mTagsList = getActivity().findViewById(R.id.list);
         mTagsAdapter = new TagsAdapter();
-        recyclerView.setAdapter(mTagsAdapter);
-        recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
+        mTagsList.setAdapter(mTagsAdapter);
+        mTagsList.setLayoutManager(new LinearLayoutManager(getActivity()));
         View emptyView = getActivity().findViewById(R.id.empty);
-        ImageView emptyViewImage = emptyView.findViewById(R.id.image);
-        emptyViewImage.setImageResource(R.drawable.ic_tag_24dp);
-        TextView emptyViewText = emptyView.findViewById(R.id.text);
-        emptyViewText.setText(R.string.empty_tags);
-        recyclerView.setEmptyView(emptyView);
+        mEmptyViewImage = emptyView.findViewById(R.id.image);
+        mEmptyViewText = emptyView.findViewById(R.id.text);
+        checkEmptyList();
+        mTagsList.setEmptyView(emptyView);
 
         refreshTags();
     }
@@ -106,10 +199,51 @@ public class TagsListFragment extends Fragment implements ActionMode.Callback, B
         mTagsBucket.stop();
     }
 
+    public void checkEmptyList() {
+        if (mIsSearching) {
+            if (DisplayUtils.isLandscape(getActivity()) && !DisplayUtils.isLargeScreen(getActivity())) {
+                setEmptyListImage(-1);
+                setEmptyListMessage(getString(R.string.empty_tags_search));
+            } else {
+                setEmptyListImage(R.drawable.ic_search_24dp);
+                setEmptyListMessage(getString(R.string.empty_tags_search));
+            }
+        } else {
+            setEmptyListImage(R.drawable.ic_tag_24dp);
+            setEmptyListMessage(getString(R.string.empty_tags));
+        }
+    }
+
     protected void refreshTags() {
         Query<Tag> tagQuery = Tag.all(mTagsBucket).reorder().orderByKey().include(Tag.NOTE_COUNT_INDEX_NAME);
         Bucket.ObjectCursor<Tag> cursor = tagQuery.execute();
         mTagsAdapter.swapCursor(cursor);
+    }
+
+    protected void refreshTagsSearch() {
+        Query<Tag> tags = Tag.all(mTagsBucket)
+            .where(NAME_PROPERTY, Query.ComparisonType.LIKE, "%" + mSearchQuery + "%")
+            .orderByKey().include(Tag.NOTE_COUNT_INDEX_NAME)
+            .reorder();
+        Bucket.ObjectCursor<Tag> cursor = tags.execute();
+        mTagsAdapter.swapCursor(cursor);
+    }
+
+    private void setEmptyListImage(@DrawableRes int image) {
+        if (mEmptyViewImage != null) {
+            if (image != -1) {
+                mEmptyViewImage.setVisibility(View.VISIBLE);
+                mEmptyViewImage.setImageResource(image);
+            } else {
+                mEmptyViewImage.setVisibility(View.GONE);
+            }
+        }
+    }
+
+    private void setEmptyListMessage(String message) {
+        if (mEmptyViewText != null && message != null) {
+            mEmptyViewText.setText(message);
+        }
     }
 
     // TODO: Finish bulk editing
@@ -160,7 +294,11 @@ public class TagsListFragment extends Fragment implements ActionMode.Callback, B
             getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    refreshTags();
+                    if (mIsSearching) {
+                        refreshTagsSearch();
+                    } else {
+                        refreshTags();
+                    }
                 }
             });
         }
@@ -172,7 +310,11 @@ public class TagsListFragment extends Fragment implements ActionMode.Callback, B
             getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    refreshTags();
+                    if (mIsSearching) {
+                        refreshTagsSearch();
+                    } else {
+                        refreshTags();
+                    }
                 }
             });
         }
@@ -184,7 +326,11 @@ public class TagsListFragment extends Fragment implements ActionMode.Callback, B
             getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    refreshTags();
+                    if (mIsSearching) {
+                        refreshTagsSearch();
+                    } else {
+                        refreshTags();
+                    }
                 }
             });
         }
@@ -226,9 +372,7 @@ public class TagsListFragment extends Fragment implements ActionMode.Callback, B
     }
 
     private class TagsAdapter extends BaseCursorAdapter<TagsAdapter.ViewHolder> {
-
         public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
-
             private TextView tagTitle;
             private TextView tagCountTextView;
             private ImageButton deleteButton;
@@ -344,18 +488,16 @@ public class TagsListFragment extends Fragment implements ActionMode.Callback, B
         public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
             Context context = parent.getContext();
             LayoutInflater inflater = LayoutInflater.from(context);
-
             View contactView = inflater.inflate(R.layout.tags_list_row, parent, false);
-
             return new ViewHolder(contactView);
         }
 
         @Override
         public void onBindViewHolder(@NonNull ViewHolder holder, Cursor cursor) {
             Tag tag = ((Bucket.ObjectCursor<Tag>)cursor).getObject();
-
             holder.tagTitle.setText(tag.getName());
             final int tagCount = mNotesBucket.query().where("tags", Query.ComparisonType.EQUAL_TO, tag.getName()).count();
+
             if (tagCount > 0) {
                 holder.tagCountTextView.setText(String.valueOf(tagCount));
             } else {

--- a/Simplenote/src/main/res/layout/tags_list_row.xml
+++ b/Simplenote/src/main/res/layout/tags_list_row.xml
@@ -41,7 +41,6 @@
         android:focusable="false"
         android:focusableInTouchMode="false"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/padding_extra_small"
         android:layout_width="wrap_content"
         android:minHeight="@dimen/minimum_target"
         android:minWidth="@dimen/minimum_target"

--- a/Simplenote/src/main/res/menu/tags_list.xml
+++ b/Simplenote/src/main/res/menu/tags_list.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="AlwaysShowAction">
+
+    <item
+        android:id="@+id/menu_search"
+        android:icon="@drawable/ic_search_24dp"
+        android:title="@string/search_tags"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:showAsAction="always|collapseActionView">
+    </item>
+
+</menu>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="notes_selected">%d notes selected</string>
     <string name="note_added">Note added</string>
     <string name="search">Search notes or tags</string>
+    <string name="search_tags">Search tags</string>
     <string name="notes">Notes</string>
     <string name="trash">Trash</string>
     <string name="untagged_notes">Untagged Notes</string>
@@ -200,6 +201,7 @@
     <string name="empty_notes_untagged">Create an untagged note</string>
     <string name="empty_notes_widget">No notes</string>
     <string name="empty_tags">No tags</string>
+    <string name="empty_tags_search">No tags found</string>
 
     <string name="snackbar_deleted_recent_search">Deleted recent search item.</string>
 


### PR DESCRIPTION
### Fix
Add search to the ***Edit tags*** screen.  See the screenshots and animations below for illustration.

![add_tags_search](https://user-images.githubusercontent.com/3827611/75713500-289dec00-5c87-11ea-9853-60415a8daabe.png)

Portrait|Landscape
-|-
![add_tags_search_protrait](https://user-images.githubusercontent.com/3827611/75712984-2d15d500-5c86-11ea-9846-d1a60d2ff004.gif)|![add_tags_search_landscape](https://user-images.githubusercontent.com/3827611/75712993-3141f280-5c86-11ea-8222-29759aff6361.gif)

### Test
0. Add multiple tags to one or more notes.
1. Open navigation drawer.
2. Tap ***Edit*** button in ***Tags*** header.
3. Tap ***Search tags*** action in app bar.
4. Enter text matching one tag.
5. Notice tag matching search is shown.
6. Notice tags not matching search are hidden.
7. Enter text matching no tags.
8. Notice no tags are shown
9. Notice ***No tags found*** message is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 4709ab9 with:
> Added search to tags list