### PR TITLE
Crash Animated Drawable

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -9,7 +9,6 @@ import android.content.SharedPreferences;
 import android.content.res.ColorStateList;
 import android.database.Cursor;
 import android.graphics.Typeface;
-import android.graphics.drawable.AnimatedVectorDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -522,7 +521,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_checklist:
-                ((AnimatedVectorDrawable) item.getIcon()).start();
+                DrawableUtils.startAnimatedVectorDrawable(item.getIcon());
                 insertChecklist();
                 return true;
             case R.id.menu_copy:
@@ -533,7 +532,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 showHistory();
                 return true;
             case R.id.menu_info:
-                ((AnimatedVectorDrawable) item.getIcon()).start();
+                DrawableUtils.startAnimatedVectorDrawable(item.getIcon());
                 showInfo();
                 return true;
             case R.id.menu_markdown:

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.ColorStateList;
 import android.content.res.Configuration;
-import android.graphics.drawable.AnimatedVectorDrawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
@@ -997,7 +996,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
     }
 
     private void setIconAfterAnimation(final MenuItem item, final @DrawableRes int drawable, final @StringRes int string) {
-        ((AnimatedVectorDrawable) item.getIcon()).start();
+        DrawableUtils.startAnimatedVectorDrawable(item.getIcon());
         new Handler().postDelayed(
             new Runnable() {
                 @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DrawableUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DrawableUtils.java
@@ -2,7 +2,9 @@ package com.automattic.simplenote.utils;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.graphics.drawable.AnimatedVectorDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -14,6 +16,7 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.FloatRange;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat;
 
 @SuppressWarnings("unused")
 public class DrawableUtils {
@@ -58,6 +61,14 @@ public class DrawableUtils {
         Resources.Theme theme = context.getTheme();
         theme.resolveAttribute(tintColorAttribute, typedValue, true);
         return typedValue.data;
+    }
+
+    public static void startAnimatedVectorDrawable(Drawable drawable) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            ((AnimatedVectorDrawable) drawable).start();
+        } else {
+            ((AnimatedVectorDrawableCompat) drawable).start();
+        }
     }
 
     public static void tintMenuWithAttribute(Context context, Menu menu, @AttrRes int tintColorAttribute) {


### PR DESCRIPTION
### Fix
Update instances of `AnimatedVectorDrawable` to use `AnimatedVectorDrawableCompat` on devices running Android 6.0 (API 23) to avoid `ClassCastException` crashes.  Even though `AnimatedVectorDrawable` was added in Android 5.0 (API 21), the support library uses `AnimatedVectorDrawable` for Android 7.0 (API 24) and higher while it uses `AnimatedVectorDrawableCompat` otherwise.

### Test
Since the `ClassCastException` crash occurs only on Android 6.0 (API 23) devices, it's best to test on at least one Android 6.0 (API 23) device and one Android 7.0 (API 24) or higher device.
1. Tap any note in list.
2. Tap ***Information*** icon in app bar.
3. Notice ***Information*** sheet is shown and ***Information*** icon animates.
4. Dismiss ***Information*** sheet.
5. Open navigation drawer.
6. Tap ***Trash*** item in navigation drawer.
7. If ***Trash*** is empty, notice disabled ***Trash*** icon in app bar.
8. If ***Trash*** is not empty, notice enabled ***Trash*** icon in app bar.
9. If ***Trash*** is empty, create and trash note.
10. Tap ***Trash*** icon in app bar.
11. Notice ***Empty trash*** dialog is shown.
12. Tap ***Yes*** button in ***Empty trash*** dialog.
13. Notice ***Empty trash*** dialog is dismissed and ***Trash*** icon does animate.
14. Notice disabled ***Trash*** icon in app bar.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@loremattei, these changes will require a new release build once they are merged.