### PR TITLE
Crash Right Click

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -1120,7 +1120,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                 @SuppressLint("ClickableViewAccessibility")
                 @Override
                 public boolean onTouch(View view, MotionEvent event) {
-                    if (event.getButtonState() == MotionEvent.BUTTON_SECONDARY) {
+                    if (event.getButtonState() == MotionEvent.BUTTON_SECONDARY && event.getAction() == MotionEvent.ACTION_DOWN) {
                         showPopupMenuAtPosition(view, position);
                         return true;
                     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -1348,7 +1348,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             return;
         }
 
-        final Note note = mNotesAdapter.getItem(position);
+        final Note note = mNotesAdapter.getItem(position + mList.getHeaderViewsCount());
         if (note == null) {
             return;
         }


### PR DESCRIPTION
### Fix
Add the header views count to the parameter of the `NotesAdapter.getItem(position)` method to compensate for the search sort view header and avoid a `CursorIndexOutOfBoundsException` crash caused when right-clicking the first note in the list.  Even though the search sort view header is hidden when not searching, it is still counted and [subtracted in the `getItem` method of the `NotesCursorAdapter` class](https://github.com/Automattic/simplenote-android/blob/4877cee531cf72b112eac655c3fd76a576e22bde/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java#L1001).  These changes add the header views count to the position in order to cancel out that subtraction.

Also, the `event.getAction() == MotionEvent.ACTION_DOWN` condition was added in order to call `showPopupMenuAtPosition(view, position)` so that only a single popup menu is shown.  If that condition is removed, two popup menus can be shown (i.e. one for `ACTION_UP` and one for `ACTION_DOWN`) when a note is right-clicked once.

### Test
Since right-clicking is available on large devices with a touchpad, a device running Chrome OS may be required to perform and verify the expected behavior.
1. Right-click first note in list.
2. Notice one popup menu is shown.
3. Notice app does not crash.
4. Right-click any note in list.
5. Notice one popup menu is shown.
6. Notice app does not crash.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.