### PR TITLE
Placeholder Touch Through

### DIFF
--- a/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
@@ -112,6 +112,8 @@
         <LinearLayout
             android:id="@+id/placeholder"
             android:background="?attr/mainBackgroundColor"
+            android:clickable="true"
+            android:focusable="true"
             android:gravity="center"
             android:layout_height="match_parent"
             android:layout_width="match_parent"


### PR DESCRIPTION
### Fix
Add the `clickable` and `focusable` attributes to the placeholder view to avoid touch events passing through the view to the note editor and showing the software keyboard.  Without these changes, the note editor can be clicked/focused and text can be input even though the placeholder view is shown, which indicates a note is not selected, and no content is being saved.

### Test
Since the view in question is only shown with the list/detail layout, using a tablet-sized device while testing is required.
1. Tap any note in list.
2. Tap anywhere in note.
3. Notice software keyboard is shown.
4. Tap back navigation bar button.
5. Notice software keyboard is hidden.
6. Tap ellipsis action in app bar.
7. Tap ***Trash*** item in menu.
8. Notice note is trashed.
9. Notice placeholder view is shown.
10. Tap anywhere in placeholder view.
11. Notice software keyboard is not shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.