### PR TITLE
Update gradle wrapper from to 5.6.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.google.com' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.3'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 19 17:54:16 MST 2020
+#Mon May 18 00:03:37 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
### Fix

* Update android gradle plugin to 3.6.3
* Update gradle wrapper to 5.6.4

### Test
Since these changes have no user-facing aspect, building the app and smoke testing is all that is required.

### Review

Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
