### PR TITLE
Update Tag Submission

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
@@ -41,11 +41,7 @@ public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTex
         @Override
         public void onTextChanged(CharSequence s, int start, int before, int count) {
             if (count >= 1 && s.charAt(start) == SPACE) {
-                if (TagUtils.hashTagValid(s.toString())) {
-                    notifyTagsChanged();
-                } else {
-                    showDialogErrorLength();
-                }
+                saveTagOrShowError(s.toString());
             }
         }
     };
@@ -72,12 +68,7 @@ public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTex
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
         if (event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
-            if (TagUtils.hashTagValid(getText().toString())) {
-                notifyTagsChanged();
-            } else {
-                showDialogErrorLength();
-            }
-
+            saveTagOrShowError(getText().toString());
             return true;
         } else {
             return super.dispatchKeyEvent(event);
@@ -101,6 +92,14 @@ public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTex
     public void notifyTagsChanged(String tag) {
         if (mTagAddedListener != null) {
             mTagAddedListener.onTagAdded(tag);
+        }
+    }
+
+    private void saveTagOrShowError(String text) {
+        if (TagUtils.hashTagValid(text)) {
+            notifyTagsChanged();
+        } else {
+            showDialogErrorLength();
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
@@ -6,6 +6,7 @@ import android.text.TextWatcher;
 import android.text.method.LinkMovementMethod;
 import android.util.AttributeSet;
 import android.view.ContextThemeWrapper;
+import android.view.KeyEvent;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
@@ -66,6 +67,21 @@ public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTex
     public TagsMultiAutoCompleteTextView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         init();
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        if (event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
+            if (TagUtils.hashTagValid(getText().toString())) {
+                notifyTagsChanged();
+            } else {
+                showDialogErrorLength();
+            }
+
+            return true;
+        } else {
+            return super.dispatchKeyEvent(event);
+        }
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
@@ -23,7 +23,7 @@ import static com.automattic.simplenote.utils.SearchTokenizer.SPACE;
 
 public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTextView implements OnItemClickListener {
     private OnTagAddedListener mTagAddedListener;
-    private TextWatcher textWatcher = new TextWatcher() {
+    private TextWatcher mTextWatcher = new TextWatcher() {
         @Override
         public void afterTextChanged(Editable s) {
             if (s.length() > 0) {
@@ -75,7 +75,7 @@ public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTex
 
     public void init() {
         setOnItemClickListener(this);
-        addTextChangedListener(textWatcher);
+        addTextChangedListener(mTextWatcher);
     }
 
     public void notifyTagsChanged() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
@@ -99,6 +99,10 @@ public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTex
         if (TagUtils.hashTagValid(text)) {
             notifyTagsChanged();
         } else {
+            removeTextChangedListener(mTextWatcher);
+            setText(getText().toString().trim());
+            setSelection(getText().length());
+            addTextChangedListener(mTextWatcher);
             showDialogErrorLength();
         }
     }

--- a/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
@@ -89,7 +89,6 @@
                         android:completionThreshold="1"
                         android:dropDownAnchor="@id/horizontal_scroll_view"
                         android:hint="@string/tag_hint"
-                        android:imeOptions="actionNext"
                         android:inputType="textNoSuggestions"
                         android:layout_height="wrap_content"
                         android:layout_width="match_parent"

--- a/Simplenote/src/main/res/layout/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_editor.xml
@@ -88,7 +88,6 @@
                         android:completionThreshold="1"
                         android:dropDownAnchor="@id/horizontal_scroll_view"
                         android:hint="@string/tag_hint"
-                        android:imeOptions="actionNext"
                         android:inputType="textNoSuggestions"
                         android:layout_height="wrap_content"
                         android:layout_width="match_parent"


### PR DESCRIPTION
### Fix
Update the tag submission in the **_Add tag..._** field by adding detection of the **_Enter_**/**_Return_** key.  Research shows that users expect to tap the **_Space_** key or **_Enter_**/**_Return_** key to save a tag.

### Test
1. Tap any note in list.
2. Enter text in **_Add tag..._** field.
3. Tap **_Space_** key.
4. Notice tag is saved with text from Step 2.
5. Enter text in **_Add tag..._** field.
6. Tap **_Enter_**/**_Return_** key.
7. Notice tag is saved with text from Step 5.
8. Enter `🏴󠁧󠁢󠁥󠁮󠁧󠁿🏴󠁧󠁢󠁥󠁮󠁧󠁿🏴󠁧󠁢󠁥󠁮󠁧󠁿🏴󠁧󠁢󠁥󠁮󠁧󠁿` in **_Add tag..._** field.
9. Tap **_Space_** key.
10. Notice **_Error_** dialog is shown.
11. Notice space is trimmed from **_Add tag..._** field.
12. Tap **_Enter_**/**_Return_** key.
13. Notice **_Error_** dialog is shown.
14. Notice newline is trimmed from **_Add tag..._** field.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.