### PR TITLE
Added RTL Mardown Preview Support

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 2.8
 -----
 * Added hotkey shortcuts for devices with hardware keyboards
-* Added RTL language rendering support to markdown preview
+* Added right-to-left language support to markdown preview
 
 2.7
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.8
 -----
 * Added hotkey shortcuts for devices with hardware keyboards
+* Added RTL language rendering support to markdown preview
 
 2.7
 -----

--- a/Simplenote/src/main/assets/dark.css
+++ b/Simplenote/src/main/assets/dark.css
@@ -51,6 +51,7 @@ html {
 .note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
 .note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
 .note-detail-markdown #title {
+    unicode-bidi: plaintext;
     line-height: 1.15;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
     margin: 1.7em 0 1em 0;
@@ -89,6 +90,7 @@ html {
 .note-detail-markdown p, .note-detail-markdown ul, .note-detail-markdown ol,
 .note-detail-markdown blockquote, .note-detail-markdown pre, .note-detail-markdown table,
 .note-detail-markdown code, .note-detail-markdown img {
+    unicode-bidi: plaintext;
     margin-bottom: 1.7em;
     box-sizing: border-box;
 }
@@ -128,9 +130,9 @@ html {
 
 .note-detail-markdown blockquote {
     font-style: italic;
-    border-left: 4px solid currentColor;
-    margin-left: 0;
-    padding-left: 1.7em;
+    border-inline-start: 4px solid currentColor;
+    margin-inline-start: 0;
+    padding-inline-start: 1.7em;
 }
 
 .note-detail-markdown code {
@@ -145,6 +147,7 @@ html {
 }
 
 .note-detail-markdown pre code {
+    unicode-bidi: isolate;
     font-size: 85%;
     color: #616870;
     background: transparent;
@@ -152,6 +155,10 @@ html {
     overflow-x: auto;
     display: block;
     margin-bottom: 0;
+}
+
+.note-detail-markdown p code {
+    unicode-bidi: isolate;
 }
 
 .note-detail-markdown table {
@@ -166,6 +173,7 @@ html {
 }
 
 .note-detail-markdown table th, .note-detail-markdown table td {
+    unicode-bidi: plaintext;
     border: 1px solid #575e65;
     padding: 6px 13px;
 }

--- a/Simplenote/src/main/assets/dark.css
+++ b/Simplenote/src/main/assets/dark.css
@@ -96,7 +96,7 @@ html {
 }
 
 .note-detail-markdown ul, .note-detail-markdown ol {
-    margin-left: 2em;
+    margin-inline-start: 2em;
 }
 
 .note-detail-markdown img {

--- a/Simplenote/src/main/assets/light.css
+++ b/Simplenote/src/main/assets/light.css
@@ -51,6 +51,7 @@ html {
 .note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
 .note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
 .note-detail-markdown #title {
+    unicode-bidi: plaintext;
     line-height: 1.15;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
     margin: 1.7em 0 1em 0;
@@ -89,6 +90,7 @@ html {
 .note-detail-markdown p, .note-detail-markdown ul, .note-detail-markdown ol,
 .note-detail-markdown blockquote, .note-detail-markdown pre, .note-detail-markdown table,
 .note-detail-markdown code, .note-detail-markdown img {
+    unicode-bidi: plaintext;
     margin-bottom: 1.7em;
     box-sizing: border-box;
 }
@@ -128,9 +130,9 @@ html {
 
 .note-detail-markdown blockquote {
     font-style: italic;
-    border-left: 4px solid currentColor;
-    margin-left: 0;
-    padding-left: 1.7em;
+    border-inline-start: 4px solid currentColor;
+    margin-inline-start: 0;
+    padding-inline-start: 1.7em;
 }
 
 .note-detail-markdown code {
@@ -145,6 +147,7 @@ html {
 }
 
 .note-detail-markdown pre code {
+    unicode-bidi: isolate;
     font-size: 85%;
     color: #616870;
     background: transparent;
@@ -152,6 +155,10 @@ html {
     overflow-x: auto;
     display: block;
     margin-bottom: 0;
+}
+
+.note-detail-markdown p code {
+    unicode-bidi: isolate;
 }
 
 .note-detail-markdown table {
@@ -166,6 +173,7 @@ html {
 }
 
 .note-detail-markdown table th, .note-detail-markdown table td {
+    unicode-bidi: plaintext;
     border: 1px solid #c0c4c8;
     padding: 6px 13px;
 }

--- a/Simplenote/src/main/assets/light.css
+++ b/Simplenote/src/main/assets/light.css
@@ -96,7 +96,7 @@ html {
 }
 
 .note-detail-markdown ul, .note-detail-markdown ol {
-    margin-left: 2em;
+    margin-inline-start: 2em;
 }
 
 .note-detail-markdown img {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -718,7 +718,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 if (mNoteMarkdownFragment == null) {
                     // Get markdown fragment and update content
                     mNoteMarkdownFragment = editorActivity.getNoteMarkdownFragment();
-                    mNoteMarkdownFragment.updateMarkdown(mContentEditText.getPlainTextContent());
+                    mNoteMarkdownFragment.updateMarkdown(mContentEditText.getPlainTextContent(true));
                 }
             } else {
                 editorActivity.hideTabs();
@@ -748,7 +748,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private void loadMarkdownData() {
         String formattedContent = NoteMarkdownFragment.getMarkdownFormattedContent(
                 mCss,
-                mContentEditText.getPlainTextContent()
+                mContentEditText.getPlainTextContent(true)
         );
 
         mMarkdown.loadDataWithBaseURL(null, formattedContent, "text/html", "utf-8", null);
@@ -1112,7 +1112,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 mIsPreviewEnabled = mNote.isPreviewEnabled();
             }
 
-            String content = mContentEditText.getPlainTextContent();
+            String content = mContentEditText.getPlainTextContent(false);
             String tagString = getNoteTagsString();
 
             if (mNote.hasChanges(content, tagString.trim(), mNote.isPinned(), mIsMarkdownEnabled, mIsPreviewEnabled)) {
@@ -1402,7 +1402,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         if (openNote == null || !openNote.getSimperiumKey().equals(note.getSimperiumKey()))
             return;
 
-        note.setContent(mContentEditText.getPlainTextContent());
+        note.setContent(mContentEditText.getPlainTextContent(false));
     }
 
     private static class LoadNoteTask extends AsyncTask<String, Void, Void> {
@@ -1569,7 +1569,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 ((NoteEditorActivity) requireActivity()).showTabs();
             }
             // Load markdown in the sibling NoteMarkdownFragment's WebView.
-            mNoteMarkdownFragment.updateMarkdown(mContentEditText.getPlainTextContent());
+            mNoteMarkdownFragment.updateMarkdown(mContentEditText.getPlainTextContent(true));
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -718,7 +718,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 if (mNoteMarkdownFragment == null) {
                     // Get markdown fragment and update content
                     mNoteMarkdownFragment = editorActivity.getNoteMarkdownFragment();
-                    mNoteMarkdownFragment.updateMarkdown(mContentEditText.getPlainTextContent(true));
+                    mNoteMarkdownFragment.updateMarkdown(mContentEditText.getPreviewTextContent());
                 }
             } else {
                 editorActivity.hideTabs();
@@ -748,7 +748,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private void loadMarkdownData() {
         String formattedContent = NoteMarkdownFragment.getMarkdownFormattedContent(
                 mCss,
-                mContentEditText.getPlainTextContent(true)
+                mContentEditText.getPreviewTextContent()
         );
 
         mMarkdown.loadDataWithBaseURL(null, formattedContent, "text/html", "utf-8", null);
@@ -1112,7 +1112,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 mIsPreviewEnabled = mNote.isPreviewEnabled();
             }
 
-            String content = mContentEditText.getPlainTextContent(false);
+            String content = mContentEditText.getPlainTextContent();
             String tagString = getNoteTagsString();
 
             if (mNote.hasChanges(content, tagString.trim(), mNote.isPinned(), mIsMarkdownEnabled, mIsPreviewEnabled)) {
@@ -1402,7 +1402,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         if (openNote == null || !openNote.getSimperiumKey().equals(note.getSimperiumKey()))
             return;
 
-        note.setContent(mContentEditText.getPlainTextContent(false));
+        note.setContent(mContentEditText.getPlainTextContent());
     }
 
     private static class LoadNoteTask extends AsyncTask<String, Void, Void> {
@@ -1569,7 +1569,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 ((NoteEditorActivity) requireActivity()).showTabs();
             }
             // Load markdown in the sibling NoteMarkdownFragment's WebView.
-            mNoteMarkdownFragment.updateMarkdown(mContentEditText.getPlainTextContent(true));
+            mNoteMarkdownFragment.updateMarkdown(mContentEditText.getPreviewTextContent());
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -2,6 +2,7 @@ package com.automattic.simplenote;
 
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -193,6 +194,13 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
                         AndDown.HOEDOWN_EXT_QUOTE | AndDown.HOEDOWN_EXT_TABLES,
                 AndDown.HOEDOWN_HTML_ESCAPE
         );
+
+        // Set auto left or right alignment for lists, tables, and quotes based on language of start
+        parsedMarkdown = parsedMarkdown
+                .replaceAll("<ol>", "<ol dir=\"auto\">")
+                .replaceAll("<ul>", "<ul dir=\"auto\">")
+                .replaceAll("<table>", "<table dir=\"auto\">")
+                .replaceAll("<blockquote>", "<blockquote dir=\"auto\">");
 
         return header + "<div class=\"note-detail-markdown\">" + parsedMarkdown +
                 "</div></body></html>";

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -194,7 +194,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
                 AndDown.HOEDOWN_HTML_ESCAPE
         );
 
-        // Set auto left or right alignment for lists, tables, and quotes based on language of start
+        // Set auto alignment for lists, tables, and quotes based on language of start.
         parsedMarkdown = parsedMarkdown
                 .replaceAll("<ol>", "<ol dir=\"auto\">")
                 .replaceAll("<ul>", "<ul dir=\"auto\">")

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -2,7 +2,6 @@ package com.automattic.simplenote;
 
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ChecklistUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ChecklistUtils.java
@@ -17,9 +17,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ChecklistUtils {
-    public static String CHECKLIST_REGEX = "(\\s+)?(-[ \\t]+\\[[xX\\s]?\\])";
-    public static String CHECKLIST_REGEX_LINES = "^(\\s+)?(-[ \\t]+\\[[xX\\s]?\\])";
-    public static String CHECKED_MARKDOWN = "- [x]";
+    public static String CHECKLIST_REGEX = "(\\s+)?(-[ \\t]+\\[[xX\u2A2F\\s]?\\])";
+    public static String CHECKLIST_REGEX_LINES = "^(\\s+)?(-[ \\t]+\\[[xX\u2A2F\\s]?\\])";
+    public static String CHECKED_MARKDOWN = "- [\u2A2F]";
     public static String UNCHECKED_MARKDOWN = "- [ ]";
     public static final int CHECKLIST_OFFSET = 3;
 
@@ -63,7 +63,7 @@ public class ChecklistUtils {
             }
 
             CheckableSpan checkableSpan = new CheckableSpan();
-            checkableSpan.setChecked(match.contains("x") || match.contains("X"));
+            checkableSpan.setChecked(match.contains("\u2A2F") || match.contains("x") || match.contains("X"));
             editable.replace(start, end, "\u00A0");
 
             Drawable iconDrawable = ContextCompat.getDrawable(context,
@@ -118,7 +118,7 @@ public class ChecklistUtils {
             }
 
             CheckableSpan checkableSpan = new CheckableSpan();
-            checkableSpan.setChecked(match.contains("x") || match.contains("X"));
+            checkableSpan.setChecked(match.contains("\u2A2F") || match.contains("x") || match.contains("X"));
             editable.replace(start, end, checkableSpan.isChecked() ? "\u2611" : "\u2610");
             editable.setSpan(checkableSpan, start, start + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
             positionAdjustment += (end - start) - 1;

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ChecklistUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ChecklistUtils.java
@@ -17,9 +17,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ChecklistUtils {
-    public static String CHECKLIST_REGEX = "(\\s+)?(-[ \\t]+\\[[xX\u2A2F\\s]?\\])";
-    public static String CHECKLIST_REGEX_LINES = "^(\\s+)?(-[ \\t]+\\[[xX\u2A2F\\s]?\\])";
-    public static String CHECKED_MARKDOWN = "- [\u2A2F]";
+    public static String CHECKLIST_REGEX = "(\\s+)?(-[ \\t]+\\[[xX\\s]?\\])";
+    public static String CHECKLIST_REGEX_LINES = "^(\\s+)?(-[ \\t]+\\[[xX\\s]?\\])";
+    public static String CHECKED_MARKDOWN_PREVIEW = "- [\u2A2F]";
+    public static String CHECKED_MARKDOWN = "- [x]";
     public static String UNCHECKED_MARKDOWN = "- [ ]";
     public static final int CHECKLIST_OFFSET = 3;
 
@@ -63,7 +64,7 @@ public class ChecklistUtils {
             }
 
             CheckableSpan checkableSpan = new CheckableSpan();
-            checkableSpan.setChecked(match.contains("\u2A2F") || match.contains("x") || match.contains("X"));
+            checkableSpan.setChecked(match.contains("x") || match.contains("X"));
             editable.replace(start, end, "\u00A0");
 
             Drawable iconDrawable = ContextCompat.getDrawable(context,
@@ -118,7 +119,7 @@ public class ChecklistUtils {
             }
 
             CheckableSpan checkableSpan = new CheckableSpan();
-            checkableSpan.setChecked(match.contains("\u2A2F") || match.contains("x") || match.contains("X"));
+            checkableSpan.setChecked(match.contains("x") || match.contains("X"));
             editable.replace(start, end, checkableSpan.isChecked() ? "\u2611" : "\u2610");
             editable.setSpan(checkableSpan, start, start + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
             positionAdjustment += (end - start) - 1;

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/MatchOffsetHighlighter.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/MatchOffsetHighlighter.java
@@ -195,7 +195,7 @@ public class MatchOffsetHighlighter implements Runnable {
             mSpannable = mTextView.getEditableText();
             mMatches = matches;
             mIndex = columnIndex;
-            mPlainText = mTextView.getPlainTextContent(false);
+            mPlainText = mTextView.getPlainTextContent();
             start();
         }
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/MatchOffsetHighlighter.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/MatchOffsetHighlighter.java
@@ -195,7 +195,7 @@ public class MatchOffsetHighlighter implements Runnable {
             mSpannable = mTextView.getEditableText();
             mMatches = matches;
             mIndex = columnIndex;
-            mPlainText = mTextView.getPlainTextContent();
+            mPlainText = mTextView.getPlainTextContent(false);
             start();
         }
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -240,21 +240,19 @@ public class SimplenoteEditText extends AppCompatEditText {
     }
 
     // Replaces any CheckableSpans with their markdown counterpart (e.g. '- [ ]')
-    public String getPlainTextContent() {
+    public String getPlainTextContent(boolean preview) {
         if (getText() == null) {
             return "";
         }
 
         SpannableStringBuilder content = new SpannableStringBuilder(getText());
         CheckableSpan[] spans = content.getSpans(0, content.length(), CheckableSpan.class);
-
+        String checked = preview ? ChecklistUtils.CHECKED_MARKDOWN_PREVIEW : ChecklistUtils.CHECKED_MARKDOWN;
+        String unchecked = ChecklistUtils.UNCHECKED_MARKDOWN;
         for(CheckableSpan span: spans) {
             int start = content.getSpanStart(span);
             int end = content.getSpanEnd(span);
-            ((Editable) content).replace(
-                    start,
-                    end,
-                    span.isChecked() ? ChecklistUtils.CHECKED_MARKDOWN : ChecklistUtils.UNCHECKED_MARKDOWN);
+            ((Editable) content).replace(start, end, span.isChecked() ? checked : unchecked);
         }
 
         return content.toString();

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -240,23 +240,45 @@ public class SimplenoteEditText extends AppCompatEditText {
     }
 
     // Replaces any CheckableSpans with their markdown counterpart (e.g. '- [ ]')
-    public String getPlainTextContent(boolean preview) {
+    public String getPlainTextContent() {
         if (getText() == null) {
             return "";
         }
 
         SpannableStringBuilder content = new SpannableStringBuilder(getText());
         CheckableSpan[] spans = content.getSpans(0, content.length(), CheckableSpan.class);
-        String checked = preview ? ChecklistUtils.CHECKED_MARKDOWN_PREVIEW : ChecklistUtils.CHECKED_MARKDOWN;
-        String unchecked = ChecklistUtils.UNCHECKED_MARKDOWN;
         for(CheckableSpan span: spans) {
             int start = content.getSpanStart(span);
             int end = content.getSpanEnd(span);
-            ((Editable) content).replace(start, end, span.isChecked() ? checked : unchecked);
+            ((Editable) content).replace(
+                    start,
+                    end,
+                    span.isChecked() ? ChecklistUtils.CHECKED_MARKDOWN : ChecklistUtils.UNCHECKED_MARKDOWN);
         }
 
         return content.toString();
     }
+
+    // Replaces any CheckableSpans with their markdown preview counterpart (e.g. '- [ ]')
+    public String getPreviewTextContent() {
+        if (getText() == null) {
+            return "";
+        }
+
+        SpannableStringBuilder content = new SpannableStringBuilder(getText());
+        CheckableSpan[] spans = content.getSpans(0, content.length(), CheckableSpan.class);
+        for(CheckableSpan span: spans) {
+            int start = content.getSpanStart(span);
+            int end = content.getSpanEnd(span);
+            ((Editable) content).replace(
+                    start,
+                    end,
+                    span.isChecked() ? ChecklistUtils.CHECKED_MARKDOWN_PREVIEW : ChecklistUtils.UNCHECKED_MARKDOWN);
+        }
+
+        return content.toString();
+    }
+
 
     public void processChecklists() {
         if (getText().length() == 0 || getContext() == null) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -259,7 +259,7 @@ public class SimplenoteEditText extends AppCompatEditText {
         return content.toString();
     }
 
-    // Replaces any CheckableSpans with their markdown preview counterpart (e.g. '- [ ]')
+    // Replaces any CheckableSpans with their markdown preview counterpart (e.g. '- [\u2A2F]')
     public String getPreviewTextContent() {
         if (getText() == null) {
             return "";


### PR DESCRIPTION
### Fix
This fixes #1005. The fix enables the preview tab to render markdown notes written in an RTL language to be previewed from right to left with the explicit exception of **code lines** and **code blocks**. I decided to leave code formatting left aligning as no relevant coding language is written in an RTL script. This fix is also capable of rendering bidirectional text depending appropriately like in Twitter for example mixing RTL and LTR languages in the same paragraph as you shall see in the demo.

This fix was mostly achieved by adding `unicode-bidi: plaintext` to CSS styles where appropriate as well as `dir="auto` to the appropriate HTML tags.

I also had to change checkbox rendering from `[x]` to `[⨯]` (i.e. using `\u2A2F` instead of `x`) as the letter x disturbed the auto aligning in the RTL language checklists. That is, since x is a Latin character, if the first checkbox in an RTL checklist is toggled, it would make the whole list render from left to right incorrectly. Using `\u2A2F` (alignment neutral character I guess) makes the web rendering alignment algorithm skip the whole `[⨯]` and look at the first character of the first checkbox of the first checklist to decide about alignment. The change was made with backward compatibility of old checkbox rendering in mind and it should not break them as per my tests. Typing `- []` and `- [x]` (with the letter x) still results in an unchecked and checked checkboxes, respectively. It is only the preview rendering that has been updated to use `\u2A2F` instead of the letter `x` to handle RTL checklists correctly.

Please do also note that HTML tags in notes are escaped by the rendering engine (Did not touch that, it was already there). This means that replacing `<ol>` by `<ol dir="auto">`for example in the formatted content will have no impact on any `<ol>` the user may have included in their note, as shown in the demos below.

### Further Reading
https://github.com/w3c/csswg-drafts/issues/2091#issuecomment-351301086
https://developer.mozilla.org/en-US/docs/Web/CSS/unicode-bidi
https://www.w3schools.com/tags/att_global_dir.asp

### Demo
#### LTR
Before|After
-|-
![before-light-ltr](https://user-images.githubusercontent.com/18679771/85341631-eecc4c00-b4e8-11ea-86d3-317dfa03ed4e.gif) | ![after-light-ltr](https://user-images.githubusercontent.com/18679771/85341700-1ae7cd00-b4e9-11ea-86f7-ac3bc265a61c.gif)
![before-dark-ltr](https://user-images.githubusercontent.com/18679771/85341758-3b178c00-b4e9-11ea-8dd1-2a16b1327168.gif) | ![after-dark-ltr](https://user-images.githubusercontent.com/18679771/85341747-39e65f00-b4e9-11ea-9146-a7338cd74b58.gif)


#### RTL
Before|After
-|-
![before-light-rtl](https://user-images.githubusercontent.com/18679771/85342483-00165800-b4eb-11ea-8ec3-dadad63b3d89.gif) | ![after-light-rtl](https://user-images.githubusercontent.com/18679771/85342467-fa207700-b4ea-11ea-93e6-503f7354d3f3.gif)
![before-dark-rtl](https://user-images.githubusercontent.com/18679771/85342476-fd1b6780-b4ea-11ea-9ca7-1b8cd8fd718f.gif) | ![after-dark-rtl](https://user-images.githubusercontent.com/18679771/85342972-1244c600-b4ec-11ea-9f9a-e5540b7e23e1.gif)

#### Mixed
Before|After
-|-
![before-light-mixed](https://user-images.githubusercontent.com/18679771/85343288-bfb7d980-b4ec-11ea-93b8-0cdbe868770b.gif) | ![after-light-mixed](https://user-images.githubusercontent.com/18679771/85343275-bb8bbc00-b4ec-11ea-81f3-530873b4a4cb.gif)
![before-dark-mixed](https://user-images.githubusercontent.com/18679771/85343280-bdee1600-b4ec-11ea-9a78-9a9023f05713.gif) | ![after-dark-mixed](https://user-images.githubusercontent.com/18679771/85343463-31902300-b4ed-11ea-9ade-20ab33746b33.gif)

### Test
> 1. Create markdown notes with an RTL language, LTR language, and mixed RTL and LTR scripts.
> 2. Check the alignment is correctly handled.

### Review
Only one developer and, **potentially**, one designer are required to review these changes, but anyone can perform the review.

### Release
> `RELEASE-NOTES.txt` was updated in d27a113 with:
> 
> > Added RTL language rendering support to markdown preview

### Final note (If I may)
I would like to point out that markdown does not support RTL languages out of the box. Since this app is about taking simple, clean and neat notes using markdown, I believe this feature is important to include. As a trilingual with an RTL native tongue, this is beneficial to me personally. The bidirectional support of writing is also so cool. A lot of RTL language speaking users, myself included, mix some English words (especially technical ones) within the notes they wrote using their native RTL language. It is a very common use case and I would highly recommend the inclusion of this feature.
