### PR TITLE
Issue/1115 list widget condensed

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -351,6 +351,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mContentEditText.setOnCheckboxToggledListener(this);
         mContentEditText.setMovementMethod(SimplenoteMovementMethod.getInstance());
         mContentEditText.setOnFocusChangeListener(this);
+        mContentEditText.setTextSize(TypedValue.COMPLEX_UNIT_SP, PrefUtils.getFontSize(requireContext()));
         mTagInput = mRootView.findViewById(R.id.tag_input);
         mTagInput.setDropDownBackgroundResource(R.drawable.bg_list_popup);
         mTagInput.setTokenizer(new SpaceTokenizer());

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -440,7 +440,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mTagInput.setOnTagAddedListener(this);
 
         if (mContentEditText != null) {
-            mContentEditText.setTextSize(TypedValue.COMPLEX_UNIT_SP, PrefUtils.getFontSize(getActivity()));
+            mContentEditText.setTextSize(TypedValue.COMPLEX_UNIT_SP, PrefUtils.getFontSize(requireContext()));
 
             if (mContentEditText.hasFocus()) {
                 showSoftKeyboard();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetFactory.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetFactory.java
@@ -64,6 +64,9 @@ public class NoteListWidgetFactory implements RemoteViewsFactory {
             views.setViewVisibility(R.id.note_published, note.isPublished() ? View.VISIBLE : View.GONE);
             views.setViewVisibility(R.id.note_status, note.isPinned() || note.isPublished() ? View.VISIBLE : View.GONE);
 
+            boolean isCondensed = PrefUtils.getBoolPref(mContext, PrefUtils.PREF_CONDENSED_LIST, false);
+            views.setViewVisibility(R.id.note_content, isCondensed ? View.GONE : View.VISIBLE);
+
             // Create intent to navigate to note editor on note list item click
             Intent intent = new Intent(mContext, NoteEditorActivity.class);
             intent.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_NOTE_TAPPED);


### PR DESCRIPTION
### Fix
Add the condensed note behavior to the note list widgets to follow the ***Condensed note list*** setting in the app to close #1115.  When the ***Condensed note list*** setting is enabled/disabled, the note content is hidden/shown in the note list in the app and in the note list widget.  See the screenshots below for illustration.

![1115_list_widget_condensed](https://user-images.githubusercontent.com/3827611/89306125-b31abb00-d62c-11ea-81ee-d68a285aad1b.png)

### Test
0. Add **_Note List (Light)_** and **_Note List (Dark)_** widgets to home screen.
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Disable ***Condensed note list*** setting under **_Notes_** section.
4. Tap back arrow in app bar.
5. Tap back button in navigation bar.
6. Notice **_Note List (Light)_** and **_Note List (Dark)_** widgets are expanded.
7. Tap recents/overview button in navigation bar.
8. Tap ***Simplenote*** app.
9. Open navigation drawer.
10. Tap ***Settings*** item in navigation drawer.
11. Enable ***Condensed note list*** setting under **_Notes_** section.
12. Tap back arrow in app bar.
13. Tap back button in navigation bar.
14. Notice **_Note List (Light)_** and **_Note List (Dark)_** widgets are condensed.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.  
@rachelmcr, I also requested you as a reviewer since you requested the feature and to ensure it is as expected.

### Release
These changes do not require release notes.