### PR TITLE
Issue/984 list widget button

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
@@ -151,8 +151,8 @@ public class NoteListWidgetDark extends AppWidgetProvider {
                 Intent intentButton = new Intent(context, NotesActivity.class);
                 intentButton.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_BUTTON_TAPPED);
                 intentButton.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT);
-                views.setOnClickPendingIntent(R.id.widget_button, pendingIntent);
+                PendingIntent pendingIntentButton = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT);
+                views.setOnClickPendingIntent(R.id.widget_button, pendingIntentButton);
 
                 views.setEmptyView(R.id.widget_list, R.id.widget_text);
                 views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_dark, context.getTheme()));

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
@@ -171,15 +171,17 @@ public class NoteListWidgetDark extends AppWidgetProvider {
                 PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
                 views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
 
-                // Reset intent to navigate to note editor on note list add button click to navigate to notes activity
+                // Create intent to navigate to note editor on note list add button click
                 Intent intentButton = new Intent(context, NotesActivity.class);
-                views.setOnClickPendingIntent(R.id.widget_button, PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT));
+                intentButton.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_BUTTON_TAPPED);
+                intentButton.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                PendingIntent pendingIntentButton = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT);
+                views.setOnClickPendingIntent(R.id.widget_button, pendingIntentButton);
 
                 views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_dark, context.getTheme()));
                 views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.empty_notes_widget));
                 views.setViewVisibility(R.id.widget_text, View.VISIBLE);
                 views.setViewVisibility(R.id.widget_list, View.GONE);
-                views.setViewVisibility(R.id.widget_button, View.GONE);
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
@@ -34,7 +34,11 @@ public class NoteListWidgetDark extends AppWidgetProvider {
     @Override
     public void onAppWidgetOptionsChanged(Context context, AppWidgetManager appWidgetManager, int appWidgetId, Bundle newOptions) {
         RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.note_list_widget_dark);
-        resizeWidget(context, newOptions, views);
+
+        if (((Simplenote) context.getApplicationContext()).getSimperium().getUser().getStatus().equals(User.Status.AUTHORIZED)) {
+            resizeWidget(context, newOptions, views);
+        }
+
         appWidgetManager.updateAppWidget(appWidgetId, views);
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
@@ -159,13 +159,6 @@ public class NoteListWidgetDark extends AppWidgetProvider {
                 views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.empty_notes_widget));
                 views.setViewVisibility(R.id.widget_text, View.GONE);
                 views.setViewVisibility(R.id.widget_list, View.VISIBLE);
-
-                if (appWidgetOptions.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT) > MINIMUM_HEIGHT_FOR_BUTTON &&
-                    appWidgetOptions.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH) > MINIMUM_WIDTH_FOR_BUTTON) {
-                    views.setViewVisibility(R.id.widget_button, View.VISIBLE);
-                } else {
-                    views.setViewVisibility(R.id.widget_button, View.GONE);
-                }
             } else {
                 // Create intent to navigate to notes activity on widget click
                 Intent intent = new Intent(context, NotesActivity.class);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
@@ -112,6 +112,10 @@ public class NoteListWidgetDark extends AppWidgetProvider {
             PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
             views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
 
+            // Reset intent to navigate to note editor on note list add button click to navigate to notes activity, which redirects to login/signup
+            Intent intentButton = new Intent(context, NotesActivity.class);
+            views.setOnClickPendingIntent(R.id.widget_button, PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT));
+
             views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.log_in_use_widget));
             views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_dark, context.getTheme()));
             views.setViewVisibility(R.id.widget_text, View.VISIBLE);
@@ -169,6 +173,10 @@ public class NoteListWidgetDark extends AppWidgetProvider {
                 intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
                 views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
+
+                // Reset intent to navigate to note editor on note list add button click to navigate to notes activity
+                Intent intentButton = new Intent(context, NotesActivity.class);
+                views.setOnClickPendingIntent(R.id.widget_button, PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT));
 
                 views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_dark, context.getTheme()));
                 views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.empty_notes_widget));

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
@@ -113,7 +113,7 @@ public class NoteListWidgetDark extends AppWidgetProvider {
             Intent intent = new Intent(context, NotesActivity.class);
             intent.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_SIGN_IN_TAPPED);
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
+            PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_IMMUTABLE);
             views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
 
             // Reset intent to navigate to note editor on note list add button click to navigate to notes activity, which redirects to login/signup
@@ -168,7 +168,7 @@ public class NoteListWidgetDark extends AppWidgetProvider {
                 Intent intent = new Intent(context, NotesActivity.class);
                 intent.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_TAPPED);
                 intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
+                PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_IMMUTABLE);
                 views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
 
                 // Create intent to navigate to note editor on note list add button click

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
@@ -151,8 +151,8 @@ public class NoteListWidgetLight extends AppWidgetProvider {
                 Intent intentButton = new Intent(context, NotesActivity.class);
                 intentButton.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_BUTTON_TAPPED);
                 intentButton.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT);
-                views.setOnClickPendingIntent(R.id.widget_button, pendingIntent);
+                PendingIntent pendingIntentButton = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT);
+                views.setOnClickPendingIntent(R.id.widget_button, pendingIntentButton);
 
                 views.setEmptyView(R.id.widget_list, R.id.widget_text);
                 views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_light, context.getTheme()));

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
@@ -137,7 +137,7 @@ public class NoteListWidgetLight extends AppWidgetProvider {
                 Intent intentLoading = new Intent(context, NotesActivity.class);
                 intentLoading.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_TAPPED);
                 intentLoading.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                PendingIntent pendingIntentLoading = PendingIntent.getActivity(context, appWidgetId, intentLoading, 0);
