### PR TITLE
Issue/982 crash restore multiple

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -115,6 +115,13 @@ public class NotesActivity extends ThemedAppCompatActivity implements
     private NoteEditorFragment mNoteEditorFragment;
     private Note mCurrentNote;
     private MenuItem mEmptyTrashMenuItem;
+    private Handler mInvalidateOptionsMenuHandler = new Handler();
+    private Runnable mInvalidateOptionsMenuRunnable = new Runnable() {
+        @Override
+        public void run() {
+            invalidateOptionsMenu();
+        }
+    };
 
     // Menu drawer
     private static final int GROUP_PRIMARY = 100;
@@ -900,13 +907,11 @@ public class NotesActivity extends ThemedAppCompatActivity implements
                 mCurrentNote.save();
                 return true;
             case R.id.menu_trash:
-                if (mNoteEditorFragment != null) {
-                    if (mCurrentNote != null) {
-                        mCurrentNote.setDeleted(!mCurrentNote.isDeleted());
-                        mCurrentNote.setModificationDate(Calendar.getInstance());
-                        mCurrentNote.save();
-                        updateViewsAfterTrashAction(mCurrentNote);
-                    }
+                if (mNoteEditorFragment != null && mCurrentNote != null) {
+                    mCurrentNote.setDeleted(!mCurrentNote.isDeleted());
+                    mCurrentNote.setModificationDate(Calendar.getInstance());
+                    mCurrentNote.save();
+                    updateViewsAfterTrashAction(mCurrentNote);
                 }
 
                 return true;
@@ -1064,7 +1069,13 @@ public class NotesActivity extends ThemedAppCompatActivity implements
             fragment.refreshList();
         }
 
-        invalidateOptionsMenu();
+        if (mInvalidateOptionsMenuHandler != null) {
+            mInvalidateOptionsMenuHandler.removeCallbacks(mInvalidateOptionsMenuRunnable);
+            mInvalidateOptionsMenuHandler.postDelayed(
+                mInvalidateOptionsMenuRunnable,
+                getResources().getInteger(android.R.integer.config_shortAnimTime)
+            );
+        }
     }
 
     public void setMarkdownShowing(boolean isMarkdownShowing) {


### PR DESCRIPTION
### Fix
Add a delay to invalidating the options menu to close #982.  The `invalidateOptionsMenu()` statement was being called too many times consecutively causing the crash described in the associated issue and shown in the stack trace below.  These changes are a method of debouncing a button by using a `Handler` to cancel any existing `Runnable` and start a new `Runnable` with a short delay if the action is triggered more than once in quick succession.  That will ensure the `invalidateOptionsMenu()` statement is called only once and avoid the crash.

<details>
<summary>Stack Trace</summary>
<pre>
Process: com.automattic.simplenote.debug, PID: 13585
    java.lang.IllegalStateException: The content of the adapter has changed but ListView did not receive a notification. Make sure the content of your adapter is not modified from a background thread, but only from the UI thread. Make sure your adapter calls notifyDataSetChanged() when its content changes. [in ListView(-1, class androidx.appcompat.widget.MenuPopupWindow$MenuDropDownListView) with Adapter(class androidx.appcompat.view.menu.MenuAdapter)]
        at android.widget.ListView.layoutChildren(ListView.java:1721)
        at android.widget.AbsListView.onTouchUp(AbsListView.java:4086)
        at android.widget.AbsListView.onTouchEvent(AbsListView.java:3878)
        at androidx.appcompat.widget.DropDownListView.onTouchEvent(DropDownListView.java:217)
        at androidx.appcompat.widget.MenuPopupWindow$MenuDropDownListView.onTouchEvent(MenuPopupWindow.java:135)
        at android.view.View.dispatchTouchEvent(View.java:13415)
        at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3054)
        at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2741)
        at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3060)
        at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2755)
        at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3060)
        at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2755)
        at android.widget.PopupWindow$PopupDecorView.dispatchTouchEvent(PopupWindow.java:2554)
        at android.view.View.dispatchPointerEvent(View.java:13674)
        at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent(ViewRootImpl.java:5471)
        at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:5274)
        at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4777)
        at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:4830)
        at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:4796)
        at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:4936)
        at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:4804)
        at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:4993)
        at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4777)
        at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:4830)
        at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:4796)
        at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:4804)
        at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4777)
        at android.view.ViewRootImpl.deliverInputEvent(ViewRootImpl.java:7494)
        at android.view.ViewRootImpl.doProcessInputEvents(ViewRootImpl.java:7463)
        at android.view.ViewRootImpl.enqueueInputEvent(ViewRootImpl.java:7424)
        at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent(ViewRootImpl.java:7619)
        at android.view.InputEventReceiver.dispatchInputEvent(InputEventReceiver.java:188)
        at android.os.MessageQueue.nativePollOnce(Native Method)
        at android.os.MessageQueue.next(MessageQueue.java:336)
        at android.os.Looper.loop(Looper.java:174)
        at android.app.ActivityThread.main(ActivityThread.java:7343)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:933)
</pre>
</details>

### Test
The crash only occurs on tablet-sized devices since phone-sized devices call `finish()` before the `invalidateOptionsMenu()` statement is called multiple times.  Therefore, using a tablet-sized device while testing is required.
1. Tap any note in list.
2. Tap ellipsis action in app bar.
3. Tap ***Trash*** action in menu multiple times quickly.
4. Notice note is trashed and app does not crash.
5. Open navigation drawer.
6. Tap ***Trash*** item in navigation drawer.
7. Tap any note in list.
8. Tap ellipsis action in app bar.
9. Tap ***Restore*** action in menu multiple times quickly.
10. Notice note is restored and app does not crash.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.