### PR TITLE
Update Gradle Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.google.com' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 18 00:03:37 EDT 2020
+#Mon Jun 15 08:41:11 MDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
### Fix
Update the Gradle build tools version from `3.6.3` to `4.0.0` and wrapper version from `5.6.4` to `6.1.1`.

### Test
Since these changes have no user-facing aspect, building the app and smoke testing is all that is required.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.