### PR TITLE
Project/update libraries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  android: wordpress-mobile/android@0.0.32
+  android: wordpress-mobile/android@1.0.13
   bundle-install: toshimaru/bundle-install@0.3.1
 
 version: 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-29.0.2
+    - build-tools-29.0.3
     - android-29
 
 env:

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -60,14 +60,16 @@ buildscript {
 }
 
 dependencies {
+    def espressoVersion = "3.2.0"
+
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.8.47'
-    androidTestImplementation 'androidx.annotation:annotation:1.0.0'
-    androidTestImplementation 'androidx.test:runner:1.1.0'
-    androidTestImplementation 'androidx.test:rules:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0'
-    androidTestImplementation('androidx.test.espresso:espresso-contrib:3.1.0') {
+    androidTestImplementation 'androidx.annotation:annotation:1.1.0'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation "androidx.test.espresso:espresso-core:${espressoVersion}"
+    androidTestImplementation "androidx.test.espresso:espresso-contrib:${espressoVersion}"
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:${espressoVersion}") {
         // Necessary to avoid version conflicts
         exclude group: 'androidx', module: 'appcompat'
         exclude group: 'androidx', module: 'support-v4'
@@ -83,9 +85,9 @@ dependencies {
 
     // Google Support
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0-beta01'
+    implementation 'com.google.android.material:material:1.1.0-rc02'
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
-    implementation 'androidx.preference:preference:1.1.0'
+    implementation 'androidx.preference:preference:1.1.1'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
     // Google Play Services
     implementation 'com.google.android.gms:play-services-wearable:17.0.0'

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'io.sentry.android.gradle'
 
 android {
-    buildToolsVersion '29.0.2'
+    buildToolsVersion '29.0.3'
     compileSdkVersion 29
 
     buildTypes {

--- a/Wear/build.gradle
+++ b/Wear/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-    buildToolsVersion '29.0.2'
+    buildToolsVersion '29.0.3'
     compileSdkVersion 29
 
     buildTypes {


### PR DESCRIPTION
### Fix
Update library version for espresso 3.2.0
Update library version for preference to 1.1.1
Update library version for material design to rc01
Update library version for annotation to 1.1.0
Update library version for runner and rules to 1.2.0

### Test
Since these changes have no user-facing aspect, building the app and smoke testing is all that is required.

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
