### PR TITLE
Issue/1023 tablet search list

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -845,7 +845,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
             // Restore the search query on landscape tablets
             if (!TextUtils.isEmpty(mTabletSearchQuery)) {
                 mSearchMenuItem.expandActionView();
-                mSearchView.setQuery(mTabletSearchQuery, false);
+                mSearchView.setQuery(mTabletSearchQuery, true);
                 mSearchView.clearFocus();
             }
 


### PR DESCRIPTION
### Fix
Update the `submit` parameter in the `SearchView.setQuery(query, submit)` statement to `true` so the search results list remains shown when a note is selected in the list and the search view is restored on large screen devices in landscape orientation to close #1023.  See the animation below for illustration.

<kbd><a href="https://user-images.githubusercontent.com/3827611/81572863-fda7d680-9360-11ea-91fe-168a4a7be56d.gif"><img src="https://user-images.githubusercontent.com/3827611/81572863-fda7d680-9360-11ea-91fe-168a4a7be56d.gif"></a></kbd>

### Test
When performing the test steps below, be sure to use a large screen device (i.e. tablet) in landscape orientation.
1. Tap ***Search*** action in app bar.
2. Notice search results list hidden.
3. Enter text matching at least two notes.
4. Submit search query with entered text.
5. Notice search results list shown.
6. Tap any note in search results list.
7. Tap any other note in search results list.
8. Notice search results list remains shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review. @rachelmcr, I also requested you as a reviewer since you caught the associated bug and to ensure it is fixed.

### Release
These changes do not require release notes.