### PR TITLE
Add california privacy

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/AboutFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AboutFragment.java
@@ -37,6 +37,7 @@ public class AboutFragment extends Fragment implements SpeedListener {
     private static final String SIMPLENOTE_TWITTER_HANDLE = "simplenoteapp";
     private static final String TWITTER_PROFILE_URL = "https://twitter.com/#!/";
     private static final String TWITTER_APP_URI = "twitter://user?screen_name=";
+    private static final String URL_CALIFORNIA = "https://automattic.com/privacy/#california-consumer-privacy-act-ccpa";
     private static final String URL_CONTRIBUTE = "https://github.com/Automattic/simplenote-android";
     private static final String URL_PRIVACY = "https://automattic.com/privacy";
     private static final String URL_TERMS = "https://simplenote.com/terms";
@@ -54,6 +55,7 @@ public class AboutFragment extends Fragment implements SpeedListener {
         View hiring = view.findViewById(R.id.about_careers);
         TextView privacy = view.findViewById(R.id.about_privacy);
         TextView terms = view.findViewById(R.id.about_terms);
+        TextView california = view.findViewById(R.id.about_california);
         TextView copyright = view.findViewById(R.id.about_copyright);
 
         String colorLink = Integer.toHexString(ContextCompat.getColor(requireContext(), R.color.blue_5) & 0xffffff);
@@ -152,6 +154,24 @@ public class AboutFragment extends Fragment implements SpeedListener {
             public void onClick(View v) {
                 try {
                     startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(URL_TERMS)));
+                } catch (Exception e) {
+                    Toast.makeText(getActivity(), R.string.no_browser_available, Toast.LENGTH_LONG).show();
+                }
+            }
+        });
+
+        california.setText(Html.fromHtml(String.format(
+            getResources().getString(R.string.link_california),
+            "<u><span style=\"color:#",
+            colorLink,
+            "\">",
+            "</span></u>"
+        )));
+        california.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                try {
+                    startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(URL_CALIFORNIA)));
                 } catch (Exception e) {
                     Toast.makeText(getActivity(), R.string.no_browser_available, Toast.LENGTH_LONG).show();
                 }

--- a/Simplenote/src/main/res/layout/fragment_about.xml
+++ b/Simplenote/src/main/res/layout/fragment_about.xml
@@ -229,11 +229,11 @@
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
             android:id="@+id/about_california"
-            android:gravity="center_horizontal"
+            android:layout_gravity="center_horizontal"
             android:layout_height="wrap_content"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             tools:text="Privacy Notice for California Users"
-            style="@style/Theme.Simplestyle.About.Subtitle">
+            style="@style/Theme.Simplestyle.About.Link">
         </com.automattic.simplenote.widgets.RobotoRegularTextView>
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView

--- a/Simplenote/src/main/res/layout/fragment_about.xml
+++ b/Simplenote/src/main/res/layout/fragment_about.xml
@@ -228,6 +228,15 @@
         </LinearLayout>
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
+            android:id="@+id/about_california"
+            android:gravity="center_horizontal"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            tools:text="Privacy Notice for California Users"
+            style="@style/Theme.Simplestyle.About.Subtitle">
+        </com.automattic.simplenote.widgets.RobotoRegularTextView>
+
+        <com.automattic.simplenote.widgets.RobotoRegularTextView
             android:id="@+id/about_copyright"
             android:gravity="center_horizontal"
             android:layout_height="wrap_content"

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -129,6 +129,7 @@
     <string name="blog">Blog</string>
     <string name="no_browser_available">\"Unable to open website. No browser available.\"</string>
     <string name="simplenote_blog_url" translatable="false">simplenote.com/blog</string>
+    <string name="link_california">%1$s%2$s%3$sPrivacy Notice for California Users%4$s</string>
     <string name="link_divider">&#183;</string>
     <string name="link_privacy">%1$s%2$s%3$sPrivacy Policy%4$s</string>
     <string name="link_terms">%1$s%2$s%3$sTerms of Service%4$s</string>


### PR DESCRIPTION
### Fix
Add the **_Privacy Notice for California Users_** item to the **_About_** screen.  See the screenshots below for illustration.

![add_california_privacy](https://user-images.githubusercontent.com/3827611/86051869-5a477980-ba13-11ea-8f1d-426e2c026f95.png)

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in drawer.
3. Tap ***About Simplenote*** item under ***More Information*** section.
4. Notice ***Privacy Notice for California Users*** link below ***Privacy Policy*** and ***Terms of Service*** links.
5. Tap ***Privacy Notice for California Users*** link.
6. Notice https://automattic.com/privacy/#california-consumer-privacy-act-ccpa site is shown if web browser does exist on device.
7. Notice "Unable to open website. No browser available." message is shown if web browser does not exist on device.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@mokagio, this requires a hotfix.