### PR TITLE
Update Shortcuts Layouts

### DIFF
--- a/Simplenote/src/main/res/layout/dialog_shortcuts_all.xml
+++ b/Simplenote/src/main/res/layout/dialog_shortcuts_all.xml
@@ -2,6 +2,7 @@
 
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:clipToPadding="false"
     android:layout_height="match_parent"
     android:layout_width="match_parent">
@@ -24,18 +25,9 @@
         <RelativeLayout
             android:id="@+id/shortcut_note_new"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_note_new_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_note_new_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_note_new"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_note_new_key_third"
@@ -63,23 +55,24 @@
                 style="@style/Shortcut.Key.Multiple">
             </TextView>
 
+            <TextView
+                android:id="@+id/shortcut_note_new_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_note_new_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_note_new"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
+            </TextView>
+
         </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/shortcut_open_search"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_open_search_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_open_search_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_open_search"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_open_search_key_third"
@@ -107,23 +100,24 @@
                 style="@style/Shortcut.Key.Multiple">
             </TextView>
 
+            <TextView
+                android:id="@+id/shortcut_open_search_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_open_search_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_open_search"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
+            </TextView>
+
         </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/shortcut_toggle_checklist"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_toggle_checklist_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_toggle_checklist_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_toggle_checklist"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_toggle_checklist_key_third"
@@ -151,23 +145,24 @@
                 style="@style/Shortcut.Key.Multiple">
             </TextView>
 
+            <TextView
+                android:id="@+id/shortcut_toggle_checklist_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_toggle_checklist_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_toggle_checklist"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
+            </TextView>
+
         </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/shortcut_toggle_preview"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_toggle_preview_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_toggle_preview"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_toggle_preview_key_third"
@@ -195,23 +190,24 @@
                 style="@style/Shortcut.Key.Multiple">
             </TextView>
 
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_toggle_preview"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
+            </TextView>
+
         </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/shortcut_toggle_list"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_toggle_list_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_toggle_list_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_toggle_list"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_toggle_list_key_third"
@@ -239,23 +235,24 @@
                 style="@style/Shortcut.Key.Multiple">
             </TextView>
 
+            <TextView
+                android:id="@+id/shortcut_toggle_list_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_toggle_list_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_toggle_list"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
+            </TextView>
+
         </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/shortcut_show_information"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_show_information_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_show_information_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_show_information"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_show_information_key_second"
@@ -274,23 +271,24 @@
                 style="@style/Shortcut.Key.Multiple">
             </TextView>
 
+            <TextView
+                android:id="@+id/shortcut_show_information_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_show_information_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_show_information"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
+            </TextView>
+
         </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/shortcut_show_history"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_show_history_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_show_history_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_show_history"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_show_history_key_second"
@@ -309,23 +307,24 @@
                 style="@style/Shortcut.Key.Multiple">
             </TextView>
 
+            <TextView
+                android:id="@+id/shortcut_show_history_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_show_history_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_show_history"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
+            </TextView>
+
         </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/shortcut_show_share"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_show_share_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_show_share_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_show_share"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_show_share_key_second"
@@ -342,6 +341,16 @@
                 android:layout_width="wrap_content"
                 android:text="@string/key_multiple_ctrl"
                 style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_share_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_show_share_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_show_share"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
             </TextView>
 
         </RelativeLayout>

--- a/Simplenote/src/main/res/layout/dialog_shortcuts_editor_edit.xml
+++ b/Simplenote/src/main/res/layout/dialog_shortcuts_editor_edit.xml
@@ -2,6 +2,7 @@
 
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:clipToPadding="false"
     android:layout_height="match_parent"
     android:layout_width="match_parent">
@@ -24,18 +25,9 @@
         <RelativeLayout
             android:id="@+id/shortcut_toggle_checklist"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_toggle_checklist_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_toggle_checklist_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_toggle_checklist"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_toggle_checklist_key_third"
@@ -63,23 +55,24 @@
                 style="@style/Shortcut.Key.Multiple">
             </TextView>
 
+            <TextView
+                android:id="@+id/shortcut_toggle_checklist_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_toggle_checklist_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_toggle_checklist"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
+            </TextView>
+
         </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/shortcut_toggle_preview"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_toggle_preview_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_toggle_preview"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_toggle_preview_key_third"
@@ -107,23 +100,24 @@
                 style="@style/Shortcut.Key.Multiple">
             </TextView>
 
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_toggle_preview"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
+            </TextView>
+
         </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/shortcut_show_information"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_show_information_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_show_information_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_show_information"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_show_information_key_second"
@@ -142,23 +136,24 @@
                 style="@style/Shortcut.Key.Multiple">
             </TextView>
 
