### PR TITLE
Revert Websocket Threading

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.6
 -----
- 
+* Fixed networking bug causing data loss
+
 2.5
 -----
 * Added a dark version of the note widget to view and open a note in the app from the home screen

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -68,7 +68,7 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Automattic and WordPress dependencies
-    implementation 'com.simperium.android:simperium:0.9.8'
+    implementation 'com.simperium.android:simperium:0.9.9'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.2'
 


### PR DESCRIPTION
### Fix
Update the `simperium` dependency from `0.9.8` to `0.9.9`, which includes reverting the `AsyncWebSocketProvider` changes in https://github.com/Automattic/simplenote-android/pull/927 to avoid data loss as described in https://github.com/Simperium/simperium-android/pull/221.

### Test
Since these changes have no user-facing aspect, smoke testing is all that is required.  The changes affect the networking protocol class so it's best to test creating and editing notes and tags to ensure syncing is working as expected across devices.  Using two emulators side-by-side is a good way to see if syncing is working.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 9898a01 with:
> Fixed networking bug causing data loss