### PR TITLE
Use AndroidX version of JUnit in order to run tests again.

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -29,7 +29,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 29
 
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     lintOptions {


### PR DESCRIPTION
@theck13 in order to run the screenshot automation, I need to be able to run the tests under `androidTest`. This is a way for me to do so, but I'm not sure if it's appropriate. If it isn't, feel free to close this PR and point me towards the best one, thanks 👍 

### Fix
As far as I could understand, back in a95c5522 we switched to AndroidX, but the statement defining the instrumentation test runner hadn't been updated. This resulted in the tests failing to run with this error

```
java.lang.RuntimeException: Unable to instantiate instrumentation
ComponentInfo{com.automattic.simplenote.debug.test/android.support.test.runner.AndroidJUnitRunner}:
java.lang.ClassNotFoundException: Didn't find class "android.support.test.runner.AndroidJUnitRunner"
on path: DexPathList[
  [
    zip file "/system/framework/android.test.runner.jar",
    zip file "/system/framework/android.test.mock.jar",
    zip file "/data/app/com.automattic.simplenote.debug.test-NQM1UL3EJ7PNW0zh1s-oFQ==/base.apk",
    zip file "/data/app/com.automattic.simplenote.debug-82lTbOU8tKb6j931lp9neA==/base.apk"
  ],
  nativeLibraryDirectories=[/system/lib]
]
```

Switching to the androidx version fixed the issue.

on `develop` | on this branch
--- | ---
<img width="1904" alt="Screen Shot 2020-05-06 at 5 05 40 pm" src="https://user-images.githubusercontent.com/1218433/81146762-4146bd00-8fbc-11ea-9bc1-7ea5916c1540.png"> | <img width="1904" alt="Screen Shot 2020-05-06 at 5 05 26 pm" src="https://user-images.githubusercontent.com/1218433/81146756-3e4bcc80-8fbc-11ea-8558-0f75871b8400.png">

### Test
Checkout locally and verify the tests run.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.