+            <TextView
+                android:id="@+id/shortcut_show_information_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_show_information_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_show_information"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
+            </TextView>
+
         </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/shortcut_show_history"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_show_history_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_show_history_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_show_history"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_show_history_key_second"
@@ -177,23 +172,24 @@
                 style="@style/Shortcut.Key.Multiple">
             </TextView>
 
+            <TextView
+                android:id="@+id/shortcut_show_history_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_show_history_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_show_history"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
+            </TextView>
+
         </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/shortcut_show_share"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_show_share_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_show_share_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_show_share"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_show_share_key_second"
@@ -210,6 +206,16 @@
                 android:layout_width="wrap_content"
                 android:text="@string/key_multiple_ctrl"
                 style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_show_share_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_show_share_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_show_share"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
             </TextView>
 
         </RelativeLayout>

--- a/Simplenote/src/main/res/layout/dialog_shortcuts_editor_preview.xml
+++ b/Simplenote/src/main/res/layout/dialog_shortcuts_editor_preview.xml
@@ -2,6 +2,7 @@
 
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:clipToPadding="false"
     android:layout_height="match_parent"
     android:layout_width="match_parent">
@@ -24,18 +25,9 @@
         <RelativeLayout
             android:id="@+id/shortcut_toggle_preview"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_toggle_preview_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_toggle_preview"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_toggle_preview_key_third"
@@ -61,6 +53,16 @@
                 android:layout_width="wrap_content"
                 android:text="@string/key_multiple_ctrl"
                 style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_toggle_preview_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_toggle_preview_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_toggle_preview"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
             </TextView>
 
         </RelativeLayout>

--- a/Simplenote/src/main/res/layout/dialog_shortcuts_list.xml
+++ b/Simplenote/src/main/res/layout/dialog_shortcuts_list.xml
@@ -2,6 +2,7 @@
 
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:clipToPadding="false"
     android:layout_height="match_parent"
     android:layout_width="match_parent">
@@ -24,18 +25,9 @@
         <RelativeLayout
             android:id="@+id/shortcut_note_new"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_note_new_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_note_new_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_note_new"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_note_new_key_third"
@@ -63,23 +55,24 @@
                 style="@style/Shortcut.Key.Multiple">
             </TextView>
 
+            <TextView
+                android:id="@+id/shortcut_note_new_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_note_new_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_note_new"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
+            </TextView>
+
         </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/shortcut_open_search"
             android:layout_height="?android:listPreferredItemHeightSmall"
-            android:layout_width="match_parent"
             android:layout_marginEnd="@dimen/padding_extra_extra_large"
-            android:layout_marginStart="@dimen/padding_extra_extra_large">
-
-            <TextView
-                android:id="@+id/shortcut_open_search_text"
-                android:layout_height="match_parent"
-                android:layout_toStartOf="@+id/shortcut_open_search_key_first"
-                android:layout_width="wrap_content"
-                android:text="@string/item_action_open_search"
-                style="@style/Shortcut.Item">
-            </TextView>
+            android:layout_marginStart="@dimen/padding_extra_extra_large"
+            android:layout_width="match_parent">
 
             <TextView
                 android:id="@+id/shortcut_open_search_key_third"
@@ -105,6 +98,16 @@
                 android:layout_width="wrap_content"
                 android:text="@string/key_multiple_ctrl"
                 style="@style/Shortcut.Key.Multiple">
+            </TextView>
+
+            <TextView
+                android:id="@+id/shortcut_open_search_text"
+                android:layout_height="match_parent"
+                android:layout_toStartOf="@+id/shortcut_open_search_key_first"
+                android:layout_width="wrap_content"
+                android:text="@string/item_action_open_search"
+                tools:ignore="RelativeOverlap"
+                style="@style/Shortcut.Item">
             </TextView>
 
         </RelativeLayout>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -298,33 +298,33 @@
     <style name="Shortcut.Key.Multiple" parent="TextAppearance.AppCompat">
         <item name="android:background">@drawable/bg_key</item>
         <item name="android:gravity">center</item>
-        <item name="android:layout_marginLeft">@dimen/padding_small</item>
+        <item name="android:layout_centerVertical">true</item>
+        <item name="android:layout_marginStart">@dimen/padding_small</item>
         <item name="android:minWidth">@dimen/key_width</item>
-        <item name="android:paddingLeft">@dimen/padding_small</item>
-        <item name="android:paddingRight">@dimen/padding_small</item>
+        <item name="android:paddingEnd">@dimen/padding_small</item>
+        <item name="android:paddingStart">@dimen/padding_small</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:textSize">@dimen/text_key</item>
-        <item name="android:layout_centerVertical">true</item>
     </style>
 
     <style name="Shortcut.Key.Single" parent="TextAppearance.AppCompat">
         <item name="android:background">@drawable/bg_key</item>
         <item name="android:gravity">center</item>
