### PR TITLE
Issue/1031 note list resize

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1357,6 +1357,11 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
             } else if (mNoteListFragment.isHidden() && mCurrentNote != null) {
                 onNoteSelected(mCurrentNote.getSimperiumKey(), null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
             }
+        } else if (mNoteListFragment.isHidden()) {
+            FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
+            fragmentTransaction.show(mNoteListFragment);
+            fragmentTransaction.commitNowAllowingStateLoss();
+            mIsTabletFullscreen = mNoteListFragment.isHidden();
         }
 
         if (newConfig.orientation == Configuration.ORIENTATION_PORTRAIT && mNoteEditorFragment != null) {


### PR DESCRIPTION
### Fix
Add showing the note list if it is hidden and the app window is resized to close #1031.

### Test
Since the app window can only be resized on large devices, a device running Chrome OS is required to perform and verify the expected behavior.

1. Maximize app window.
2. Tap any note in list.
3. Tap ***Hide List*** action in app bar.
4. Notice note list is hidden.
5. Resize window to smaller than maximum.
6. Notice note list is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.