### PR TITLE
Update Nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.2.6)
     naturally (2.2.0)
-    nokogiri (1.10.4)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)


### PR DESCRIPTION
Dismisses the warning – will not be a breaking change as it just updates the libxml version.
