### PR TITLE
Automatic upload to GooglePlay

### DIFF
--- a/.configure
+++ b/.configure
@@ -22,6 +22,11 @@
       "file": "android/debug.keystore",
       "destination": "~/.android/debug_a8c.keystore",
       "encrypt": true
+    },
+    {
+      "file": "android/WPAndroid/google-upload-credentials.json",
+      "destination": "google-upload-credentials.json",
+      "encrypt": true
     }
   ],
   "file_dependencies": [

--- a/.configure
+++ b/.configure
@@ -1,7 +1,7 @@
 {
   "project_name": "simplenote-android",
   "branch": "master",
-  "pinned_hash": "3f8583d82b6a6549c34bdf9427999497aa35f3b7",
+  "pinned_hash": "632d1d8739c3b959e0cb7b2741bd94722a219385",
   "files_to_copy": [
     {
       "file": "android/simplenote/Simplenote/gradle.properties",
@@ -24,9 +24,9 @@
       "encrypt": true
     },
     {
-      "file": "android/WPAndroid/google-upload-credentials.json",
+      "file": "android/Simplenote/google-upload-credentials.json",
       "destination": "google-upload-credentials.json",
-      "encrypt": true
+      "encrypt": false
     }
   ],
   "file_dependencies": [

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ fastlane/README.md
 fastlane/report.xml
 fastlane/.env
 fastlane/screenshots
+google-upload-credentials.json
 
 # Configure
 *.bak

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -193,30 +193,30 @@ SUPPORTED_LOCALES = [
       beta: true,
       final: false)
     android_build_preflight()
-    build_beta(skip_prechecks: true, skip_confirm: options[:skip_confirm], create_release: options[:create_release])
+    build_and_upload_beta(skip_prechecks: true, skip_confirm: options[:skip_confirm], create_release: options[:create_release])
   end
 
   #####################################################################################
-  # build_beta
+  # build_and_upload_beta
   # -----------------------------------------------------------------------------------
   # This lane builds the app it for internal testing  
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_beta [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
+  # bundle exec fastlane build_and_upload_beta [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
-  # bundle exec fastlane build_beta 
-  # bundle exec fastlane build_beta skip_confirm:true 
-  # bundle exec fastlane build_beta create_release:true 
+  # bundle exec fastlane build_and_upload_beta 
+  # bundle exec fastlane build_and_upload_beta skip_confirm:true 
+  # bundle exec fastlane build_and_upload_beta create_release:true 
   #####################################################################################
   desc "Builds and updates for distribution"
-  lane :build_beta do | options |
+  lane :build_and_upload_beta do | options |
     android_build_prechecks(skip_confirm: options[:skip_confirm], beta: true) unless (options[:skip_prechecks])
     android_build_preflight() unless (options[:skip_prechecks])
 
     # Create the file names
     version=android_get_release_version()
-    build_apk(version: version, flavor:"Vanilla")
+    build_and_upload_apk(version: version, flavor:"Vanilla", upload_track:"Beta")
 
     if (options[:create_release])
       create_gh_release(version: version)
@@ -224,20 +224,20 @@ SUPPORTED_LOCALES = [
   end
 
   #####################################################################################
-  # build_release
+  # build_and_upload_release
   # -----------------------------------------------------------------------------------
   # This lane builds the final release of the app and uploads it 
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_release [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
+  # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
-  # bundle exec fastlane build_release 
-  # bundle exec fastlane build_release skip_confirm:true 
-  # bundle exec fastlane build_release create_release:true 
+  # bundle exec fastlane build_and_upload_release 
+  # bundle exec fastlane build_and_upload_release skip_confirm:true 
+  # bundle exec fastlane build_and_upload_release create_release:true 
   #####################################################################################
   desc "Builds and updates for distribution"
-  lane :build_release do | options |
+  lane :build_and_upload_release do | options |
     android_build_prechecks(skip_confirm: options[:skip_confirm], 
       alpha: false,
       beta: false,
@@ -246,7 +246,7 @@ SUPPORTED_LOCALES = [
     
     # Create the file names
     version=android_get_release_version()
-    build_apk(version: version, flavor:"Vanilla")
+    build_and_upload_apk(version: version, flavor:"Vanilla", upload_track:"Production")
 
     if (options[:create_release])
       create_gh_release(version: version)
@@ -297,34 +297,6 @@ SUPPORTED_LOCALES = [
   end 
 
   #####################################################################################
-  # build_and_upload_beta
-  # -----------------------------------------------------------------------------------
-  # This lane builds the apk and uploads it to the beta channel
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # bundle exec fastlane build_and_upload_apk version:<version>
-  #  [skip_confirm:<skip confirm>] 
-  #####################################################################################
-  desc "Builds an app apk and upload to the beta channel"
-  lane :build_and_upload_beta do | options |
-    build_and_upload_apk(version: options[:version], skip_confirm: options[:skip_confirm], upload_track: "beta")
-  end
-
-  #####################################################################################
-  # build_and_upload_release
-  # -----------------------------------------------------------------------------------
-  # This lane builds the apk and uploads it to the production channel
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # bundle exec fastlane build_and_upload_apk version:<version>
-  #  [skip_confirm:<skip confirm>] 
-  #####################################################################################
-  desc "Builds an app apk and upload to the production channel"
-  lane :build_and_upload_beta do | options |
-    build_and_upload_apk(version: options[:version], skip_confirm: options[:skip_confirm], upload_track: "production")
-  end
-
-  #####################################################################################
   # build_and_upload_apk
   # -----------------------------------------------------------------------------------
   # This lane builds and uploads an app apk 
@@ -368,7 +340,7 @@ SUPPORTED_LOCALES = [
 
     upload_to_play_store(
       package_name: 'com.automattic.simplenote',
-      aab: apk_file_path,
+      apk: apk_file_path,
       track: upload_track,
       release_status: 'draft',
       skip_upload_metadata: true,
@@ -378,7 +350,7 @@ SUPPORTED_LOCALES = [
       json_key: './google-upload-credentials.json',
     ) unless upload_track.blank?
   
-    return apk_file_path
+    apk_file_path
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -297,21 +297,52 @@ SUPPORTED_LOCALES = [
   end 
 
   #####################################################################################
-  # build_bundle
+  # build_and_upload_beta
   # -----------------------------------------------------------------------------------
-  # This lane builds an app bundle
+  # This lane builds the apk and uploads it to the beta channel
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_bundle [skip_confirm:<skip confirm>]
+  # bundle exec fastlane build_and_upload_apk version:<version>
+  #  [skip_confirm:<skip confirm>] 
   #####################################################################################
-  desc "Builds an app bundle"
-  lane :build_apk do | options |
+  desc "Builds an app apk and upload to the beta channel"
+  lane :build_and_upload_beta do | options |
+    build_and_upload_apk(version: options[:version], skip_confirm: options[:skip_confirm], upload_track: "beta")
+  end
+
+  #####################################################################################
+  # build_and_upload_release
+  # -----------------------------------------------------------------------------------
+  # This lane builds the apk and uploads it to the production channel
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane build_and_upload_apk version:<version>
+  #  [skip_confirm:<skip confirm>] 
+  #####################################################################################
+  desc "Builds an app apk and upload to the production channel"
+  lane :build_and_upload_beta do | options |
+    build_and_upload_apk(version: options[:version], skip_confirm: options[:skip_confirm], upload_track: "production")
+  end
+
+  #####################################################################################
+  # build_and_upload_apk
+  # -----------------------------------------------------------------------------------
+  # This lane builds and uploads an app apk 
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane build_and_upload_apk version:<version>
+  #  [updload_track:<upload_track: [production | beta]>] 
+  #  [skip_confirm:<skip confirm>] 
+  #####################################################################################
+  desc "Builds an app apk and upload it"
+  lane :build_and_upload_apk do | options |
     # Create the file names
     version=options[:version]
     apk_name="simplenote-#{version["name"]}.apk"
     orign_file="Simplenote-release.apk"
     output_dir="Simplenote/build/outputs/apk/release/"
     build_dir="build/"
+    upload_track=options[:upload_track]
 
     # Build
     Dir.chdir(".") do
@@ -327,7 +358,27 @@ SUPPORTED_LOCALES = [
       sh("cp -v #{output_dir}#{orign_file} #{build_dir}#{apk_name}")
       UI.message("Apk ready: #{apk_name}")
     end
-    "#{build_dir}#{apk_name}"
+
+    version=android_get_release_version()
+
+    project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
+    apk_file_path = File.join(project_root, "#{build_dir}", "#{apk_name}")
+
+    UI.error("Unable to find a build artifact at #{apk_file_path}") unless File.exist? apk_file_path
+
+    upload_to_play_store(
+      package_name: 'com.automattic.simplenote',
+      aab: apk_file_path,
+      track: upload_track,
+      release_status: 'draft',
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+      json_key: './google-upload-credentials.json',
+    ) unless upload_track.blank?
+  
+    return apk_file_path
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -216,7 +216,7 @@ SUPPORTED_LOCALES = [
 
     # Create the file names
     version=android_get_release_version()
-    build_and_upload_apk(version: version, flavor:"Vanilla", upload_track:"Beta")
+    build_and_upload_apk(version: version, flavor:"Vanilla", upload_track:"beta")
 
     if (options[:create_release])
       create_gh_release(version: version)
@@ -246,7 +246,7 @@ SUPPORTED_LOCALES = [
     
     # Create the file names
     version=android_get_release_version()
-    build_and_upload_apk(version: version, flavor:"Vanilla", upload_track:"Production")
+    build_and_upload_apk(version: version, flavor:"Vanilla", upload_track:"production")
 
     if (options[:create_release])
       create_gh_release(version: version)


### PR DESCRIPTION
This PR adds automatic upload to Play Store to the Fastlane build lanes. 

### Test
**Note: Be careful with testing: if you have any release which is not fully rolled out, this may mess things up.**
1. Pull the latest `mobile-secrets` repository.
2. Create a new branch out of this one and call it `release/<something>`.
3. Update `versionCode` and `versionName` in `build.gradle`. Use a beta (`-rc-`) version name.
4. Run `bundle install`.
5. Run `bundle exec fastlane build_and_upload_beta` and make sure it succeeds. 
6. Go to Google Play Console and verify that there's a new release draft in the beta lane with the new binary attached.
7. Discard the release draft.
8. Go to the artifact library and delete the test binary

9. Update `versionCode` and `versionName` in `build.gradle`. Use a release (not `-rc-`) version name.
10. Run `bundle exec fastlane build_and_upload_release` and make sure it succeeds. 
11. Go to Google Play Console and verify that there's a new release draft in the production lane with the new binary attached.
12. Discard the release draft.
13. Go to the artifact library and delete the test binary

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
