### PR TITLE
Update README version shield to 2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Simplenote for Android
-[![Version](https://img.shields.io/badge/version-2.7-blue.svg)](https://github.com/Automattic/simplenote-android/releases/tag/2.7) [![CircleCI](https://img.shields.io/circleci/build/gh/Automattic/simplenote-android.svg?label=circleci)](https://circleci.com/gh/Automattic/simplenote-android) [![Travis CI](https://img.shields.io/travis/Automattic/simplenote-android/develop.svg?label=travisci)](https://travis-ci.org/Automattic/simplenote-android)
+[![Version](https://img.shields.io/badge/version-2.8-blue.svg)](https://github.com/Automattic/simplenote-android/releases/tag/2.8) [![CircleCI](https://img.shields.io/circleci/build/gh/Automattic/simplenote-android.svg?label=circleci)](https://circleci.com/gh/Automattic/simplenote-android) [![Travis CI](https://img.shields.io/travis/Automattic/simplenote-android/develop.svg?label=travisci)](https://travis-ci.org/Automattic/simplenote-android)
 
 Simplenote for Android. Learn more at [Simplenote.com](https://simplenote.com).
 


### PR DESCRIPTION
### Fix
Updates the version shield in the README, as per release process checklist. After opening this kind of dedicated for the last two releases, I think I'll make the commit part of the release branch next time, to save back and forth in PR reviews.

### Test
Nothing to test, just a README change.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.