### PR TITLE
Add Keyboard Shortcuts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.8
 -----
- 
+* Added hotkey shortcuts for devices with hardware keyboards
+
 2.7
 -----
 * Updated primary color to new Simplenote blue

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -248,6 +248,11 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
     public void onConfigurationChanged(@NonNull Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
 
+        // Relaunch shortcut dialog for window is maximized or restored (Chrome OS).
+        if (getSupportFragmentManager().findFragmentByTag(ShortcutDialogFragment.DIALOG_TAG) != null) {
+            ShortcutDialogFragment.showShortcuts(NoteEditorActivity.this, isPreviewTabSelected());
+        }
+
         // If changing to large screen landscape, we finish the activity to go back to
         // NotesActivity with the note selected in the multipane layout.
         if (DisplayUtils.isLargeScreen(this) &&

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -6,6 +6,7 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.HapticFeedbackConstants;
+import android.view.KeyEvent;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.RelativeLayout;
@@ -92,6 +93,14 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
         Intent intent = getIntent();
         mNoteId = intent.getStringExtra(NoteEditorFragment.ARG_ITEM_ID);
 
+        try {
+            Simplenote application = (Simplenote) getApplication();
+            Bucket<Note> notesBucket = application.getNotesBucket();
+            mNote = notesBucket.get(mNoteId);
+        } catch (BucketObjectMissingException exception) {
+            exception.printStackTrace();
+        }
+
         if (savedInstanceState == null) {
             // Create the note editor fragment
             Bundle arguments = new Bundle();
@@ -119,35 +128,35 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
             );
             mViewPager.setPagingEnabled(false);
             mViewPager.addOnPageChangeListener(
-                    new NoteEditorViewPager.OnPageChangeListener() {
-                        @Override
-                        public void onPageSelected(int position) {
-                            if (position == 1) {  // Preview is position 1
-                                DisplayUtils.hideKeyboard(mViewPager);
-                            }
-
-                            try {
-                                Simplenote application = (Simplenote) getApplication();
-                                Bucket<Note> notesBucket = application.getNotesBucket();
-                                mNote = notesBucket.get(mNoteId);
-
-                                if (mNote != null) {
-                                    mNote.setPreviewEnabled(position == 1);  // Preview is position 1
-                                    mNote.save();
-                                }
-                            } catch (BucketObjectMissingException exception) {
-                                exception.printStackTrace();
-                            }
+                new NoteEditorViewPager.OnPageChangeListener() {
+                    @Override
+                    public void onPageSelected(int position) {
+                        if (position == 1) {  // Preview is position 1
+                            DisplayUtils.hideKeyboard(mViewPager);
                         }
 
-                        @Override
-                        public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-                        }
+                        try {
+                            Simplenote application = (Simplenote) getApplication();
+                            Bucket<Note> notesBucket = application.getNotesBucket();
+                            mNote = notesBucket.get(mNoteId);
 
-                        @Override
-                        public void onPageScrollStateChanged(int state) {
+                            if (mNote != null) {
+                                mNote.setPreviewEnabled(position == 1);  // Preview is position 1
+                                mNote.save();
+                            }
+                        } catch (BucketObjectMissingException exception) {
+                            exception.printStackTrace();
                         }
                     }
+
+                    @Override
+                    public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+                    }
+
+                    @Override
+                    public void onPageScrollStateChanged(int state) {
+                    }
+                }
             );
 
             isMarkdownEnabled = intent.getBooleanExtra(NoteEditorFragment.ARG_MARKDOWN_ENABLED, false);
@@ -251,6 +260,89 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
         }
     }
 
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_C:
+                if (event.isShiftPressed() && event.isCtrlPressed()) {
+                    if (!isPreviewTabSelected()) {
+                        if (mNoteEditorFragment != null) {
+                            mNoteEditorFragment.insertChecklist();
+                        }
+                    } else {
+                        Toast.makeText(NoteEditorActivity.this, R.string.item_action_toggle_checklist_edit_error, Toast.LENGTH_SHORT).show();
+                    }
+
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            case KeyEvent.KEYCODE_COMMA:
+                if (event.isCtrlPressed()) {
+                    ShortcutDialogFragment.showShortcuts(NoteEditorActivity.this, isPreviewTabSelected());
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            case KeyEvent.KEYCODE_H:
+                if (event.isCtrlPressed()) {
+                    if (!isPreviewTabSelected()) {
+                        if (mNoteEditorFragment != null) {
+                            mNoteEditorFragment.showHistory();
+                        }
+                    } else {
+                        Toast.makeText(NoteEditorActivity.this, R.string.item_action_show_history_edit_error, Toast.LENGTH_SHORT).show();
+                    }
+
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            case KeyEvent.KEYCODE_I:
+                if (event.isCtrlPressed()) {
+                    if (!isPreviewTabSelected()) {
+                        if (mNoteEditorFragment != null) {
+                            mNoteEditorFragment.showInfo();
+                        }
+                    } else {
+                        Toast.makeText(NoteEditorActivity.this, R.string.item_action_show_information_edit_error, Toast.LENGTH_SHORT).show();
+                    }
+
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            case KeyEvent.KEYCODE_P:
+                if (event.isShiftPressed() && event.isCtrlPressed()) {
+                    if (mNote != null && mNote.isMarkdownEnabled()) {
+                        togglePreview();
+                    } else {
+                        Toast.makeText(NoteEditorActivity.this, R.string.item_action_toggle_preview_enable_error, Toast.LENGTH_SHORT).show();
+                    }
+
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            case KeyEvent.KEYCODE_S:
+                if (event.isCtrlPressed()) {
+                    if (!isPreviewTabSelected()) {
+                        if (mNoteEditorFragment != null) {
+                            mNoteEditorFragment.shareNote();
+                        }
+                    } else {
+                        Toast.makeText(NoteEditorActivity.this, R.string.item_action_show_share_edit_error, Toast.LENGTH_SHORT).show();
+                    }
+
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            default:
+                return super.onKeyUp(keyCode, event);
+        }
+    }
+
     protected NoteMarkdownFragment getNoteMarkdownFragment() {
         return (NoteMarkdownFragment) mNoteEditorFragmentPagerAdapter.getItem(1);
     }
@@ -258,6 +350,10 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
     public void hideTabs() {
         mTabLayout.setVisibility(View.GONE);
         mViewPager.setPagingEnabled(false);
+    }
+
+    private boolean isPreviewTabSelected() {
+        return mNote != null && mNote.isMarkdownEnabled() && mViewPager != null && mViewPager.getCurrentItem() == 1;  // Preview is position 1
     }
 
     public void showTabs() {
@@ -363,6 +459,24 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
         mNoteEditorFragment.scrollToMatch(mSearchMatchIndexes[mSearchMatchIndex]);
         setSearchMatchBarVisible(true);
         updateSearchMatchBarStatus();
+    }
+
+    private void togglePreview() {
+        int position = mNote.isPreviewEnabled() ? 0 : 1;  // Edit is position 0, Preview is position 1
+        mViewPager.setCurrentItem(position);
+
+        try {
+            Simplenote application = (Simplenote) getApplication();
+            Bucket<Note> notesBucket = application.getNotesBucket();
+            mNote = notesBucket.get(mNoteId);
+
+            if (mNote != null) {
+                mNote.setPreviewEnabled(position == 1);  // Preview is position 1
+                mNote.save();
+            }
+        } catch (BucketObjectMissingException exception) {
+            exception.printStackTrace();
+        }
     }
 
     private void updateSearchMatchBarStatus() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -259,6 +259,8 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
                 newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE && mNoteId != null) {
             Intent resultIntent = new Intent();
             resultIntent.putExtra(Simplenote.SELECTED_NOTE_ID, mNoteId);
+            resultIntent.putExtra(ShortcutDialogFragment.DIALOG_VISIBLE,
+                    getSupportFragmentManager().findFragmentByTag(ShortcutDialogFragment.DIALOG_TAG) != null);
             resultIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
             setResult(Activity.RESULT_OK, resultIntent);
             finish();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -576,7 +576,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
         if (mNote != null) {
-            menu.findItem(R.id.menu_info).setVisible(true);
             MenuItem pinItem = menu.findItem(R.id.menu_pin);
             MenuItem shareItem = menu.findItem(R.id.menu_share);
             MenuItem historyItem = menu.findItem(R.id.menu_history);
@@ -622,7 +621,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         super.onPrepareOptionsMenu(menu);
     }
 
-    private void insertChecklist() {
+    public void insertChecklist() {
         try {
             mContentEditText.insertChecklist();
         } catch (Exception e) {
@@ -674,7 +673,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         );
     }
 
-    private void shareNote() {
+    public void shareNote() {
         if (mNote != null) {
             mContentEditText.clearFocus();
             showShareSheet();
@@ -686,7 +685,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         }
     }
 
-    private void showHistory() {
+    public void showHistory() {
         if (mNote != null && mNote.getVersion() > 1) {
             mContentEditText.clearFocus();
             mHistoryTimeoutHandler.postDelayed(mHistoryTimeoutRunnable, HISTORY_TIMEOUT);
@@ -696,7 +695,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         }
     }
 
-    private void showInfo() {
+    public void showInfo() {
         if (mNote != null) {
             mContentEditText.clearFocus();
             saveNote();
@@ -952,6 +951,14 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         }
 
         new SaveNoteTask(this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    public boolean isPlaceholderVisible() {
+        if (mPlaceholderView != null) {
+            return mPlaceholderView.getVisibility() == View.VISIBLE;
+        } else {
+            return false;
+        }
     }
 
     public void setPlaceholderVisible(boolean isVisible) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -130,7 +130,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private boolean mIsPreviewEnabled;
     private boolean mShouldScrollToSearchMatch;
     private ActionMode mActionMode;
+    private MenuItem mChecklistMenuItem;
     private MenuItem mCopyMenuItem;
+    private MenuItem mInformationMenuItem;
     private MenuItem mShareMenuItem;
     private MenuItem mViewLinkMenuItem;
     private String mLinkUrl;
@@ -522,7 +524,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_checklist:
-                DrawableUtils.startAnimatedVectorDrawable(item.getIcon());
                 insertChecklist();
                 return true;
             case R.id.menu_copy:
@@ -533,7 +534,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 showHistory();
                 return true;
             case R.id.menu_info:
-                DrawableUtils.startAnimatedVectorDrawable(item.getIcon());
                 showInfo();
                 return true;
             case R.id.menu_markdown:
@@ -583,7 +583,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             MenuItem copyLinkItem = menu.findItem(R.id.menu_copy);
             MenuItem markdownItem = menu.findItem(R.id.menu_markdown);
             MenuItem trashItem = menu.findItem(R.id.menu_trash);
-            MenuItem checklistItem = menu.findItem(R.id.menu_checklist);
+            mChecklistMenuItem = menu.findItem(R.id.menu_checklist);
+            mInformationMenuItem = menu.findItem(R.id.menu_info).setVisible(true);
 
             pinItem.setChecked(mNote.isPinned());
             publishItem.setChecked(mNote.isPublished());
@@ -597,8 +598,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 publishItem.setEnabled(false);
                 copyLinkItem.setEnabled(false);
                 markdownItem.setEnabled(false);
-                checklistItem.setEnabled(false);
-                DrawableUtils.setMenuItemAlpha(checklistItem, 0.3);  // 0.3 is 30% opacity.
+                mChecklistMenuItem.setEnabled(false);
+                DrawableUtils.setMenuItemAlpha(mChecklistMenuItem, 0.3);  // 0.3 is 30% opacity.
             } else {
                 pinItem.setEnabled(true);
                 shareItem.setEnabled(true);
@@ -606,8 +607,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 publishItem.setEnabled(true);
                 copyLinkItem.setEnabled(mNote.isPublished());
                 markdownItem.setEnabled(true);
-                checklistItem.setEnabled(true);
-                DrawableUtils.setMenuItemAlpha(checklistItem, 1.0);  // 1.0 is 100% opacity.
+                mChecklistMenuItem.setEnabled(true);
+                DrawableUtils.setMenuItemAlpha(mChecklistMenuItem, 1.0);  // 1.0 is 100% opacity.
             }
 
             if (mNote.isDeleted()) {
@@ -622,6 +623,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     public void insertChecklist() {
+        DrawableUtils.startAnimatedVectorDrawable(mChecklistMenuItem.getIcon());
+
         try {
             mContentEditText.insertChecklist();
         } catch (Exception e) {
@@ -696,6 +699,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     public void showInfo() {
+        DrawableUtils.startAnimatedVectorDrawable(mInformationMenuItem.getIcon());
+
         if (mNote != null) {
             mContentEditText.clearFocus();
             saveNote();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -515,7 +515,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         }
     }
 
-    private void createNewNote(String label){
+    public void createNewNote(String label){
         if (!isAdded()) return;
 
         addNote();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -18,6 +19,7 @@ import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.ProgressBar;
+import android.widget.Toast;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
@@ -109,6 +111,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
     private boolean mIsTabletFullscreen;
     private boolean mShouldSelectNewNote;
 
+    private Menu mMenu;
     private String mTabletSearchQuery;
     private UndoBarController mUndoBarController;
     private View mFragmentsContainer;
@@ -728,6 +731,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.notes_list, menu);
         MenuCompat.setGroupDividerEnabled(menu, true);
+        mMenu = menu;
 
         // restore the search query if on a landscape tablet
         String searchQuery = null;
@@ -890,33 +894,13 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         if (mDrawerToggle.onOptionsItemSelected(item)) {
             return true;
         }
+
         switch (item.getItemId()) {
             case R.id.menu_sidebar:
-                FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-
-                if (mNoteListFragment.isHidden()) {
-                    ft.show(mNoteListFragment);
-                    setIconAfterAnimation(item, R.drawable.av_list_hide_show_24dp, R.string.list_hide);
-                } else {
-                    ft.hide(mNoteListFragment);
-                    setIconAfterAnimation(item, R.drawable.av_list_show_hide_24dp, R.string.list_show);
-                }
-
-                ft.commitNowAllowingStateLoss();
-                mIsTabletFullscreen = mNoteListFragment.isHidden();
+                toggleSidebar(item);
                 return true;
             case R.id.menu_markdown_preview:
-                if (mIsShowingMarkdown) {
-                    setIconAfterAnimation(item, R.drawable.av_visibility_on_off_24dp, R.string.markdown_show);
-                    setMarkdownShowing(false);
-                    mCurrentNote.setPreviewEnabled(false);
-                } else {
-                    setIconAfterAnimation(item, R.drawable.av_visibility_off_on_24dp, R.string.markdown_hide);
-                    setMarkdownShowing(true);
-                    mCurrentNote.setPreviewEnabled(true);
-                }
-
-                mCurrentNote.save();
+                togglePreview(item);
                 return true;
             case R.id.menu_trash:
                 if (mNoteEditorFragment != null && mCurrentNote != null) {
@@ -1385,6 +1369,119 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         }
     }
 
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_C:
+                if (event.isShiftPressed() && event.isCtrlPressed()) {
+                    if (isLargeLandscapeAndNoteSelected()) {
+                        if (mNoteEditorFragment != null) {
+                            mNoteEditorFragment.insertChecklist();
+                        }
+                    } else {
+                        Toast.makeText(NotesActivity.this, R.string.item_action_toggle_checklist_error, Toast.LENGTH_SHORT).show();
+                    }
+
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            case KeyEvent.KEYCODE_COMMA:
+                if (event.isCtrlPressed()) {
+                    ShortcutDialogFragment.showShortcuts(NotesActivity.this, false);
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            case KeyEvent.KEYCODE_H:
+                if (event.isCtrlPressed()) {
+                    if (isLargeLandscapeAndNoteSelected()) {
+                        if (mNoteEditorFragment != null) {
+                            mNoteEditorFragment.showHistory();
+                        }
+                    } else {
+                        Toast.makeText(NotesActivity.this, R.string.item_action_show_history_error, Toast.LENGTH_SHORT).show();
+                    }
+
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            case KeyEvent.KEYCODE_I:
+                if (event.isShiftPressed() && event.isCtrlPressed()) {
+                    getNoteListFragment().createNewNote("keyboard_shortcut");
+                    return true;
+                } else if (event.isCtrlPressed()) {
+                    if (isLargeLandscapeAndNoteSelected()) {
+                        if (mNoteEditorFragment != null) {
+                            mNoteEditorFragment.showInfo();
+                        }
+                    } else {
+                        Toast.makeText(NotesActivity.this, R.string.item_action_show_information_error, Toast.LENGTH_SHORT).show();
+                    }
+
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            case KeyEvent.KEYCODE_L:
+                if (event.isShiftPressed() && event.isCtrlPressed()) {
+                    if (isLargeLandscapeAndNoteSelected()) {
+                        toggleSidebar(mMenu.findItem(R.id.menu_sidebar));
+                    } else {
+                        Toast.makeText(NotesActivity.this, R.string.item_action_toggle_list_error, Toast.LENGTH_SHORT).show();
+                    }
+
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            case KeyEvent.KEYCODE_P:
+                if (event.isShiftPressed() && event.isCtrlPressed()) {
+                    if (isLargeLandscapeAndNoteSelected()) {
+                        if (mCurrentNote != null && mCurrentNote.isMarkdownEnabled()) {
+                            togglePreview(mMenu.findItem(R.id.menu_markdown_preview));
+                        } else {
+                            Toast.makeText(NotesActivity.this, R.string.item_action_toggle_preview_enable_error, Toast.LENGTH_SHORT).show();
+                        }
+                    } else {
+                        Toast.makeText(NotesActivity.this, R.string.item_action_toggle_preview_error, Toast.LENGTH_SHORT).show();
+                    }
+
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            case KeyEvent.KEYCODE_S:
+                if (event.isShiftPressed() && event.isCtrlPressed()) {
+                    if (mSearchMenuItem != null && mSearchView != null) {
+                        mSearchMenuItem.expandActionView();
+                        mSearchView.requestFocus();
+                    }
+
+                    return true;
+                } else if (event.isCtrlPressed()) {
+                    if (isLargeLandscapeAndNoteSelected()) {
+                        if (mNoteEditorFragment != null) {
+                            mNoteEditorFragment.shareNote();
+                        }
+                    } else {
+                        Toast.makeText(NotesActivity.this, R.string.item_action_show_share_error, Toast.LENGTH_SHORT).show();
+                    }
+
+                    return true;
+                } else {
+                    return super.onKeyUp(keyCode, event);
+                }
+            default:
+                return super.onKeyUp(keyCode, event);
+        }
+    }
+
+    private boolean isLargeLandscapeAndNoteSelected() {
+        return DisplayUtils.isLargeScreenLandscape(NotesActivity.this) && mNoteEditorFragment != null && !mNoteEditorFragment.isPlaceholderVisible();
+    }
+
     public void checkEmptyListText(boolean isSearch) {
         if (isSearch) {
             if (DisplayUtils.isLandscape(this) && !DisplayUtils.isLargeScreen(this)) {
@@ -1455,6 +1552,35 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                     getResources().getQuantityString(R.plurals.trashed_notes, noteIds.size(), noteIds.size())
             );
         }
+    }
+
+    private void togglePreview(MenuItem item) {
+        if (mIsShowingMarkdown) {
+            setIconAfterAnimation(item, R.drawable.av_visibility_on_off_24dp, R.string.markdown_show);
+            setMarkdownShowing(false);
+            mCurrentNote.setPreviewEnabled(false);
+        } else {
+            setIconAfterAnimation(item, R.drawable.av_visibility_off_on_24dp, R.string.markdown_hide);
+            setMarkdownShowing(true);
+            mCurrentNote.setPreviewEnabled(true);
+        }
+
+        mCurrentNote.save();
+    }
+
+    private void toggleSidebar(MenuItem item) {
+        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+
+        if (mNoteListFragment.isHidden()) {
+            ft.show(mNoteListFragment);
+            setIconAfterAnimation(item, R.drawable.av_list_hide_show_24dp, R.string.list_hide);
+        } else {
+            ft.hide(mNoteListFragment);
+            setIconAfterAnimation(item, R.drawable.av_list_show_hide_24dp, R.string.list_show);
+        }
+
+        ft.commitNowAllowingStateLoss();
+        mIsTabletFullscreen = mNoteListFragment.isHidden();
     }
 
     /* Simperium Bucket Listeners */

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1255,6 +1255,11 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                         if (mNoteEditorFragment != null) {
                             mNoteEditorFragment.setNote(selectedNoteId);
                         }
+
+                        // Relaunch shortcut dialog if it was showing in editor (Chrome OS).
+                        if (data.getBooleanExtra(ShortcutDialogFragment.DIALOG_VISIBLE, false)) {
+                            ShortcutDialogFragment.showShortcuts(NotesActivity.this, false);
+                        }
                     }
                 }
                 break;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1316,8 +1316,12 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
     @Override
     public void onConfigurationChanged(@NonNull Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-
         mDrawerToggle.onConfigurationChanged(newConfig);
+
+        // Relaunch shortcut dialog for window is maximized or restored (Chrome OS).
+        if (getSupportFragmentManager().findFragmentByTag(ShortcutDialogFragment.DIALOG_TAG) != null) {
+            ShortcutDialogFragment.showShortcuts(NotesActivity.this, false);
+        }
 
         if (DisplayUtils.isLargeScreen(this)) {
             mIsShowingMarkdown = false;

--- a/Simplenote/src/main/java/com/automattic/simplenote/ShortcutDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/ShortcutDialogFragment.java
@@ -1,0 +1,60 @@
+package com.automattic.simplenote;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.view.View;
+
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatDialogFragment;
+import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentTransaction;
+
+import com.automattic.simplenote.utils.DisplayUtils;
+
+public class ShortcutDialogFragment extends AppCompatDialogFragment {
+    public final static String DIALOG_TAG = "shortcut_tag";
+    public final static String DIALOG_VISIBLE = "shortcut_visible";
+
+    private boolean mIsPreview;
+
+    private ShortcutDialogFragment(boolean isPreview) {
+        mIsPreview = isPreview;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        if (getContext() != null && getActivity() != null) {
+            View view = View.inflate(requireContext(), getLayout(), null);
+            return new AlertDialog.Builder(new ContextThemeWrapper(requireContext(), R.style.Dialog))
+                .setView(view)
+                .setPositiveButton(android.R.string.ok, null)
+                .create();
+        } else {
+            return super.onCreateDialog(savedInstanceState);
+        }
+    }
+
+    private @LayoutRes int getLayout() {
+        return DisplayUtils.isLargeScreenLandscape(requireContext()) ? R.layout.dialog_shortcuts_all :
+                !(getActivity() instanceof NoteEditorActivity) ? R.layout.dialog_shortcuts_list :
+                        mIsPreview ? R.layout.dialog_shortcuts_editor_preview :
+                                R.layout.dialog_shortcuts_editor_edit;
+    }
+
+    public static void showShortcuts(@NonNull FragmentActivity activity, boolean isPreview) {
+        FragmentTransaction transaction = activity.getSupportFragmentManager().beginTransaction();
+        Fragment fragment = activity.getSupportFragmentManager().findFragmentByTag(DIALOG_TAG);
+
+        if (fragment != null) {
+            transaction.remove(fragment);
+        }
+
+        ShortcutDialogFragment dialog = new ShortcutDialogFragment(isPreview);
+        dialog.show(transaction, DIALOG_TAG);
+    }
+}

--- a/Simplenote/src/main/res/drawable/bg_key.xml
+++ b/Simplenote/src/main/res/drawable/bg_key.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <corners
+        android:radius="@dimen/corner_radius">
+    </corners>
+
+    <solid
+        android:color="?attr/keyBackgroundColor">
+    </solid>
+
+</shape>

--- a/Simplenote/src/main/res/layout/dialog_shortcuts_all.xml
+++ b/Simplenote/src/main/res/layout/dialog_shortcuts_all.xml
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:clipToPadding="false"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+
+    <LinearLayout
+        android:clipToPadding="false"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/padding_large"
+        android:paddingTop="@dimen/padding_large">
+
+        <TextView
+            android:layout_height="@dimen/header_height"
+            android:layout_width="match_parent"
+            android:text="@string/action"
+            style="@style/Shortcut.Header">
+        </TextView>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_note_new"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_note_new_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_note_new_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_note_new"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_note_new_key_third"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_i"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_note_new_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_note_new_key_third"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_shift"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_note_new_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_note_new_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_open_search"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_open_search_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_open_search_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_open_search"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_open_search_key_third"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_s"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_open_search_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_open_search_key_third"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_shift"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_open_search_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_open_search_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_toggle_checklist"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_toggle_checklist_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_toggle_checklist_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_toggle_checklist"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_checklist_key_third"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_c"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_checklist_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_toggle_checklist_key_third"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_shift"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_checklist_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_toggle_checklist_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_toggle_preview"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_toggle_preview"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_key_third"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_p"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_third"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_shift"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_toggle_list"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_toggle_list_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_toggle_list_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_toggle_list"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_list_key_third"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_l"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_list_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_toggle_list_key_third"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_shift"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_list_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_toggle_list_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_show_information"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_show_information_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_show_information_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_show_information"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_information_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_i"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_information_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_show_information_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_show_history"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_show_history_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_show_history_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_show_history"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_history_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_h"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_history_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_show_history_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_show_share"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_show_share_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_show_share_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_show_share"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_share_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_s"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_share_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_show_share_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/Simplenote/src/main/res/layout/dialog_shortcuts_editor_edit.xml
+++ b/Simplenote/src/main/res/layout/dialog_shortcuts_editor_edit.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:clipToPadding="false"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+
+    <LinearLayout
+        android:clipToPadding="false"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/padding_large"
+        android:paddingTop="@dimen/padding_large">
+
+        <TextView
+            android:layout_height="@dimen/header_height"
+            android:layout_width="match_parent"
+            android:text="@string/action"
+            style="@style/Shortcut.Header">
+        </TextView>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_toggle_checklist"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_toggle_checklist_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_toggle_checklist_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_toggle_checklist"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_checklist_key_third"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_c"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_checklist_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_toggle_checklist_key_third"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_shift"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_checklist_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_toggle_checklist_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_toggle_preview"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_toggle_preview"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_key_third"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_p"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_third"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_shift"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_show_information"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_show_information_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_show_information_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_show_information"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_information_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_i"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_information_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_show_information_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_show_history"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_show_history_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_show_history_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_show_history"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_history_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_h"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_history_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_show_history_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_show_share"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_show_share_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_show_share_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_show_share"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_share_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_s"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_share_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_show_share_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/Simplenote/src/main/res/layout/dialog_shortcuts_editor_preview.xml
+++ b/Simplenote/src/main/res/layout/dialog_shortcuts_editor_preview.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:clipToPadding="false"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+
+    <LinearLayout
+        android:clipToPadding="false"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/padding_large"
+        android:paddingTop="@dimen/padding_large">
+
+        <TextView
+            android:layout_height="@dimen/header_height"
+            android:layout_width="match_parent"
+            android:text="@string/action"
+            style="@style/Shortcut.Header">
+        </TextView>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_toggle_preview"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_toggle_preview"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_key_third"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_p"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_third"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_shift"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/Simplenote/src/main/res/layout/dialog_shortcuts_list.xml
+++ b/Simplenote/src/main/res/layout/dialog_shortcuts_list.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:clipToPadding="false"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+
+    <LinearLayout
+        android:clipToPadding="false"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/padding_large"
+        android:paddingTop="@dimen/padding_large">
+
+        <TextView
+            android:layout_height="@dimen/header_height"
+            android:layout_width="match_parent"
+            android:text="@string/action"
+            style="@style/Shortcut.Header">
+        </TextView>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_note_new"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_note_new_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_note_new_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_note_new"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_note_new_key_third"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_i"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_note_new_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_note_new_key_third"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_shift"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_note_new_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_note_new_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/shortcut_open_search"
+            android:layout_height="?android:listPreferredItemHeightSmall"
+            android:layout_width="match_parent"
+            android:layout_marginEnd="@dimen/padding_extra_extra_large"
+            android:layout_marginStart="@dimen/padding_extra_extra_large">
+
+            <TextView
+                android:id="@+id/shortcut_open_search_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_open_search_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_open_search"
+                style="@style/Shortcut.Item">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_open_search_key_third"
+                android:layout_height="@dimen/key_height"
+                android:layout_width="wrap_content"
+                android:text="@string/key_single_s"
+                style="@style/Shortcut.Key.Single">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_open_search_key_second"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_open_search_key_third"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_shift"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_open_search_key_first"
+                android:layout_height="@dimen/key_height"
+                android:layout_toStartOf="@+id/shortcut_open_search_key_second"
+                android:layout_width="wrap_content"
+                android:text="@string/key_multiple_ctrl"
+                style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+        </RelativeLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -33,6 +33,7 @@
         <item name="hintTextColor">@color/text_title_disabled</item>
         <item name="iconTintColor">@color/item_blue_dark</item>
         <item name="isLightTheme">false</item>
+        <item name="keyBackgroundColor">@color/gray_40</item>
         <item name="listBackgroundSelector">@drawable/bg_list_dark</item>
         <item name="listDividerDrawable">@drawable/divider_dark</item>
         <item name="listSearchHighlightBackgroundColor">@color/simplenote_blue_60</item>

--- a/Simplenote/src/main/res/values/attrs.xml
+++ b/Simplenote/src/main/res/values/attrs.xml
@@ -22,6 +22,7 @@
     <attr name="chipCheckedOffBackgroundColor" format="reference"/>
     <attr name="chipCheckedOnBackgroundColor" format="reference"/>
     <attr name="chipTextColor" format="reference"/>
+    <attr name="keyBackgroundColor" format="reference"/>
     <attr name="pinIconSelector" format="reference"/>
 
     <attr name="toolbarColor" format="reference|color"/>

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -40,8 +40,11 @@
     <dimen name="corner_radius">4dp</dimen>
     <dimen name="divider_height">1dp</dimen>
     <dimen name="elevation_bar">8dp</dimen>
+    <dimen name="header_height">48dp</dimen>
     <dimen name="icon_empty">72dp</dimen>
     <dimen name="icon_status">16dp</dimen>
+    <dimen name="key_height">32dp</dimen>
+    <dimen name="key_width">28dp</dimen>
     <dimen name="line_spacing">4dp</dimen>
     <dimen name="line_spacing_list">2dp</dimen>
     <dimen name="logo_empty">96dp</dimen>
@@ -58,6 +61,9 @@
     <dimen name="text_content_title">16sp</dimen>
     <dimen name="text_date">14sp</dimen>
     <dimen name="text_empty">16sp</dimen>
+    <dimen name="text_header">14sp</dimen>
+    <dimen name="text_item">16sp</dimen>
+    <dimen name="text_key">14sp</dimen>
     <dimen name="text_tag">14sp</dimen>
     <dimen name="text_suggestion">16sp</dimen>
     <dimen name="text_widget">12sp</dimen>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -230,6 +230,25 @@
     <string name="passcode_wrong_passcode">Wrong passcode, please try again.</string>
     <string name="passcodelock_prompt_message">Enter your passcode</string>
 
+    <!-- SHORTCUTS -->
+    <string name="action">Action</string>
+    <string name="item_action_note_new" translatable="false">@string/new_note</string>
+    <string name="item_action_open_search">Open Search</string>
+    <string name="item_action_show_history">Show History</string>
+    <string name="item_action_show_information">Show Information</string>
+    <string name="item_action_show_share">Show Share</string>
+    <string name="item_action_toggle_checklist" translatable="false">@string/toggle_checklist</string>
+    <string name="item_action_toggle_list">Toggle List</string>
+    <string name="item_action_toggle_preview">Toggle Preview</string>
+    <string name="key_multiple_ctrl">Ctrl</string>
+    <string name="key_multiple_shift">Shift</string>
+    <string name="key_single_c">C</string>
+    <string name="key_single_h">H</string>
+    <string name="key_single_i">I</string>
+    <string name="key_single_l">L</string>
+    <string name="key_single_p">P</string>
+    <string name="key_single_s">S</string>
+
     <!-- SIMPERIUM -->
     <string name="simperium_button_login">Log In</string>
     <string name="simperium_button_login_email">Log In with Email</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -235,11 +235,22 @@
     <string name="item_action_note_new" translatable="false">@string/new_note</string>
     <string name="item_action_open_search">Open Search</string>
     <string name="item_action_show_history">Show History</string>
+    <string name="item_action_show_history_edit_error">Select Edit tab to show history</string>
+    <string name="item_action_show_history_error">Select a note to show history</string>
     <string name="item_action_show_information">Show Information</string>
+    <string name="item_action_show_information_edit_error">Select Edit tab to show information</string>
+    <string name="item_action_show_information_error">Select a note to show information</string>
     <string name="item_action_show_share">Show Share</string>
+    <string name="item_action_show_share_edit_error">Select Edit tab to show share</string>
+    <string name="item_action_show_share_error">Select a note to show share</string>
     <string name="item_action_toggle_checklist" translatable="false">@string/toggle_checklist</string>
+    <string name="item_action_toggle_checklist_edit_error">Select Edit tab to toggle checklist</string>
+    <string name="item_action_toggle_checklist_error">Select a note to toggle checklist</string>
     <string name="item_action_toggle_list">Toggle List</string>
+    <string name="item_action_toggle_list_error">Select a note to toggle list</string>
     <string name="item_action_toggle_preview">Toggle Preview</string>
+    <string name="item_action_toggle_preview_enable_error">Enable markdown to toggle preview</string>
+    <string name="item_action_toggle_preview_error">Select a note to toggle preview</string>
     <string name="key_multiple_ctrl">Ctrl</string>
     <string name="key_multiple_shift">Shift</string>
     <string name="key_single_c">C</string>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -41,6 +41,7 @@
         <item name="fabIconColor">@android:color/white</item>
         <item name="hintTextColor">@color/text_title_disabled</item>
         <item name="iconTintColor">@color/item_blue_light</item>
+        <item name="keyBackgroundColor">@color/gray_5</item>
         <item name="listBackgroundSelector">@drawable/bg_list_light</item>
         <item name="listDividerDrawable">@drawable/divider_light</item>
         <item name="listSearchHighlightBackgroundColor">@color/simplenote_blue_5</item>
@@ -291,6 +292,50 @@
 
     <style name="PasscodeKeyboardImageStyle" parent="@style/PasscodeKeyboardButtonStyle">
         <item name="android:tint">@color/passcodelock_button_image_color</item>
+    </style>
+
+    <style name="Shortcut.Key.Multiple" parent="TextAppearance.AppCompat">
+        <item name="android:background">@drawable/bg_key</item>
+        <item name="android:gravity">center</item>
+        <item name="android:layout_marginLeft">@dimen/padding_small</item>
+        <item name="android:minWidth">@dimen/key_width</item>
+        <item name="android:paddingLeft">@dimen/padding_small</item>
+        <item name="android:paddingRight">@dimen/padding_small</item>
+        <item name="android:textAllCaps">true</item>
+        <item name="android:textSize">@dimen/text_key</item>
+        <item name="android:layout_centerVertical">true</item>
+    </style>
+
+    <style name="Shortcut.Key.Single" parent="TextAppearance.AppCompat">
+        <item name="android:background">@drawable/bg_key</item>
+        <item name="android:gravity">center</item>
+        <item name="android:layout_marginLeft">@dimen/padding_small</item>
+        <item name="android:minWidth">@dimen/key_width</item>
+        <item name="android:paddingLeft">@dimen/padding_small</item>
+        <item name="android:paddingRight">@dimen/padding_small</item>
+        <item name="android:textAllCaps">true</item>
+        <item name="android:textSize">@dimen/text_key</item>
+        <item name="android:layout_centerVertical">true</item>
+        <item name="android:layout_alignParentRight">true</item>
+    </style>
+
+    <style name="Shortcut.Header" parent="TextAppearance.AppCompat">
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:layout_marginLeft">@dimen/padding_extra_extra_large</item>
+        <item name="android:layout_marginRight">@dimen/padding_extra_extra_large</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textColor">?attr/colorAccent</item>
+        <item name="android:textSize">@dimen/text_header</item>
+    </style>
+
+    <style name="Shortcut.Item" parent="TextAppearance.AppCompat">
+        <item name="android:ellipsize">end</item>
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:maxLines">1</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textSize">@dimen/text_item</item>
+        <item name="android:layout_alignParentLeft">true</item>
     </style>
 
 </resources>


### PR DESCRIPTION
### Fix
Add hotkey shortcuts for devices with hardware keyboards including an informational dialog to close #538.  The dialog and available shortcuts change based on the layout and screen being shown.  There are four variations of the dialog based on the available shortcut(s).

#### Large Device in Landscape
Shortcut|Keys
-|-
New Note|`CTRL` `SHIFT` `I`
Open Search|`CTRL` `SHIFT` `S`
Toggle Checklist|`CTRL` `SHIFT` `C`
Toggle Preview|`CTRL` `SHIFT` `P`
Toggle List|`CTRL` `SHIFT` `L`
Show Information|`CTRL` `I`
Show History|`CTRL` `H`
Show Share|`CTRL` `S`

#### Small Device in Landscape and Portrait or Large Device in Portrait
##### Note List
Shortcut|Keys
-|-
New Note|`CTRL` `SHIFT` `I`
Open Search|`CTRL` `SHIFT` `S`

##### Editor with Edit Tab
Shortcut|Keys
-|-
Toggle Checklist|`CTRL` `SHIFT` `C`
Toggle Preview|`CTRL` `SHIFT` `P`
Show Information|`CTRL` `I`
Show History|`CTRL` `H`
Show Share|`CTRL` `S`

##### Editor with Preview Tab
Shortcut|Keys
-|-
Toggle Preview|`CTRL` `SHIFT` `P`

See the screenshots below for illustration.

![add_keyboard_shortcuts_small](https://user-images.githubusercontent.com/3827611/83545352-511ec780-a4bc-11ea-85a5-8c1d2fba0873.png)

![add_keyboard_shortcuts_large](https://user-images.githubusercontent.com/3827611/83545366-55e37b80-a4bc-11ea-91b6-500765c8cd81.png)

I'm not completely satisified with the `switch` statements in the `onKeyUp` methods ([`NotesActivity`](https://github.com/Automattic/simplenote-android/blob/d57696763dd56643f0bf152bccea2f6509d3e38d/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java#L1381-L1488) and [`NoteEditorActivity`](https://github.com/Automattic/simplenote-android/blob/d57696763dd56643f0bf152bccea2f6509d3e38d/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java#L270-L351)).  The logic is solid, but it seems like it could be optimized somehow.  I'm open to any suggestions.

### Test
Since the keyboard shortcuts dialog is only shown when the `CTRL` and `,` keys are pressed and the keyboard shortcuts only work on a device with a hardware keyboard, a device with a hardware keyboard is required to perform and verify the expected behavior.
#### Large Device in Landscape
1. Launch app without selecting note in list.
2. Press `CTRL` `,` keys.
3. Notice keyboard shortcuts dialog is shown.
4. Dismiss keyboard shortcuts dialog.
5. Press keys to perform keyboard shortcuts.
6. Notice shortcuts requiring note to be selected show error message.
7. Notice **_Open Search_** and **_New Note_** keyboard shortcuts work without selecting note in list.
8. Select note in list.
9. Press keys to perform keyboard shortcuts.
10. Notice keyboard shortcuts work as expected.

#### Small Device in Landscape and Portrait or Large Device in Portrait
1. Launch app without selecting note in list.
2. Press `CTRL` `,` keys.
3. Notice keyboard shortcuts dialog is shown.
4. Dismiss keyboard shortcuts dialog.
5. Press keys to perform keyboard shortcuts.
6. Notice shortcuts requiring note to be selected show error message.
7. Notice **_Open Search_** and **_New Note_** keyboard shortcuts work without selecting note in list.
8. Select note in list with markdown enabled.
9. Select _**Edit**_ tab.
10. Press `CTRL` `,` keys.
11. Notice keyboard shortcuts dialog is shown.
12. Dismiss keyboard shortcuts dialog.
13. Press keys to perform keyboard shortcuts.
14. Notice shortcuts work as expected.
15. Select _**Preview**_ tab.
16. Press `CTRL` `,` keys.
17. Notice keyboard shortcuts dialog is shown.
18. Dismiss keyboard shortcuts dialog.
19. Press keys to perform keyboard shortcuts.
20. Notice shortcuts work as expected.
21. Notice shortcuts requiring _**Edit**_ to be selected show error message.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in d5769676 with:
> Added hotkey shortcuts for devices with hardware keyboards