### PR TITLE
Issue/1029 publish network check

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -57,6 +57,7 @@ import com.automattic.simplenote.utils.ContextUtils;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.MatchOffsetHighlighter;
+import com.automattic.simplenote.utils.NetworkUtils;
 import com.automattic.simplenote.utils.NoteUtils;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.automattic.simplenote.utils.SimplenoteLinkify;
@@ -1274,6 +1275,11 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     private void publishNote() {
+        if (!NetworkUtils.isNetworkAvailable(requireContext())) {
+            Toast.makeText(requireContext(), R.string.error_network_required, Toast.LENGTH_LONG).show();
+            return;
+        }
+
         if (isAdded()) {
             mPublishingSnackbar = Snackbar.make(mRootView, R.string.publishing, Snackbar.LENGTH_INDEFINITE);
             mPublishingSnackbar.show();
@@ -1283,6 +1289,11 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     private void unpublishNote() {
+        if (!NetworkUtils.isNetworkAvailable(requireContext())) {
+            Toast.makeText(requireContext(), R.string.error_network_required, Toast.LENGTH_LONG).show();
+            return;
+        }
+
         if (isAdded()) {
             mPublishingSnackbar = Snackbar.make(mRootView, R.string.unpublishing, Snackbar.LENGTH_INDEFINITE);
             mPublishingSnackbar.show();

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/NetworkUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/NetworkUtils.java
@@ -1,0 +1,27 @@
+package com.automattic.simplenote.utils;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+public class NetworkUtils {
+    /**
+     * @return information on the active network connection
+     */
+    private static NetworkInfo getActiveNetworkInfo(Context context) {
+        if (context == null) {
+            return null;
+        }
+
+        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        return cm != null ? cm.getActiveNetworkInfo() : null;
+    }
+
+    /**
+     * @return true if a network connection is available; false otherwise
+     */
+    public static boolean isNetworkAvailable(Context context) {
+        NetworkInfo info = getActiveNetworkInfo(context);
+        return info != null && info.isConnected();
+    }
+}

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -149,6 +149,7 @@
     <string name="unpublish_successful">Public link removed.</string>
     <string name="publishing">Publishing&#8230;</string>
     <string name="unpublishing">Removing public link&#8230;</string>
+    <string name="error_network_required">A network connection is required. Please, check your connection and try again.</string>
     <string name="retry">Retry</string>
 
     <string name="collaborate">Collaborate</string>


### PR DESCRIPTION
### Fix
Add a network connection check before the publish and unpublish actions are executed to close #1029.  If a network connection is detected, the publish/unpublish action continues as expeected.  If no network connection is detected, the following message is shown.

> A network connection is required. Please, check your connection and try again.

### Test
1. Enable airplane mode.
2. Tap any note in list.
3. Tap ellipsis action in app bar.
4. Tap ***Publish***/***Unpublish*** item in menu.
5. Notice toast with ***A network connection is required. Please, check your connection and try again.*** message is shown.
6. Disable airplane mode.
7. Tap ellipsis action in app bar.
8. Tap ***Publish***/***Unpublish*** item in menu.
9. Notice snackbar with ***Publishing...***/***Removing public link...*** message is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.