### PR TITLE
Issue/1046 search history padding

### DIFF
--- a/Simplenote/src/main/res/layout/search_suggestion.xml
+++ b/Simplenote/src/main/res/layout/search_suggestion.xml
@@ -28,6 +28,8 @@
         android:layout_marginEnd="@dimen/padding_small"
         android:layout_weight="1"
         android:layout_width="0dp"
+        android:paddingBottom="@dimen/padding_medium"
+        android:paddingTop="@dimen/padding_medium"
         android:textColor="?attr/noteTitleColor"
         android:textSize="@dimen/text_suggestion"
         tools:text="tag:work"


### PR DESCRIPTION
### Fix
Add top and bottom padding to the `TextView` in the `search_suggestion` layout to close #1046.  The `padding_medium` value was added, which is 8dp.  That way the row height would not increase for single-lined suggestions with default text size.  See the screenshots below for illustration.

![1046_search_history_padding](https://user-images.githubusercontent.com/3827611/83689619-94586380-a5ac-11ea-88eb-7c3f256f8a27.png)

### Test
1. Tap ***Search Notes or Tags*** action in top app bar.
2. Enter enough text to wrap two or three lines.
3. Notice top and bottom padding.
4. Submit search with entered text.
5. Tap ***Close*** (i.e. ***X***) icon in search field.
6. Notice search suggestion entered in Step 2.
7. Notice top and bottom padding.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.