### PR TITLE
Save Callback Looper

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -10,6 +10,7 @@ import android.graphics.drawable.AnimatedVectorDrawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -1453,7 +1454,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements
         if (note.equals(mCurrentNote)) {
             mCurrentNote = note;
 
-            new Handler().postDelayed(
+            new Handler(Looper.getMainLooper()).postDelayed(
                 new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
### Fix
Add the `Looper.getMainLooper()` as a parameter to the post-delayed `Handler()` in the `onSaveObject()` callback to ensure the `invalidateOptionsMenu()` statement is called and avoid a `RuntimeException`.  Even though the app does not crash, the `RuntimeException` is occurring when causing the `invalidateOptionsMenu()` to not be called and the action/menu items are not updating as expected.  See the stack trace below for details.

<details>
<summary>Stack Trace</summary>
<pre>
2020-03-10 17:32:31.426 13156-13306/com.automattic.simplenote.debug E/Simperium.Bucket: Listener failed onSaveObject com.automattic.simplenote.NotesActivity@944cda6
    java.lang.RuntimeException: Can't create handler inside thread Thread[pool-1-thread-2,5,main] that has not called Looper.prepare()
        at android.os.Handler.<init>(Handler.java:207)
        at android.os.Handler.<init>(Handler.java:119)
        at com.automattic.simplenote.NotesActivity.onSaveObject(NotesActivity.java:1461)
        at com.automattic.simplenote.NotesActivity.onSaveObject(NotesActivity.java:97)
        at com.simperium.client.Bucket.notifyOnSaveListeners(Bucket.java:783)
        at com.simperium.client.Bucket$1.run(Bucket.java:312)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
</pre>
</details>

### Test
There is no visible difference in the user interface for these changes.  The console log must be watched in order to determine whether the `RuntimeException` occurs or not.
1. Tap any note in list.
2. Tap ellipsis action in app bar.
3. Tap ***Trash*** item in menu.
4. Notice stack trace is not shown in console log.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.