-        <item name="android:layout_marginLeft">@dimen/padding_small</item>
+        <item name="android:layout_alignParentEnd">true</item>
+        <item name="android:layout_centerVertical">true</item>
+        <item name="android:layout_marginStart">@dimen/padding_small</item>
         <item name="android:minWidth">@dimen/key_width</item>
-        <item name="android:paddingLeft">@dimen/padding_small</item>
-        <item name="android:paddingRight">@dimen/padding_small</item>
+        <item name="android:paddingEnd">@dimen/padding_small</item>
+        <item name="android:paddingStart">@dimen/padding_small</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:textSize">@dimen/text_key</item>
-        <item name="android:layout_centerVertical">true</item>
-        <item name="android:layout_alignParentRight">true</item>
     </style>
 
     <style name="Shortcut.Header" parent="TextAppearance.AppCompat">
         <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:gravity">center_vertical</item>
-        <item name="android:layout_marginLeft">@dimen/padding_extra_extra_large</item>
-        <item name="android:layout_marginRight">@dimen/padding_extra_extra_large</item>
+        <item name="android:layout_marginEnd">@dimen/padding_extra_extra_large</item>
+        <item name="android:layout_marginStart">@dimen/padding_extra_extra_large</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:textColor">?attr/colorAccent</item>
         <item name="android:textSize">@dimen/text_header</item>
@@ -333,10 +333,10 @@
     <style name="Shortcut.Item" parent="TextAppearance.AppCompat">
         <item name="android:ellipsize">end</item>
         <item name="android:gravity">center_vertical</item>
+        <item name="android:layout_alignParentStart">true</item>
         <item name="android:maxLines">1</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:textSize">@dimen/text_item</item>
-        <item name="android:layout_alignParentLeft">true</item>
     </style>
 
 </resources>


### PR DESCRIPTION
### Fix
Update the layouts and styles of the shortcuts dialogs to support better internationalization.  Attributes with left/right modifiers were changed to start/end, respectively.  The shortcut text view was moved after the dependent key view to avoid overlap and the `tools:ignore="RelativeOverlap"` attribute was added to ignore the associated warnings.  I'm not sure why the warning is still appearing even though the text has the `android:ellipsize` and `android:layout_toStartOf` attributes.  I'm open to suggestions on how to avoid the warning without using `tools:ignore="RelativeOverlap"`.

### Test
There are no visual changes with this pull request.  The shortcuts dialogs should appear the same as they did in https://github.com/Automattic/simplenote-android/pull/1055 before these changes.  Since the keyboard shortcuts dialog is only shown when the `CTRL` and `,` keys are pressed and the keyboard shortcuts only work on a device with a hardware keyboard, a device with a hardware keyboard is required to perform and verify the expected behavior.
#### Large Device in Landscape
1. Launch app without selecting note in list.
2. Press `CTRL` `,` keys.
3. Notice keyboard shortcuts dialog is shown.
4. Dismiss keyboard shortcuts dialog.
5. Press keys to perform keyboard shortcuts.
6. Notice shortcuts requiring note to be selected show error message.
7. Notice **_Open Search_** and **_New Note_** keyboard shortcuts work without selecting note in list.
8. Select note in list.
9. Press keys to perform keyboard shortcuts.
10. Notice keyboard shortcuts work as expected.

#### Small Device in Landscape and Portrait or Large Device in Portrait
1. Launch app without selecting note in list.
2. Press `CTRL` `,` keys.
3. Notice keyboard shortcuts dialog is shown.
4. Dismiss keyboard shortcuts dialog.
5. Press keys to perform keyboard shortcuts.
6. Notice shortcuts requiring note to be selected show error message.
7. Notice **_Open Search_** and **_New Note_** keyboard shortcuts work without selecting note in list.
8. Select note in list with markdown enabled.
9. Select _**Edit**_ tab.
10. Press `CTRL` `,` keys.
11. Notice keyboard shortcuts dialog is shown.
12. Dismiss keyboard shortcuts dialog.
13. Press keys to perform keyboard shortcuts.
14. Notice shortcuts work as expected.
15. Select _**Preview**_ tab.
16. Press `CTRL` `,` keys.
17. Notice keyboard shortcuts dialog is shown.
18. Dismiss keyboard shortcuts dialog.
19. Press keys to perform keyboard shortcuts.
20. Notice shortcuts work as expected.
21. Notice shortcuts requiring _**Edit**_ to be selected show error message.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
