### PR TITLE
Release/test create betas

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: f04b19fddf1f3a9485a48a7ba4a93d32c0af62d5
-  tag: 0.9.7
+  revision: d15c7ae69091a2f36c73bc934bb0893a9a13141a
+  tag: 0.9.10
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.7)
+    fastlane-plugin-wpmreleasetoolkit (0.9.10)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -165,7 +165,7 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.10.6)
+    oj (3.10.7)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.0)
@@ -176,7 +176,7 @@ GEM
       options (~> 2.3.0)
     public_suffix (2.0.5)
     rake (12.3.3)
-    rake-compiler (1.1.0)
+    rake-compiler (1.1.1)
       rake
     rchardet (1.8.0)
     representable (3.0.4)

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -30,7 +30,7 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "2.8-rc-3"
+            versionName "2.8"
         }
         versionCode 109
         minSdkVersion 23

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -30,7 +30,7 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "2.8-rc-2"
+            versionName "2.8-rc-3"
         }
         versionCode 109
         minSdkVersion 23

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -178,11 +178,12 @@ SUPPORTED_LOCALES = [
   # This lane builds the app it for both internal and external distribution 
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_pre_releases [skip_confirm:<skip confirm>]
+  # bundle exec fastlane build_pre_releases [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
   # bundle exec fastlane build_pre_releases 
-  # bundle exec fastlane build_pre_releases skip_confirm:true 
+  # bundle exec fastlane build_pre_releases skip_confirm:true
+  # bundle exec fastlane build_pre_releases create_release:true 
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_pre_releases do | options |
@@ -191,7 +192,7 @@ SUPPORTED_LOCALES = [
       beta: true,
       final: false)
     android_build_preflight()
-    build_beta(skip_prechecks: true, skip_confirm: options[:skip_confirm])
+    build_beta(skip_prechecks: true, skip_confirm: options[:skip_confirm], create_release: options[:create_release])
   end
 
   #####################################################################################
@@ -200,11 +201,12 @@ SUPPORTED_LOCALES = [
   # This lane builds the app it for internal testing  
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_beta [skip_confirm:<skip confirm>]
+  # bundle exec fastlane build_beta [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
   # bundle exec fastlane build_beta 
   # bundle exec fastlane build_beta skip_confirm:true 
+  # bundle exec fastlane build_beta create_release:true 
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_beta do | options |
@@ -214,6 +216,10 @@ SUPPORTED_LOCALES = [
     # Create the file names
     version=android_get_release_version()
     build_apk(version: version, flavor:"Vanilla")
+
+    if (options[:create_release])
+      create_gh_release(version: version)
+    end
   end
 
   #####################################################################################
@@ -222,11 +228,12 @@ SUPPORTED_LOCALES = [
   # This lane builds the final release of the app and uploads it 
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_release [skip_confirm:<skip confirm>]
+  # bundle exec fastlane build_release [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
   # bundle exec fastlane build_release 
   # bundle exec fastlane build_release skip_confirm:true 
+  # bundle exec fastlane build_release create_release:true 
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_release do | options |
@@ -239,6 +246,10 @@ SUPPORTED_LOCALES = [
     # Create the file names
     version=android_get_release_version()
     build_apk(version: version, flavor:"Vanilla")
+
+    if (options[:create_release])
+      create_gh_release(version: version)
+    end
   end
 
 ########################################################################
@@ -393,6 +404,16 @@ SUPPORTED_LOCALES = [
     sh("cd .. && mkdir -p #{update_strings_path} && cp #{main_strings_path} #{update_strings_path} && git add #{update_strings_path}strings.xml")
     sh("git diff-index --quiet HEAD || git commit -m \"Update strings file for translation automation\"")
     sh("git push origin HEAD")
+  end
+
+  private_lane :create_gh_release do | options |
+    version = options[:version]
+    apk_file_path = universal_apk_file_path(version)
+    create_release(repository:GHHELPER_REPO, 
+      version: version["name"], 
+      release_notes_file_path:release_notes_path,
+      release_assets:"#{apk_file_path}"
+    )
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -61,6 +61,9 @@ SUPPORTED_LOCALES = [
    
     android_bump_version_release()
     new_version = android_get_app_version()
+    extract_release_notes_for_version(version: new_version, 
+      release_notes_file_path:"#{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt", 
+      extracted_notes_file_path:release_notes_path)
     android_update_release_notes(new_version: new_version)
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
@@ -390,6 +393,22 @@ SUPPORTED_LOCALES = [
     sh("cd .. && mkdir -p #{update_strings_path} && cp #{main_strings_path} #{update_strings_path} && git add #{update_strings_path}strings.xml")
     sh("git diff-index --quiet HEAD || git commit -m \"Update strings file for translation automation\"")
     sh("git push origin HEAD")
+  end
+
+  #####################################################################################
+  # Utils
+  #####################################################################################
+  def release_notes_path
+    "#{ENV["PROJECT_ROOT_FOLDER"]}Simplenote/metadata/release_notes.txt"
+  end
+
+  def universal_apk_name(version)
+    "simplenote-#{version["name"]}.apk"
+  end
+
+  def universal_apk_file_path(version)
+    project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
+    File.join(project_root, "build", universal_apk_name(version))
   end
 
 end

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.7'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.10'


### PR DESCRIPTION
This PR adds GitHub releases creation to the lanes that build the beta and the final artefacts.
It also tweaks the `code_freeze` lane to update the `release_notes.txt` file with the draft release notes so that they are available when building the first beta.

**To Test**
_1. Code freeze lane_
You can simulate a complete code freeze, but since the work the new action does is unrelated to the other steps, it can be safely tested alone.

1.a Checkout a newbranch from this one.
1.b Comment out all the steps in `code_freeze` other than lines 63 to 66. Commit the changes.
1.c `bundle install`.
1.c Run `bundle exec fastlane code_freeze` and verify that `Simplenote/metadata/release_notes.txt` has been updated with the content of the main `RELEASE_NOTES.txt` related to the current version.
1.d Delete the test branch

_2. Beta build_
2.a Checkout a new `release/` branch from this one.
2.b Edit `build.gradle` with a new beta version and `versionCode`. Commit the changes.
2.c Run `bundle install`.
2.d Run `bundle exec fastlane build_pre_releases create_release:true` and verify that the a release is drafted on GitHub and that the release notes are added, the "Pre-release" option is checked and the .apk is uploaded.
2.e Delete the draft release.
2.f Delete the test branch.

_3. Release build_
2.a Checkout a new `release/` branch from this one.
2.b Edit `build.gradle` with a final version and versionCode. Commit the changes.
2.c Run `bundle install`.
2.d Run `bundle exec fastlane build_release create_release:true`  and verify that the a release is drafted on GitHub and that the release notes are added and the .apk is uploaded.
2.e Delete the draft release.
2.f Delete the test branch.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
