### PR TITLE
Issue/1057 tag sync reverted

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -716,7 +716,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         editor.apply();
     }
 
-    protected void setMarkdownEnabled(boolean enabled) {
+    private void setMarkdownEnabled(boolean enabled) {
         mIsMarkdownEnabled = enabled;
 
         if (mIsMarkdownEnabled) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1096,7 +1096,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mContentEditText.setText(content);
     }
 
-    protected void saveNote() {
+    private void saveNote() {
         try {
             if (mNote == null || mNotesBucket == null || mContentEditText == null || mIsLoadingNote ||
                 (mHistoryBottomSheet != null && mHistoryBottomSheet.getDialog() != null && mHistoryBottomSheet.getDialog().isShowing())) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1355,6 +1355,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         if (changeType == Bucket.ChangeType.MODIFY) {
             if (getNote() != null && getNote().getSimperiumKey().equals(key)) {
                 try {
+                    mNotesBucket = noteBucket;
                     final Note updatedNote = mNotesBucket.get(key);
                     if (getActivity() != null) {
                         getActivity().runOnUiThread(new Runnable() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -706,6 +706,25 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     private void setMarkdown(boolean isChecked) {
         mIsMarkdownEnabled = isChecked;
+        showMarkdownActionOrTabs();
+        saveNote();
+
+        // Set preference so that next new note will have markdown enabled.
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putBoolean(PrefUtils.PREF_MARKDOWN_ENABLED, isChecked);
+        editor.apply();
+    }
+
+    protected void setMarkdownEnabled(boolean enabled) {
+        mIsMarkdownEnabled = enabled;
+
+        if (mIsMarkdownEnabled) {
+            loadMarkdownData();
+        }
+    }
+
+    private void showMarkdownActionOrTabs() {
         Activity activity = getActivity();
 
         if (activity instanceof NoteEditorActivity) {
@@ -725,22 +744,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         } else if (activity instanceof NotesActivity) {
             setMarkdownEnabled(mIsMarkdownEnabled);
             ((NotesActivity) getActivity()).setMarkdownShowing(false);
-        }
-
-        saveNote();
-
-        // Set preference so that next new note will have markdown enabled.
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putBoolean(PrefUtils.PREF_MARKDOWN_ENABLED, isChecked);
-        editor.apply();
-    }
-
-    protected void setMarkdownEnabled(boolean enabled) {
-        mIsMarkdownEnabled = enabled;
-
-        if (mIsMarkdownEnabled) {
-            loadMarkdownData();
         }
     }
 
@@ -788,8 +791,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 mIsMarkdownEnabled = mNote.isMarkdownEnabled();
                 mIsPreviewEnabled = mNote.isPreviewEnabled();
 
-                // Show/Hide tabs based on markdown flag.
-                setMarkdown(mIsMarkdownEnabled);
+                // Show/Hide action/tabs based on markdown flag.
+                showMarkdownActionOrTabs();
 
                 // Save note so any local changes get synced.
                 mNote.save();


### PR DESCRIPTION
### Fix
Add setting the notes bucket member variable when a change is detected and showing the markdown action (i.e. eye icon) or tabs (i.e. **_Edit_** and **_Preview_**) to close #1057.  See the animation below for illustration.

![1057_tag_sync_reverted](https://user-images.githubusercontent.com/3827611/83821623-208d8800-a68c-11ea-86ee-6a3a2f8a909c.gif)

The high-resolution source video used to create the animation can be seen [here](https://drive.google.com/file/d/1Jj9Q2lgok9TYchQ9H84AgQsaNy_U7MKP/view).

The animation and video show that the tags are not synced perfectly on Simplenote iOS.  I've notified @jleandroperez and he'll look into that separately.  If it requires changes to Simplenote Android, those will be in a subsequent pull request.

### Test
As shown in the animations above, the best way to test these changes is to have an Android device side-by-side with a device on another platform.
1. ***Android***: Tap any note in list.
2. ***Other***: Select note from Step 1 in list.
3. ***Android***: Add `android` tag to note.
4. ***Other***: Notice `android` tag in note.
5. ***Other***: Add `other` tag to note.
6. ***Android***: Notice `other` tag in note.
7. ***Android***: Remove `other` tag from note.
8. ***Other***: Notice `other` tag removed from note.
9. ***Other***: Remove `android` tag from note.
10. ***Android***: Notice `android` tag removed from note.


### Review
Only one developer is required to review these changes, but anyone can perform the review.  @rachelmcr, I also requested you as a reviewer since you caught the associated bug and to ensure it is fixed.

### Release
These changes do not require release notes.

#### Note
@mokagio, these changes will require a new release candidate build once they are merged.