### PR TITLE
Add Button Description

### DIFF
--- a/Simplenote/src/main/res/layout/fragment_notes_list.xml
+++ b/Simplenote/src/main/res/layout/fragment_notes_list.xml
@@ -57,6 +57,7 @@
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_button"
+        android:contentDescription="@string/new_note"
         android:layout_gravity="end|bottom"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/padding_large"


### PR DESCRIPTION
### Fix
Add the `contentDescription` attribute to the `FloatingActionButton` view in the `fragment_notes_list` layout.  Adding a description to the floating action button supports screen readers and accessibility.

### Test
Since these changes have no user-facing aspect, smoke testing is all that is required.  The changes affect the **_New Note_** floating action button so it's best to test creating a new note.

For a more in-depth test and to verify the changes pass accessibility standards, the [Accessibility Scanner app](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor) can be used.  Once downloaded and installed, a snapshot of the note list with the floating action button can be captured and the following screen should be shown.

<kbd><a href="https://user-images.githubusercontent.com/3827611/88448265-16b91300-cdf9-11ea-90aa-f4c198288beb.png"><img src="https://user-images.githubusercontent.com/3827611/88448265-16b91300-cdf9-11ea-90aa-f4c198288beb.png" width="300"></a></kbd>

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
