### PR TITLE
Fixed where Preview tab did not reload changes from Edit tab (#1070)

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -474,6 +474,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         if (mAutoSaveHandler != null) {
             mAutoSaveHandler.removeCallbacks(mAutoSaveRunnable);
+            mAutoSaveHandler.post(mAutoSaveRunnable);
         }
 
         if (mPublishTimeoutHandler != null) {


### PR DESCRIPTION
### Fix
Fix for [Issue 1070](https://github.com/Automattic/simplenote-android/issues/1070) where changes in the Edit tab were not shown in the Preview tab if the user switched tabs too quickly after making edits.

Runnable `mAutoSaveRunnable` calls `saveAndSyncNote()` which launches a new `SaveNoteTask`. Then `onPostExecute()` of `SaveNoteTask` calls `updateMarkdownView()`. Upon text edit, `mAutoSaveRunnable` is posted at a 2000 ms delay, but in the `onPause()` method of `NoteEditorFragment`, callbacks for `mAutoSaveRunnable` are removed. This means that if the user changes to the Preview tab within 2 seconds of making edits, the edits are not reflected in the Preview tab.

The fix in this PR still removes the callbacks but then immediately posts one final `mAutoSaveRunnable`.

### Test
> 1. Create and open a new note.
> 2. Enable Markdown in the overflow menu.
> 3. Make an edit in the Edit tab.
> 4. Immediately switch to the Preview tab.
> 5. The content has now been updated.

See similar test steps in the [filed issue](https://github.com/Automattic/simplenote-android/issues/1070) to compare before and after.

### Review
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.