### PR TITLE
Update Empty Trash

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1052,7 +1052,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
             menu.setGroupVisible(R.id.group_2, false);
         }
 
-        menu.findItem(R.id.menu_empty_trash).setVisible(false);
+        menu.findItem(R.id.menu_empty_trash).setVisible(mSelectedTag != null && mSelectedTag.id == TRASH_ID);
     }
 
     public void updateViewsAfterTrashAction(Note note) {


### PR DESCRIPTION
### Fix
The changes in the **_Add Actions Sync_** pull request, https://github.com/Automattic/simplenote-android/pull/1028, included [updating the actions on large screen devices in landscape orientation in the onPrepareOptionsMenu method](https://github.com/Automattic/simplenote-android/commit/15326ec5596dfdb85bb92ecde57bb62bcc972de2#diff-6f25240fa3acbd8a012570ad7711f836).  That change made the **_Empty Trash_** action always invisible.  These change make the **_Empty Trash_** action visible when **_Trash_** is selected and invisible otherwise.

### Test
When performing the test steps below, be sure to use a large screen device (i.e. tablet) in landscape orientation.
1. Open navigation drawer.
2. Tap ***All Notes*** item in drawer.
3. Notice ***Empty Trash*** action is invisible.
4. Open navigation drawer.
5. Tap ***Trash*** item in drawer.
6. Notice ***Empty Trash*** action is visible.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.