### PR TITLE
Empty Trash Actions

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -992,6 +992,10 @@ public class NotesActivity extends ThemedAppCompatActivity implements
                 public void run() {
                     item.setIcon(drawable);
                     item.setTitle(string);
+
+                    if (item == mEmptyTrashMenuItem) {
+                        invalidateOptionsMenu();
+                    }
                 }
             },
             getResources().getInteger(R.integer.time_animation)


### PR DESCRIPTION
### Fix
Add the `invalidateOptionsMenu()` statement after the action icon animation when emptying the trash.  Without that statement, the other actions were still shown in ***Trash*** even though no notes existed for those actions.  These changes remove those actions after the action animation completes only when emptying the trash.  See the animations below for illustration.

Before|After
-|-
<a href="https://user-images.githubusercontent.com/3827611/76368068-9f289280-62f4-11ea-8f47-f6739ae6b3ca.gif"><img src="https://user-images.githubusercontent.com/3827611/76368068-9f289280-62f4-11ea-8f47-f6739ae6b3ca.gif"></a>|<a href="https://user-images.githubusercontent.com/3827611/76368070-a059bf80-62f4-11ea-8fb2-a16406ae0ea3.gif"><img src="https://user-images.githubusercontent.com/3827611/76368070-a059bf80-62f4-11ea-8fb2-a16406ae0ea3.gif"></a>

### Test
Since the actions in question are only shown with the list/detail view, using a tablet-sized device while testing is required.

0. Trash at least one note.
1. Open navigation drawer.
2. Tap ***Trash*** item in navigation drawer.
3. Notice multiple actions in app bar.
4. Tap ***Empty Trash*** action in app bar.
5. Notice ***Empty Trash*** action animation.
6. Notice only disabled ***Empty Trash*** action in app bar.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.