### PR TITLE
Update finalize_release lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -156,6 +156,7 @@ SUPPORTED_LOCALES = [
   desc "Updates store metadata and runs the release checks"
   lane :finalize_release do | options |
     android_finalize_prechecks(options)
+    configure_apply(force: is_ci)
     hotfix = android_current_branch_is_hotfix
     android_update_metadata(options) unless hotfix
     android_bump_version_final_release() unless hotfix


### PR DESCRIPTION
### Fix
This PR adds `configure_apply` to the `finalize_release` lane because after the translations are downloaded, they are checked and validate by linting and building. It the configuration is not up to date, the build phase can fail.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
