### PR TITLE
Issue/1020 markdown setting sync

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -785,6 +785,13 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             mContentEditText.setText(mNote.getContent());
 
             if (isNoteUpdate) {
+                // Update markdown and preview flags from updated note.
+                mIsMarkdownEnabled = mNote.isMarkdownEnabled();
+                mIsPreviewEnabled = mNote.isPreviewEnabled();
+
+                // Show/Hide tabs based on markdown flag.
+                setMarkdown(mIsMarkdownEnabled);
+
                 // Save the note so any local changes get synced
                 mNote.save();
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -779,9 +779,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private void refreshContent(boolean isNoteUpdate) {
         if (mNote != null) {
             // Restore the cursor position if possible.
-
             int cursorPosition = newCursorLocation(mNote.getContent(), getNoteContentString(), mContentEditText.getSelectionEnd());
-
             mContentEditText.setText(mNote.getContent());
 
             if (isNoteUpdate) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -790,7 +790,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 // Show/Hide tabs based on markdown flag.
                 setMarkdown(mIsMarkdownEnabled);
 
-                // Save the note so any local changes get synced
+                // Save note so any local changes get synced.
                 mNote.save();
 
                 if (mContentEditText.hasFocus()


### PR DESCRIPTION
### Fix
Update the `mIsMarkdownEnabled` and `mIsPreviewEnabled` flags in the `NoteEditorFragment.refreshContent` method before saving the note when a remote updated is triggered to close #1020.  See the animation below for illustration.

<a href="https://user-images.githubusercontent.com/3827611/81424000-7b29d780-9112-11ea-8fc7-f25a472b3468.gif"><img src="https://user-images.githubusercontent.com/3827611/81424000-7b29d780-9112-11ea-8fc7-f25a472b3468.gif"></a>

### Test
As shown in the animation above, the best way to test these changes is to have an Android device side-by-side with a device on another platform.
1. **_Android_**: Tap any note in list with markdown enabled.
2. **_Android_**: Notice **_Edit_** and **_Preview_** tabs shown.
3. **_Other_**: Disable markdown.
4. **_Android_**: Notice **_Edit_** and **_Preview_** tabs hidden.
5. **_Other_**: Enable markdown.
6. **_Android_**: Notice **_Edit_** and **_Preview_** tabs shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review. @rachelmcr, I also requested you as a reviewer since you caught the associated bug and to ensure it is fixed.

### Release
These changes do not require release notes.