### PR TITLE
Update Title Span

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * Added a note list widget to open any note in the app from the home screen
 * Added support for right-to-left languages and layouts
 * Fixed a bug that highlighted search terms incorrectly in notes with checklists
+* Fixed a bug with the note title that made the app lag while editing a note
 
 2.4
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -887,9 +887,14 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mContentEditText.addTextChangedListener(this);
     }
 
+    /**
+     * Set the note title to be a larger size and bold style.
+     *
+     * Remove all existing spans before applying spans or performance issues will occur.  Since both
+     * {@link RelativeSizeSpan} and {@link StyleSpan} inherit from {@link MetricAffectingSpan}, all
+     * spans are removed when {@link MetricAffectingSpan} is removed.
+     */
     private void setTitleSpan(Editable editable) {
-        // Set the note title to be a larger size and bold style.
-        // NOTE: Remove all existing spans before applying spans or performance issues will occur.
         for (MetricAffectingSpan span : editable.getSpans(0, editable.length(), MetricAffectingSpan.class)) {
             editable.removeSpan(span);
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -887,15 +887,22 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     private void setTitleSpan(Editable editable) {
-        // Set the note title to be a larger size
-        // Remove any existing size spans
-        RelativeSizeSpan[] spans = editable.getSpans(0, editable.length(), RelativeSizeSpan.class);
-        for (RelativeSizeSpan span : spans) {
+        // Set the note title to be a larger size and bold style.
+        // NOTE: Remove all existing spans before applying spans or performance issues will occur.
+        for (RelativeSizeSpan span : editable.getSpans(0, editable.length(), RelativeSizeSpan.class)) {
             editable.removeSpan(span);
         }
+
+        for (StyleSpan span : editable.getSpans(0, editable.length(), StyleSpan.class)) {
+            editable.removeSpan(span);
+        }
+
         int newLinePosition = getNoteContentString().indexOf("\n");
-        if (newLinePosition == 0)
+
+        if (newLinePosition == 0) {
             return;
+        }
+
         int titleEndPosition = (newLinePosition > 0) ? newLinePosition : editable.length();
         editable.setSpan(new RelativeSizeSpan(1.3f), 0, titleEndPosition, Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
         editable.setSpan(new StyleSpan(Typeface.BOLD), 0, titleEndPosition, Spanned.SPAN_INCLUSIVE_EXCLUSIVE);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -20,6 +20,7 @@ import android.text.Layout;
 import android.text.Spanned;
 import android.text.TextUtils.SimpleStringSplitter;
 import android.text.TextWatcher;
+import android.text.style.MetricAffectingSpan;
 import android.text.style.RelativeSizeSpan;
 import android.text.style.StyleSpan;
 import android.text.style.URLSpan;
@@ -889,11 +890,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private void setTitleSpan(Editable editable) {
         // Set the note title to be a larger size and bold style.
         // NOTE: Remove all existing spans before applying spans or performance issues will occur.
-        for (RelativeSizeSpan span : editable.getSpans(0, editable.length(), RelativeSizeSpan.class)) {
-            editable.removeSpan(span);
-        }
-
-        for (StyleSpan span : editable.getSpans(0, editable.length(), StyleSpan.class)) {
+        for (MetricAffectingSpan span : editable.getSpans(0, editable.length(), MetricAffectingSpan.class)) {
             editable.removeSpan(span);
         }
 


### PR DESCRIPTION
### Fix
Add removing the `StyleSpan` (i.e. `BOLD`) before reapplying the `RelativeSizeSpan` and `StyleSpan` to the note title when a note is edited.   If a span is applied repeatedly without removing the span first, performance issues occur.  While the `RelativeSizeSpan` was already being removed, the `StyleSpan` was not, which made the app lag when editing a note.

### Test
1. Tap ***New Note*** floating action button.
2. Enter more than 200 characters in note title.
3. Notice app doesn't lag.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 46e2c9c5 with:
> Fixed a bug with the note title that made the app lag while editing a note