### PR TITLE
Issue/1113 font resize swipe

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -351,6 +351,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mContentEditText.setOnCheckboxToggledListener(this);
         mContentEditText.setMovementMethod(SimplenoteMovementMethod.getInstance());
         mContentEditText.setOnFocusChangeListener(this);
+        mContentEditText.setTextSize(TypedValue.COMPLEX_UNIT_SP, PrefUtils.getFontSize(requireContext()));
         mTagInput = mRootView.findViewById(R.id.tag_input);
         mTagInput.setDropDownBackgroundResource(R.drawable.bg_list_popup);
         mTagInput.setTokenizer(new SpaceTokenizer());

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -440,7 +440,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mTagInput.setOnTagAddedListener(this);
 
         if (mContentEditText != null) {
-            mContentEditText.setTextSize(TypedValue.COMPLEX_UNIT_SP, PrefUtils.getFontSize(getActivity()));
+            mContentEditText.setTextSize(TypedValue.COMPLEX_UNIT_SP, PrefUtils.getFontSize(requireContext()));
 
             if (mContentEditText.hasFocus()) {
                 showSoftKeyboard();


### PR DESCRIPTION
### Fix
Add setting the text size of the note editor when the screen is created to close #1113.  The size will still be set when the screen is resumed in order to update the text size if the value is changed in **_Settings_** and the note editor is open as with a tablet in landscape orientation.

### Test
1. Tap any note in list with markdown enabled.
2. Tap **_Preview_** tab.
3. Tap back arrow in app bar.
4. Tap note from Step 1.
5. Notice **_Preview_** tab is shown.
6. Swipe right to show **_Edit_** tab.
7. Notice text size does not resize.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.