### PR TITLE
Crash Sheet Debounce

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1297,19 +1297,19 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     private void showShareSheet() {
-        if (isAdded()) {
+        if (isAdded() && mShareBottomSheet != null && !mShareBottomSheet.isAdded()) {
             mShareBottomSheet.show(requireFragmentManager(), mNote);
         }
     }
 
     private void showInfoSheet() {
-        if (isAdded()) {
+        if (isAdded() && mInfoBottomSheet != null && !mInfoBottomSheet.isAdded()) {
             mInfoBottomSheet.show(requireFragmentManager(), mNote);
         }
     }
 
     private void showHistorySheet() {
-        if (isAdded()) {
+        if (isAdded() && mHistoryBottomSheet != null && !mHistoryBottomSheet.isAdded()) {
             // Request revisions for the current note
             mNotesBucket.getRevisions(mNote, MAX_REVISIONS, mHistoryBottomSheet.getRevisionsRequestCallbacks());
             saveNote();


### PR DESCRIPTION
### Fix
Add conditions to ensure the ***History***, ***Information***, and ***Share*** bottom sheets are not added if they are already added.  These changes will "debounce" the action so that the bottom sheet is only attempted to be shown once.  Without these changes, tapping the ***History***, ***Information***, or ***Share*** action multiple times quickly before the associated bottom sheet is shown causes a crash.  See the stack trace below for example.

<details>
<summary>Stack Trace</summary>
<pre>
2020-03-09 08:00:21.538 8709-8709/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.automattic.simplenote, PID: 8709
    java.lang.IllegalStateException: Fragment already added: ShareBottomSheetDialog{1c61021 (e1d95e24-424e-491b-8a65-4fc415360ed7) ShareBottomSheetDialog}
        at androidx.fragment.app.FragmentManagerImpl.addFragment(Unknown Source:98)
        at androidx.fragment.app.BackStackRecord.executeOps(Unknown Source:143)
        at androidx.fragment.app.FragmentManagerImpl.executeOps(Unknown Source:38)
        at androidx.fragment.app.FragmentManagerImpl.executeOpsTogether(Unknown Source:114)
        at androidx.fragment.app.FragmentManagerImpl.removeRedundantOperationsAndExecute(Unknown Source:88)
        at androidx.fragment.app.FragmentManagerImpl.execSingleAction(Unknown Source:31)
        at androidx.fragment.app.BackStackRecord.commitNow(Unknown Source:6)
        at androidx.fragment.app.DialogFragment.showNow(Unknown Source:13)
        at com.automattic.simplenote.ShareBottomSheetDialog.show(Unknown Source:10)
        at com.automattic.simplenote.NoteEditorFragment.showShareSheet(Unknown Source:14)
        at com.automattic.simplenote.NoteEditorFragment.shareNote(Unknown Source:9)
        at com.automattic.simplenote.NoteEditorFragment.onOptionsItemSelected(Unknown Source:18)
        at androidx.fragment.app.Fragment.performOptionsItemSelected(Unknown Source:13)
        at androidx.fragment.app.FragmentManagerImpl.dispatchOptionsItemSelected(Unknown Source:26)
        at androidx.fragment.app.FragmentController.dispatchOptionsItemSelected(Unknown Source:4)
        at androidx.fragment.app.FragmentActivity.onMenuItemSelected(Unknown Source:24)
        at androidx.appcompat.app.AppCompatActivity.onMenuItemSelected(Unknown Source:0)
        at androidx.appcompat.view.WindowCallbackWrapper.onMenuItemSelected(Unknown Source:2)
        at androidx.appcompat.view.WindowCallbackWrapper.onMenuItemSelected(Unknown Source:2)
        at androidx.appcompat.app.ToolbarActionBar$2.onMenuItemClick(Unknown Source:5)
        at androidx.appcompat.widget.Toolbar$1.onMenuItemClick(Unknown Source:6)
        at androidx.appcompat.widget.ActionMenuView$MenuBuilderCallback.onMenuItemSelected(Unknown Source:6)
        at androidx.appcompat.view.menu.MenuBuilder.dispatchMenuItemSelected(Unknown Source:4)
        at androidx.appcompat.view.menu.MenuItemImpl.invoke(Unknown Source:14)
        at androidx.appcompat.view.menu.MenuBuilder.performItemAction(Unknown Source:12)
        at androidx.appcompat.view.menu.MenuBuilder.performItemAction(Unknown Source:1)
        at androidx.appcompat.widget.ActionMenuView.invokeItem(Unknown Source:3)
        at androidx.appcompat.view.menu.ActionMenuItemView.onClick(Unknown Source:6)
        at android.view.View.performClick(View.java:7125)
        at android.view.View.performClickInternal(View.java:7102)
        at android.view.View.access$3500(View.java:801)
        at android.view.View$PerformClick.run(View.java:27336)
        at android.os.Handler.handleCallback(Handler.java:883)
        at android.os.Handler.dispatchMessage(Handler.java:100)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
</pre>
</details>

### Test
1. Tap any note in list with markdown disabled.
2. Tap ***History***, ***Information***, or ***Share*** action multiple times quickly.
3. Notice app does not crash.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.