### PR TITLE
Issue/1015 crash save note

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1081,7 +1081,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     protected void saveNote() {
         try {
-            if (mNote == null || mContentEditText == null || mIsLoadingNote ||
+            if (mNote == null || mNotesBucket == null || mContentEditText == null || mIsLoadingNote ||
                 (mHistoryBottomSheet != null && mHistoryBottomSheet.getDialog() != null && mHistoryBottomSheet.getDialog().isShowing())) {
                 return;
             } else {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1085,9 +1085,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 (mHistoryBottomSheet != null && mHistoryBottomSheet.getDialog() != null && mHistoryBottomSheet.getDialog().isShowing())) {
                 return;
             } else {
-                Simplenote application = (Simplenote) requireActivity().getApplication();
-                Bucket<Note> notesBucket = application.getNotesBucket();
-                mNote = notesBucket.get(mNote.getSimperiumKey());
+                mNote = mNotesBucket.get(mNote.getSimperiumKey());
                 mIsPreviewEnabled = mNote.isPreviewEnabled();
             }
 


### PR DESCRIPTION
### Fix
Remove the `requireActivity()` reference from the `saveNote()` method in the `NoteEditorFragment` class to avoid a crash and close #1015.  See the stack trace below for details.

<details>
<summary>Stack Trace</summary>
<pre>
java.lang.IllegalStateException: Fragment NoteEditorFragment{d7c0cf9 (cff0345c-62ee-4d48-b3a7-759b15da6fca)} not attached to an activity.
    at androidx.fragment.app.Fragment.requireActivity
    at com.automattic.simplenote.NoteEditorFragment.saveNote
    at com.automattic.simplenote.NoteEditorFragment$SaveNoteTask.doInBackground
    at com.automattic.simplenote.NoteEditorFragment$SaveNoteTask.doInBackground
    at android.os.AsyncTask$2.call(AsyncTask.java:333)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
    at java.lang.Thread.run(Thread.java:764)
java.lang.RuntimeException: An error occurred while executing doInBackground()
    at android.os.AsyncTask$3.done(AsyncTask.java:354)
    at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
    at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
    at java.util.concurrent.FutureTask.run(FutureTask.java:271)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
    at java.lang.Thread.run(Thread.java:764)
</pre>
</details>

Even though I'm unable to reproduce the crash, the stack trace suggests these changes will avoid the exceptions and crash.

### Test
These test steps require editing a note on both the mobile and web apps.
1. ***Mobile***: Tap any unpinned note in list.
2. ***Mobile***: Tap ellipsis action in app bar.
3. ***Mobile***: Tap ***Pin*** in action menu.
4. ***Mobile***: Tap back arrow in app bar.
5. ***Web***: Click note in list from Step 1.
6. ***Web***: Click ***Info*** button in top, right corner.
7. ***Web***: Click ***Pin to top*** switch in menu.
8. ***Mobile***: Notice note from Step 1 is pinned.
9. ***Mobile***: Tap note from Step 1 in list.
10. ***Mobile***: Tap back arrow in app bar.
11. ***Mobile***: Notice app does not crash.

### Review
Only one developer is required to review these changes, but anyone can perform the review. @rachelmcr, I also requested you as a reviewer since you caught the associated crash and to ensure it is fixed.

### Release
These changes do not require release notes.