### PR TITLE
Update Menu Case

### DIFF
--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -98,7 +98,7 @@
     <string name="call">Call</string>
     <string name="email">Email</string>
     <string name="view_map">View map</string>
-    <string name="view_in_browser">View in browser</string>
+    <string name="view_in_browser">View in Browser</string>
     <string name="link">Link</string>
     <string name="link_copied">Link copied!</string>
     <string name="copy">Copy</string>


### PR DESCRIPTION
### Fix
Update the title text of action menu items used for long-press hints and accessibility from sentence to title case to follow the [Material guidelines for menus](https://material.io/components/menus).  The following action was updated:
- View in Browser (browser icon for links)

This is an addition to https://github.com/Automattic/simplenote-android/pull/965 for the ***View in Browser*** hint, which was overlooked in the original pull request.

### Test
0. Enable the ***Detect links*** setting
1. Tap any note in list with at least one link.
2. Tap anywhere in link.
3. Long-press browser icon in app bar.
4. Notice ***View in Browser*** hint is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.