### PR TITLE
Issue/1030 bottom sheet resize

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/HistoryBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/HistoryBottomSheetDialog.java
@@ -27,7 +27,7 @@ import java.util.Calendar;
 import java.util.Map;
 
 public class HistoryBottomSheetDialog extends BottomSheetDialogBase {
-    private static final String TAG = HistoryBottomSheetDialog.class.getSimpleName();
+    public static final String TAG = HistoryBottomSheetDialog.class.getSimpleName();
 
     private ArrayList<Note> mNoteRevisionsList;
     private Fragment mFragment;

--- a/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
@@ -21,7 +21,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog;
 import java.text.NumberFormat;
 
 public class InfoBottomSheetDialog extends BottomSheetDialogBase {
-    private static final String TAG = InfoBottomSheetDialog.class.getSimpleName();
+    public static final String TAG = InfoBottomSheetDialog.class.getSimpleName();
 
     private Fragment mFragment;
     private TextView mCountCharacters;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -248,7 +248,7 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
     public void onConfigurationChanged(@NonNull Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
 
-        // Relaunch shortcut dialog for window is maximized or restored (Chrome OS).
+        // Relaunch shortcut dialog when window is maximized or restored (Chrome OS).
         if (getSupportFragmentManager().findFragmentByTag(ShortcutDialogFragment.DIALOG_TAG) != null) {
             ShortcutDialogFragment.showShortcuts(NoteEditorActivity.this, isPreviewTabSelected());
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1357,11 +1357,31 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
             } else if (mNoteListFragment.isHidden() && mCurrentNote != null) {
                 onNoteSelected(mCurrentNote.getSimperiumKey(), null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
             }
-        } else if (mNoteListFragment.isHidden()) {
-            FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
-            fragmentTransaction.show(mNoteListFragment);
-            fragmentTransaction.commitNowAllowingStateLoss();
-            mIsTabletFullscreen = mNoteListFragment.isHidden();
+        } else {
+            if (mNoteListFragment.isHidden()) {
+                FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
+                fragmentTransaction.show(mNoteListFragment);
+                fragmentTransaction.commitNowAllowingStateLoss();
+                mIsTabletFullscreen = mNoteListFragment.isHidden();
+            }
+
+            HistoryBottomSheetDialog dialogHistory = (HistoryBottomSheetDialog) getSupportFragmentManager().findFragmentByTag(HistoryBottomSheetDialog.TAG);
+
+            if (dialogHistory != null) {
+                dialogHistory.dismiss();
+            }
+
+            InfoBottomSheetDialog dialogInfo = (InfoBottomSheetDialog) getSupportFragmentManager().findFragmentByTag(InfoBottomSheetDialog.TAG);
+
+            if (dialogInfo != null) {
+                dialogInfo.dismiss();
+            }
+
+            ShareBottomSheetDialog dialogShare = (ShareBottomSheetDialog) getSupportFragmentManager().findFragmentByTag(ShareBottomSheetDialog.TAG);
+
+            if (dialogShare != null) {
+                dialogShare.dismiss();
+            }
         }
 
         if (newConfig.orientation == Configuration.ORIENTATION_PORTRAIT && mNoteEditorFragment != null) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1323,7 +1323,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         super.onConfigurationChanged(newConfig);
         mDrawerToggle.onConfigurationChanged(newConfig);
 
-        // Relaunch shortcut dialog for window is maximized or restored (Chrome OS).
+        // Relaunch shortcut dialog when window is maximized or restored (Chrome OS).
         if (getSupportFragmentManager().findFragmentByTag(ShortcutDialogFragment.DIALOG_TAG) != null) {
             ShortcutDialogFragment.showShortcuts(NotesActivity.this, false);
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1358,6 +1358,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 onNoteSelected(mCurrentNote.getSimperiumKey(), null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
             }
         } else {
+            // Show list/sidebar when it was hidden while in landscape orientation.
             if (mNoteListFragment.isHidden()) {
                 FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
                 fragmentTransaction.show(mNoteListFragment);
@@ -1365,6 +1366,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 mIsTabletFullscreen = mNoteListFragment.isHidden();
             }
 
+            // Dismiss all bottom sheet dialogs when going from editor to list view.
             HistoryBottomSheetDialog dialogHistory = (HistoryBottomSheetDialog) getSupportFragmentManager().findFragmentByTag(HistoryBottomSheetDialog.TAG);
 
             if (dialogHistory != null) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/ShareBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/ShareBottomSheetDialog.java
@@ -30,7 +30,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ShareBottomSheetDialog extends BottomSheetDialogBase {
-    private static final String TAG = ShareBottomSheetDialog.class.getSimpleName();
+    public static final String TAG = ShareBottomSheetDialog.class.getSimpleName();
+
     private static final int SHARE_SHEET_COLUMN_COUNT = 3;
 
     private Fragment mFragment;


### PR DESCRIPTION
### Fix
Add dismissing bottom sheets (i.e. **_History_**, **_Information_**, and **_Share_**) when the window is resized to close #1030.  Since resizing the window results in the list view being shown and the bottom sheets are no longer relevant, they are dismissed rather than relaunched.

### Test
Since the app window can only be resized on large devices, a device running Chrome OS is required to perform and verify the expected behavior.
1. Maximize app window.
2. Tap any note in list.
3. Tap ***Information*** action in app bar.
4. Notice ***Information*** bottom sheet is shown.
5. Resize window to smaller than maximum.
6. Notice ***Information*** bottom sheet is dismissed.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.