### PR TITLE
Update Password Policy

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -68,7 +68,7 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Automattic and WordPress dependencies
-    implementation 'com.simperium.android:simperium:0.9.6'
+    implementation 'com.simperium.android:simperium:0.9.7'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.2'
 

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -68,7 +68,7 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Automattic and WordPress dependencies
-    implementation 'com.simperium.android:simperium:0.9.7'
+    implementation 'com.simperium.android:simperium:0.9.8'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.2'
 

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -240,6 +240,7 @@
     <string name="simperium_dialog_message_login_reset">Your password is insecure and must be reset.  The password requirements are:\n\n- Password cannot match email\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
     <string name="simperium_dialog_message_network">There is no network available.  Please, connect to a network and try again.</string>
     <string name="simperium_dialog_message_password">The password requirements are:\n\n- Password cannot match email\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
+    <string name="simperium_dialog_message_password_login">Passwords must be a minimum of %1$d characters excluding new lines, spaces, and tabs.</string>
     <string name="simperium_dialog_message_signup">Could not sign up with the provided email address and password.</string>
     <string name="simperium_dialog_message_signup_existing">The email address you entered is already associated with a Simplenote account.</string>
     <string name="simperium_dialog_progress_logging_in">Logging in&#8230;</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -248,7 +248,7 @@
     <string name="simperium_error_email">Invalid email</string>
     <string name="simperium_error_password">Invalid password</string>
     <string name="simperium_footer_login">%1$s%2$s%3$sForgot password?%4$s</string>
-    <string name="simperium_footer_login_url">https://app.simplenote.com/forgot?email=%1$s</string>
+    <string name="simperium_footer_login_url">https://app.simplenote.com/forgot/?email=%1$s</string>
     <string name="simperium_footer_signup">By creating an account, you agree to our %1$s%2$s%3$sTerms and Conditions%4$s</string>
     <string name="simperium_footer_signup_url">https://simplenote.com/terms/</string>
     <string name="simperium_hint_email">Email</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -239,7 +239,7 @@
     <string name="simperium_dialog_message_login">Could not log in with the provided email address and password.</string>
     <string name="simperium_dialog_message_login_reset">Your password is insecure and must be reset.  The password requirements are:\n\n- Password cannot match email\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
     <string name="simperium_dialog_message_network">There is no network available.  Please, connect to a network and try again.</string>
-    <string name="simperium_dialog_message_password">Passwords must be a minimum of %1$d characters excluding new lines, spaces, and tabs.</string>
+    <string name="simperium_dialog_message_password">The password requirements are:\n\n- Password cannot match email\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
     <string name="simperium_dialog_message_signup">Could not sign up with the provided email address and password.</string>
     <string name="simperium_dialog_message_signup_existing">The email address you entered is already associated with a Simplenote account.</string>
     <string name="simperium_dialog_progress_logging_in">Logging in&#8230;</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -233,8 +233,11 @@
     <string name="simperium_button_login">Log In</string>
     <string name="simperium_button_login_email">Log In with Email</string>
     <string name="simperium_button_login_other">Log In with WordPress.com</string>
+    <string name="simperium_button_login_reset">Reset</string>
     <string name="simperium_button_signup">Sign Up</string>
+    <string name="simperium_dialog_button_reset_url">https://app.simplenote.com/reset/?email=%1$s</string>
     <string name="simperium_dialog_message_login">Could not log in with the provided email address and password.</string>
+    <string name="simperium_dialog_message_login_reset">Your password is insecure and must be reset.  The password requirements are:\n\n- Password cannot match email\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
     <string name="simperium_dialog_message_network">There is no network available.  Please, connect to a network and try again.</string>
     <string name="simperium_dialog_message_password">Passwords must be a minimum of %1$d characters excluding new lines, spaces, and tabs.</string>
     <string name="simperium_dialog_message_signup">Could not sign up with the provided email address and password.</string>


### PR DESCRIPTION
### Fix
Update the simperium dependency, which includes updating the password policy as described in https://github.com/Simperium/simperium-android/pull/219.  The updated password policy requirements are the following:
- Password cannot match email
- Minimum of 8 characters
- No new lines
- No tabs

### Test
In order to test the login password length updates, change your Simplenote password to more than four and less than eight characters.

0. Clear app data.
1. Tap ***Sign Up*** button.
2. Enter email address in ***Email*** field.
3. Notice ***Sign Up*** button is disabled.
4. Enter email address, new lines, or tabs in ***Password*** field.
5. Notice ***Sign Up*** button is enabled after eight characters are input.
6. Tap ***Sign Up*** button.
7. Notice ***Error*** dialog with password requirements is shown.
8. Tap ***OK*** button in dialog.
9. Tap back arrow in top app bar.
10. Tap ***Log In*** button.
11. Tap ***Log In with Email*** button.
12. Enter email address in ***Email*** field.
13. Notice ***Log In*** button is disabled.
14. Enter password of more than four and less than eight characters in ***Password*** field.
15. Notice ***Log In*** button is enabled after four characters are input.
16. Tap ***Log In*** button.
17. Notice ***Error*** dialog with password requirements is shown.
18. Tap ***Reset*** button in dialog.
19. Notice external browser is opened showing the https://app.simplenote.com/reset/ page.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.