### PR TITLE
Issue/991 new note loop

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -93,18 +93,21 @@ import static com.automattic.simplenote.utils.TagsAdapter.UNTAGGED_NOTES_ID;
 import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
 import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
 
-public class NotesActivity extends ThemedAppCompatActivity implements
-        NoteListFragment.Callbacks, User.StatusChangeListener, Simperium.OnUserCreatedListener, UndoBarController.UndoListener,
+public class NotesActivity extends ThemedAppCompatActivity implements NoteListFragment.Callbacks,
+        User.StatusChangeListener, Simperium.OnUserCreatedListener, UndoBarController.UndoListener,
         Bucket.Listener<Note> {
-
     public static String TAG_NOTE_LIST = "noteList";
     public static String TAG_NOTE_EDITOR = "noteEditor";
+
+    private static String STATE_NOTE_LIST_WIDGET_BUTTON_TAPPED = "STATE_NOTE_LIST_WIDGET_BUTTON_TAPPED";
+
     protected Bucket<Note> mNotesBucket;
     protected Bucket<Tag> mTagsBucket;
-    private boolean mIsShowingMarkdown;
-    private boolean mShouldSelectNewNote;
+    private boolean mHasTappedNoteListWidgetButton;
     private boolean mIsSettingsClicked;
+    private boolean mIsShowingMarkdown;
     private boolean mIsTabletFullscreen;
+    private boolean mShouldSelectNewNote;
 
     private String mTabletSearchQuery;
     private UndoBarController mUndoBarController;
@@ -184,8 +187,10 @@ public class NotesActivity extends ThemedAppCompatActivity implements
             fragmentTransaction.add(R.id.note_fragment_container, mNoteListFragment, TAG_NOTE_LIST);
             fragmentTransaction.commit();
         } else {
+            mHasTappedNoteListWidgetButton = savedInstanceState.getBoolean(STATE_NOTE_LIST_WIDGET_BUTTON_TAPPED);
             mNoteListFragment = (NoteListFragment) getSupportFragmentManager().findFragmentByTag(TAG_NOTE_LIST);
         }
+
         mIsTabletFullscreen = mNoteListFragment.isHidden();
 
         if (DisplayUtils.isLargeScreen(this)) {
@@ -255,7 +260,8 @@ public class NotesActivity extends ThemedAppCompatActivity implements
                     CATEGORY_WIDGET,
                     "note_list_widget_tapped"
                 );
-            } else if (intent.getExtras().getSerializable(KEY_LIST_WIDGET_CLICK) == NOTE_LIST_WIDGET_BUTTON_TAPPED) {
+            } else if (intent.getExtras().getSerializable(KEY_LIST_WIDGET_CLICK) == NOTE_LIST_WIDGET_BUTTON_TAPPED && !mHasTappedNoteListWidgetButton) {
+                mHasTappedNoteListWidgetButton = true;
                 AnalyticsTracker.track(
                     NOTE_LIST_WIDGET_BUTTON_TAPPED,
                     CATEGORY_WIDGET,
@@ -327,6 +333,12 @@ public class NotesActivity extends ThemedAppCompatActivity implements
         mNotesBucket.removeOnSaveObjectListener(this);
         mNotesBucket.removeOnDeleteObjectListener(this);
         mNotesBucket.stop();
+    }
+
+    @Override
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putBoolean(STATE_NOTE_LIST_WIDGET_BUTTON_TAPPED, mHasTappedNoteListWidgetButton);
+        super.onSaveInstanceState(outState);
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -272,7 +272,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                     CATEGORY_NOTE,
                     "note_list_widget"
                 );
-                getIntent().removeExtra(KEY_LIST_WIDGET_CLICK);
+                intent.removeExtra(KEY_LIST_WIDGET_CLICK);
                 getNoteListFragment().addNote();
             }
         }


### PR DESCRIPTION
### Fix
Add a condition to detect when the new note floating action button is tapped in the note list widget to close #991.  These changes use the activity instance state to track whether the note list widget new note button has been tapped in order to avoid an infinite loop of new notes being created when the underlying activity is removed by the operating system.

### Test
These steps assume the AOSP launcher (i.e. Nexus/Pixel launcher). The steps to add the widget to the home screen may be slightly different based on the launcher used. Other steps should be the same regardless of launcher.

0. Enable _*Don't keep activities*_ setting in _*Developer options*_.
1. Long-press home screen.
2. Tap ***Widgets*** option.
3. Scroll to ***Simplenote*** widget.
4. Notice ***Note List (Dark)*** and ***Note List (Light)*** widgets.
5. Long-press ***Note List (Dark)*** or ***Note List (Light)*** widget.
6. Place widget on home screen.
7. Notice note list shown in widget.
8. Long-press widget.
9. Notice circular handles are shown.
10. Drag circular handles horizontally and vertically.
11. Notice new note button is shown in widget when large enough.
12. Tap new note button in widget.
13. Notice note editor with new note is shown in app.
14. Tap back arrow in top app bar or back button in navigation bar.
15. Notice note editor with new note is not shown.
16. Notice note list is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release candidate build once they are merged.