### PR TITLE
Issue/1029 publish network check

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/ShareBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/ShareBottomSheetDialog.java
@@ -12,6 +12,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -22,6 +23,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.utils.IconResizer;
+import com.automattic.simplenote.utils.NetworkUtils;
 import com.automattic.simplenote.utils.ShareButtonAdapter;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
@@ -75,6 +77,11 @@ public class ShareBottomSheetDialog extends BottomSheetDialogBase {
             mPublishButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+                    if (!NetworkUtils.isNetworkAvailable(requireContext())) {
+                        Toast.makeText(requireContext(), R.string.error_network_required, Toast.LENGTH_LONG).show();
+                        return;
+                    }
+
                     mListener.onSharePublishClicked();
                 }
             });
@@ -82,6 +89,11 @@ public class ShareBottomSheetDialog extends BottomSheetDialogBase {
             mUnpublishButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+                    if (!NetworkUtils.isNetworkAvailable(requireContext())) {
+                        Toast.makeText(requireContext(), R.string.error_network_required, Toast.LENGTH_LONG).show();
+                        return;
+                    }
+
                     mListener.onShareUnpublishClicked();
                 }
             });


### PR DESCRIPTION
### Fix
Add a network connection check before the publish and unpublish actions are executed to complement #1034.  If a network connection is detected, the publish/unpublish action continues as expected.  If no network connection is detected, the following message is shown.

> A network connection is required. Please, check your connection and try again.

### Test
1. Enable airplane mode.
2. Tap any note in list.
3. Tap ellipsis action in app bar.
4. Tap ***Share*** item in menu.
5. Notice ***Share*** bottom sheet is shown.
4. Tap ***Publish***/***Remove public link*** item in sheet.
5. Notice toast with ***A network connection is required. Please, check your connection and try again.*** message is shown.
6. Disable airplane mode.
7. Tap ellipsis action in app bar.
8. Tap ***Publish***/***Remove public link*** item in menu.
9. Notice snackbar with ***Publishing...***/***Removing public link...*** message is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.