### PR TITLE
Merge 2.9-rc-1 into develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,6 @@
+3.0
+-----
+ 
 2.9
 -----
 * Fixed a bug with duplicate tags and special characters in tag names

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -30,9 +30,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "2.8"
+            versionName "2.9-rc-1"
         }
-        versionCode 110
+        versionCode 111
         minSdkVersion 23
         targetSdkVersion 29
 

--- a/Simplenote/metadata/PlayStoreStrings.pot
+++ b/Simplenote/metadata/PlayStoreStrings.pot
@@ -11,17 +11,17 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_029"
+msgid ""
+"2.9:\n"
+"* Fixed a bug with duplicate tags and special characters in tag names\n"
+msgstr ""
+
 msgctxt "release_note_028"
 msgid ""
 "2.8:\n"
 "* Added hotkey shortcuts for devices with hardware keyboards\n"
 "* Added right-to-left language support to markdown preview\n"
-msgstr ""
-
-msgctxt "release_note_027"
-msgid ""
-"2.7:\n"
-"* Updated primary color to new Simplenote blue\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/Simplenote/metadata/release_notes.txt
+++ b/Simplenote/metadata/release_notes.txt
@@ -1,2 +1,1 @@
 * Fixed a bug with duplicate tags and special characters in tag names
- 

--- a/Simplenote/metadata/release_notes.txt
+++ b/Simplenote/metadata/release_notes.txt
@@ -1,2 +1,2 @@
-* Added hotkey shortcuts for devices with hardware keyboards
-* Added right-to-left language support to markdown preview
+* Fixed a bug with duplicate tags and special characters in tag names
+ 

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -14,6 +14,12 @@
     <string name="words">Words</string>
     <string name="edit_tags">Edit Tags</string>
     <string name="rename_tag">Rename Tag</string>
+    <string name="rename_tag_error_empty">Tags cannot be empty</string>
+    <string name="rename_tag_error_length">Tag length too long</string>
+    <string name="rename_tag_error_spaces">Tags cannot contain spaces</string>
+    <string name="rename_tag_message">An error occurred renaming the tag. Please, try again. If the problem continues, contact us at %1$s%2$s%3$s%4$s%5$s for help.</string>
+    <string name="rename_tag_message_email" translatable="false">\u003c\u0061\u0020\u0068\u0072\u0065\u0066\u003d\u0022\u006d\u0061\u0069\u006c\u0074\u006f\u003a\u0073\u0075\u0070\u0070\u006f\u0072\u0074\u0040\u0073\u0069\u006d\u0070\u006c\u0065\u006e\u006f\u0074\u0065\u002e\u0063\u006f\u006d\u0022\u003e\u0073\u0075\u0070\u0070\u006f\u0072\u0074\u0040\u0073\u0069\u006d\u0070\u006c\u0065\u006e\u006f\u0074\u0065\u002e\u0063\u006f\u006d\u003c\u002f\u0061\u003e</string>
+    <string name="rename_tag_message_length">The tag length is too long. Please, try again with a shorter name. If the problem continues, contact us at %1$s%2$s%3$s%4$s%5$s for help.</string>
     <string name="tag_name">Tag name</string>
     <string name="delete_tag">Delete Tag</string>
     <string name="save">Save</string>
@@ -63,6 +69,10 @@
     <string name="of">of</string>
 
     <!-- Preferences -->
+    <string name="export_file">simplenote.json</string>
+    <string name="export_message_failure">Data could not be saved</string>
+    <string name="export_message_success">Data saved to file</string>
+    <string name="export_setting">Export data</string>
     <string name="editor">Editor</string>
     <string name="condensed_note_list">Condensed note list</string>
     <string name="sort_order">Sort order</string>
@@ -135,10 +145,10 @@
     <string name="link_terms">%1$s%2$s%3$sTerms of Service%4$s</string>
 
     <!-- Unsynced note warnings -->
-    <string name="unsynced_notes">Unsynced notes detected</string>
-    <string name="unsynced_notes_message">Logging out will delete any unsynced notes. You can verify your synced notes by logging in to app.simplenote.com in a web browser.</string>
-    <string name="visit_web_app">Visit web app</string>
-    <string name="delete_notes">Delete notes</string>
+    <string name="unsynced_notes">Unsynced Notes</string>
+    <string name="unsynced_notes_message">Logging out will delete any unsynced notes.</string>
+    <string name="export_unsynced_notes">Export unsynced notes</string>
+    <string name="log_out_anyway">Log out anyway</string>
 
     <!-- Note publishing -->
     <string name="publish">Publish</string>


### PR DESCRIPTION
I will not be opening a PR against `master` because, thanks to #1088, the strings on GlotPress should update from merges on `develop` now, as long as this has been addressed

> After this [#1088] is merged, we'll make GlotPress point to this shadow strings.xml in develop and we won't need to use master for this anymore.

This will be a good real world test of the new setup.