### PR TITLE
Update Splash Status

### DIFF
--- a/Simplenote/src/main/res/values-v27/styles.xml
+++ b/Simplenote/src/main/res/values-v27/styles.xml
@@ -12,7 +12,7 @@
     
     <style name="Theme.Simplestyle.Splash">
         <item name="android:navigationBarColor">@color/blue</item>
-        <item name="android:statusBarColor">@color/blue</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowBackground">@drawable/bg_splash</item>
         <item name="android:windowLightNavigationBar">false</item>
         <item name="android:windowLightStatusBar">false</item>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -104,7 +104,7 @@
     
     <style name="Theme.Simplestyle.Splash">
         <item name="android:navigationBarColor">@color/blue</item>
-        <item name="android:statusBarColor">@color/blue</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowBackground">@drawable/bg_splash</item>
         <item name="android:windowLightStatusBar">false</item>
     </style>


### PR DESCRIPTION
### Fix
Update the color of the status bar attribute in the `Theme.Simplestyle.Splash` style.  When the ***Passcode Lock*** setting is enabled and the app is reopened before the app is locked, the status bar is blue while the background is white before it changes to white.  These changes avoid that intermediate color.  See the screenshots below for illustration.

![update_splash_status](https://user-images.githubusercontent.com/3827611/77326077-e2183c00-6cde-11ea-8b7e-0fa75f6f4425.png)

### Test
0. Enable ***Passcode Lock*** setting.
1. Open app.
2. Enter passcode.
3. Notice note list is shown.
4. Tap recents/overview navigation button.
5. Notice app preview is blank (i.e. white for ***Light*** and gray for ***Dark***).
6. Tap app within two seconds of Step 4.
7. Notice status bar matches background color.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.