### PR TITLE
Add Actions Sync

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -793,6 +793,11 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 // Save note so any local changes get synced.
                 mNote.save();
 
+                // Update current note object on large screen devices in landscape orientation.
+                if (DisplayUtils.isLargeScreenLandscape(requireContext())) {
+                    ((NotesActivity) requireActivity()).setCurrentNote(mNote);
+                }
+
                 // Update overflow popup menu.
                 requireActivity().invalidateOptionsMenu();
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -793,6 +793,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 // Save note so any local changes get synced.
                 mNote.save();
 
+                // Update overflow popup menu.
+                requireActivity().invalidateOptionsMenu();
+
                 if (mContentEditText.hasFocus()
                         && cursorPosition != mContentEditText.getSelectionEnd()
                         && cursorPosition < mContentEditText.getText().length()) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -793,11 +793,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 // Save note so any local changes get synced.
                 mNote.save();
 
-                // Update current note object on large screen devices in landscape orientation.
-                if (DisplayUtils.isLargeScreenLandscape(requireContext())) {
-                    ((NotesActivity) requireActivity()).setCurrentNote(mNote);
-                }
-
                 // Update overflow popup menu.
                 requireActivity().invalidateOptionsMenu();
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -960,6 +960,10 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
+        if (DisplayUtils.isLargeScreenLandscape(NotesActivity.this)) {
+            updateActionsForLargeLandscape(menu);
+        }
+
         MenuItem pinItem = menu.findItem(R.id.menu_pin);
         MenuItem shareItem = menu.findItem(R.id.menu_share);
         MenuItem historyItem = menu.findItem(R.id.menu_history);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -960,10 +960,6 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
-        if (DisplayUtils.isLargeScreenLandscape(NotesActivity.this)) {
-            updateActionsForLargeLandscape(menu);
-        }
-
         MenuItem pinItem = menu.findItem(R.id.menu_pin);
         MenuItem shareItem = menu.findItem(R.id.menu_share);
         MenuItem historyItem = menu.findItem(R.id.menu_history);


### PR DESCRIPTION
### Fix
Add invalidating the options menu and setting the current note in order to update the actions when note settings are changed remotely.  See the animations below for illustration.

<kbd><a href="https://user-images.githubusercontent.com/3827611/81724633-ef7db700-9441-11ea-83f1-25f09fb0f151.gif"><img src="https://user-images.githubusercontent.com/3827611/81724633-ef7db700-9441-11ea-83f1-25f09fb0f151.gif"></a></kbd>

<kbd><a href="https://user-images.githubusercontent.com/3827611/81724637-f278a780-9441-11ea-920c-96f28816d120.gif"><img src="https://user-images.githubusercontent.com/3827611/81724637-f278a780-9441-11ea-920c-96f28816d120.gif"></a></kbd>

### Test
When performing the test steps below, be sure to use a small screen device (i.e. phone) in any orientation and large screen device (i.e. tablet) in landscape orientation.  As shown in the animations above, the best way to test these changes is to have an Android device side-by-side with a device on another platform.  Note that the ***Show Markdown*** action may be hidden behind the overflow popup menu in Step 8 of the ***Tablet [Landscape]*** section below.
#### Phone [Portrait/Landscape], Tablet [Portrait]
1. **_Android_**: Tap any note in list.
2. **_Android_**: Tap ellipsis action to show overflow menu.
3. **_Other_**: Click **_Info_** button in top, right corner.
4. **_Other_**: Toggle ***Pin to top*** switch.
5. **_Android_**: Notice ***Pin*** checkbox updates.
6. **_Other_**: Toggle ***Markdown*** switch.
7. **_Android_**: Notice ***Markdown*** checkbox updates.
8. **_Android_**: Notice ***Edit*** and ***Preview*** tabs are shown/hidden. 
#### Tablet [Landscape]
1. **_Android_**: Tap any note in list.
2. **_Android_**: Tap ellipsis action to show overflow menu.
3. **_Other_**: Click **_Info_** button in top, right corner.
4. **_Other_**: Toggle ***Pin to top*** switch.
5. **_Android_**: Notice ***Pin*** checkbox updates.
6. **_Other_**: Toggle ***Markdown*** switch.
7. **_Android_**: Notice ***Markdown*** checkbox updates.
8. **_Android_**: Notice ***Show Markdown*** action is shown/hidden.

### Review
Only one developer is required to review these changes, but anyone can perform the review. @rachelmcr, I also requested you as a reviewer since you caught the associated bug and to ensure it is fixed.

### Release
These changes do not require release notes.