### PR TITLE
Issue/1058 link share text

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -43,6 +43,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.view.ActionMode;
+import androidx.core.app.ShareCompat;
 import androidx.core.view.MenuCompat;
 import androidx.core.widget.NestedScrollView;
 import androidx.fragment.app.Fragment;
@@ -227,7 +228,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                     return true;
                 case R.id.menu_share:
                     if (mLinkText != null) {
-                        showShareSheet();
+                        showShare(mLinkText);
                         mode.finish();
                     }
                     return true;
@@ -1317,6 +1318,15 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         if (clipboard != null) {
             clipboard.setPrimaryClip(clip);
         }
+    }
+
+    private void showShare(String text) {
+        startActivity(
+            ShareCompat.IntentBuilder.from(requireActivity())
+                .setText(text)
+                .setType("text/plain")
+                .createChooserIntent()
+        );
     }
 
     private void showShareSheet() {


### PR DESCRIPTION
### Fix
Add sharing link text rather than note content when tapping the ***Share*** action while a link is selected to close #1058.  The system share interface is slightly different for each Android version.  Android API versions 25, 27, and 29 are shown as examples.  See the screenshots below for illustration.

![1058_link_share_text](https://user-images.githubusercontent.com/3827611/83825573-ed042b00-a696-11ea-83ed-33bb03ff5f5f.png)

### Test
1. Tap any note in list with link.
2. Tap anywhere inside link text.
3. Notice ***Link*** app bar is shown.
4. Tap ***Share*** action in ***Link*** app bar.
5. Notice system share interface is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review. 
 @rachelmcr, I also requested you as a reviewer since you caught the associated bug and to ensure it is fixed.

### Release
These changes do not require release notes.