+                PendingIntent pendingIntentLoading = PendingIntent.getActivity(context, appWidgetId, intentLoading, PendingIntent.FLAG_IMMUTABLE);
                 views.setOnClickPendingIntent(R.id.widget_layout, pendingIntentLoading);
 
                 // Create intent for note list widget service
@@ -168,7 +168,7 @@ public class NoteListWidgetLight extends AppWidgetProvider {
                 Intent intent = new Intent(context, NotesActivity.class);
                 intent.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_TAPPED);
                 intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
+                PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_IMMUTABLE);
                 views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
 
                 // Create intent to navigate to note editor on note list add button click

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
@@ -171,15 +171,17 @@ public class NoteListWidgetLight extends AppWidgetProvider {
                 PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
                 views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
 
-                // Reset intent to navigate to note editor on note list add button click to navigate to notes activity
+                // Create intent to navigate to note editor on note list add button click
                 Intent intentButton = new Intent(context, NotesActivity.class);
-                views.setOnClickPendingIntent(R.id.widget_button, PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT));
+                intentButton.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_BUTTON_TAPPED);
+                intentButton.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                PendingIntent pendingIntentButton = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT);
+                views.setOnClickPendingIntent(R.id.widget_button, pendingIntentButton);
 
                 views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_light, context.getTheme()));
                 views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.empty_notes_widget));
                 views.setViewVisibility(R.id.widget_text, View.VISIBLE);
                 views.setViewVisibility(R.id.widget_list, View.GONE);
-                views.setViewVisibility(R.id.widget_button, View.GONE);
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
@@ -159,13 +159,6 @@ public class NoteListWidgetLight extends AppWidgetProvider {
                 views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.empty_notes_widget));
                 views.setViewVisibility(R.id.widget_text, View.GONE);
                 views.setViewVisibility(R.id.widget_list, View.VISIBLE);
-
-                if (appWidgetOptions.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT) > MINIMUM_HEIGHT_FOR_BUTTON &&
-                    appWidgetOptions.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH) > MINIMUM_WIDTH_FOR_BUTTON) {
-                    views.setViewVisibility(R.id.widget_button, View.VISIBLE);
-                } else {
-                    views.setViewVisibility(R.id.widget_button, View.GONE);
-                }
             } else {
                 // Create intent to navigate to notes activity on widget click
                 Intent intent = new Intent(context, NotesActivity.class);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
@@ -34,7 +34,11 @@ public class NoteListWidgetLight extends AppWidgetProvider {
     @Override
     public void onAppWidgetOptionsChanged(Context context, AppWidgetManager appWidgetManager, int appWidgetId, Bundle newOptions) {
         RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.note_list_widget_light);
-        resizeWidget(context, newOptions, views);
+
+        if (((Simplenote) context.getApplicationContext()).getSimperium().getUser().getStatus().equals(User.Status.AUTHORIZED)) {
+            resizeWidget(context, newOptions, views);
+        }
+
         appWidgetManager.updateAppWidget(appWidgetId, views);
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
@@ -112,6 +112,10 @@ public class NoteListWidgetLight extends AppWidgetProvider {
             PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
             views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
 
+            // Reset intent to navigate to note editor on note list add button click to navigate to notes activity, which redirects to login/signup
+            Intent intentButton = new Intent(context, NotesActivity.class);
+            views.setOnClickPendingIntent(R.id.widget_button, PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT));
+
             views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.log_in_use_widget));
             views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_light, context.getTheme()));
             views.setViewVisibility(R.id.widget_text, View.VISIBLE);
@@ -169,6 +173,10 @@ public class NoteListWidgetLight extends AppWidgetProvider {
                 intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
                 views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
+
+                // Reset intent to navigate to note editor on note list add button click to navigate to notes activity
+                Intent intentButton = new Intent(context, NotesActivity.class);
+                views.setOnClickPendingIntent(R.id.widget_button, PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT));
 
                 views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_light, context.getTheme()));
                 views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.empty_notes_widget));


### PR DESCRIPTION
### Fix
When no account is logged into Simplenote, reset the list widget button click action since the floating action button is not visible and do not show the floating action button when the widget is resized to close #984.  Also, the floating action button is shown when the widget is large enough and the account has no notes.  That way the user can tap the widget background to open the app with the note list visible or tap the floating action button to create a new note directly.

### Test
These steps assume the AOSP launcher (i.e. Nexus/Pixel launcher). The steps to add the widget to the home screen may be slightly different based on the launcher used. Other steps should be the same regardless of launcher.
1. Long-press home screen.
2. Tap ***Widgets*** option.
3. Scroll to ***Simplenote*** widget.
4. Notice ***Note List (Dark)*** and ***Note List (Light)*** widgets.
5. Long-press ***Note List (Dark)*** or ***Note List (Light)*** widget.
6. Place widget on home screen.
7. Notice note list shown in widget.
8. Long-press widget.
9. Notice circular handles are shown.
10. Drag circular handles horizontally and vertically.
11. Notice note button is shown in widget when large enough.
12. Notice note list is vertically scrollable.
13. Tap any note in widget.
14. Notice note is shown in app.
15. Go to home screen.
16. Tap button in widget.
17. Notice new note is shown in app.
18. Tap back arrow in app bar.
19. Notice note list is shown.
20. Open navigation drawer.
21. Tap ***Settings*** in navigation drawer.
22. Tap ***Log out*** item under ***Account*** section.
23. Notice login/signup screen is shown.
24. Go to home screen.
25. Notice ***Log in to use widget*** is shown and button is hidden.
26. Long-press widget.
27. Notice circular handles are shown.
28. Drag circular handles horizontally and vertically.
29. Notice note button is hidden in widget regardless of size.
30. Tap widget.
31. Notice login/signup screen is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.  @rachelmcr, I also requested you as a reviewer since you caught the associated bugs and to ensure they are fixed.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.