### PR TITLE
Update version to 2.7 in README shield (develop only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Simplenote for Android
-[![Version](https://img.shields.io/badge/version-2.6-blue.svg)](https://github.com/Automattic/simplenote-android/releases/tag/2.6) [![CircleCI](https://img.shields.io/circleci/build/gh/Automattic/simplenote-android.svg?label=circleci)](https://circleci.com/gh/Automattic/simplenote-android) [![Travis CI](https://img.shields.io/travis/Automattic/simplenote-android/develop.svg?label=travisci)](https://travis-ci.org/Automattic/simplenote-android)
+[![Version](https://img.shields.io/badge/version-2.7-blue.svg)](https://github.com/Automattic/simplenote-android/releases/tag/2.7) [![CircleCI](https://img.shields.io/circleci/build/gh/Automattic/simplenote-android.svg?label=circleci)](https://circleci.com/gh/Automattic/simplenote-android) [![Travis CI](https://img.shields.io/travis/Automattic/simplenote-android/develop.svg?label=travisci)](https://travis-ci.org/Automattic/simplenote-android)
 
 Simplenote for Android. Learn more at [Simplenote.com](https://simplenote.com).
 


### PR DESCRIPTION
I should have done this as part of the original PR to merge release into here, #1076, but it was in a later step in the checklist and the PR has already been merged.

Notice I only opened this against `develop` because the release branch has already been merged into both `develop` and `master`, and it would require extra work to open this same PR against `master`. If it's useful I can open it, though.