### PR TITLE
Search Match Tab

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -61,6 +61,7 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
     private TabLayout mTabLayout;
     private boolean isMarkdownEnabled;
     private boolean isPreviewEnabled;
+    private boolean isSearchMatch;
     private int[] mSearchMatchIndexes;
     private int mSearchMatchIndex;
 
@@ -169,6 +170,7 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
 
         if (intent.hasExtra(NoteEditorFragment.ARG_MATCH_OFFSETS)) {
             setUpSearchMatchBar(intent);
+            isSearchMatch = true;
         }
 
         mViewPager.setAdapter(mNoteEditorFragmentPagerAdapter);
@@ -178,7 +180,7 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
         if (isMarkdownEnabled) {
             showTabs();
 
-            if (isPreviewEnabled) {
+            if (isPreviewEnabled & !isSearchMatch) {
                 mViewPager.setCurrentItem(mNoteEditorFragmentPagerAdapter.getCount() - 1);
             }
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1056,14 +1056,16 @@ public class NotesActivity extends ThemedAppCompatActivity implements
 
             Intent editNoteIntent = new Intent(this, NoteEditorActivity.class);
             editNoteIntent.putExtras(arguments);
+
             if (mNoteListFragment.isHidden()) {
                 editNoteIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
             }
+
             startActivityForResult(editNoteIntent, Simplenote.INTENT_EDIT_NOTE);
         } else {
             mNoteEditorFragment.setNote(noteID, matchOffsets);
             getNoteListFragment().setNoteSelected(noteID);
-            setMarkdownShowing(isPreviewEnabled);
+            setMarkdownShowing(isPreviewEnabled && matchOffsets == null);
 
             if (mSearchView != null && mSearchView.getQuery() != null) {
                 mTabletSearchQuery = mSearchView.getQuery().toString();


### PR DESCRIPTION
### Fix
Add overriding the `ARG_PREVIEW_ENABLED` value when opening a note from search.  This does not change the last viewed tab setting added in https://github.com/Automattic/simplenote-android/pull/764 and https://github.com/Automattic/simplenote-android/pull/803 that opens a note in either the ***Edit*** or ***Preview*** tab, whichever was last shown when exiting the note.

Currently, if markdown is enabled for the note and the last viewed tab was ***Preview***, a note will be opened from the note list _and_ search showing the ***Preview*** tab as expected due to the `ARG_PREVIEW_ENABLED` value.  However, search matches are not shown in the ***Preview*** tab since the rendered markdown may show incorrect matches.  These changes force the ***Edit*** tab to be shown only when opening a note from search.  The `ARG_PREVIEW_ENABLED` value will be honored when opening a note from the list and not searching.

### Test
These steps are focused on phone-sized devices, but also work on tablet-sized devices in landscape orientation.  There are no tabs (i.e. ***Edit*** and ***Preview***) on tablet-sized devices in landscape orientation.  The markdown view overlays the editor view in that layout.  If testing on a tablet-sized device in landscape orientation, ignore the ***Edit*** and ***Preview*** mentions and look for the ***Hide Markdown*** and ***Show Markdown*** actions in the app bar and the change in note content.
1. Tap note in list with markdown enabled and ***Preview*** tab last viewed.
2. Notice ***Preview*** tab is shown.
3. Tap back arrow in app bar.
4. Tap ***Search*** action in app bar.
5. Enter text in note from Step 1.
6. Tap note in search results from Step 1.
7. Notice ***Edit*** tab is shown with search matches.
8. Tap back arrow in app bar.
9. Tap back arrow in app bar.
10. Tap note in list from Step 1.
11. Notice ***Preview*** tab is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.