### PR TITLE
Issue/980 checklist removes checkbox

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -910,7 +910,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
      */
     private void setTitleSpan(Editable editable) {
         for (MetricAffectingSpan span : editable.getSpans(0, editable.length(), MetricAffectingSpan.class)) {
-            editable.removeSpan(span);
+            if (span instanceof RelativeSizeSpan || span instanceof StyleSpan) {
+                editable.removeSpan(span);
+            }
         }
 
         int newLinePosition = getNoteContentString().indexOf("\n");


### PR DESCRIPTION
### Fix
Add conditions for which to remove spans from a note to close https://github.com/Automattic/simplenote-android/issues/980.  This bug was introduced in https://github.com/Automattic/simplenote-android/pull/972.  The note title in the editor contains `RelativeSizeSpan` and `StyleSpan`, which both extend `MetricAffectingSpan`.  To reduce the number of loops to remove both `RelativeSizeSpan` and `StyleSpan` from the title, all instances of `MetricAffectingSpan` are removed.  Consequently, that caused all checkboxes to be removed since they also extend `MetricAffectingSpan`.  These changes only remove spans if they are instances of `RelativeSizeSpan` or `StyleSpan`, which checkboxes are not.

### Test
1. Tap any note in list with checklist.
2. Edit title or content of note.
3. Notice checkboxes are not removed.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.