### PR TITLE
Add Style Setting (Part 3)

### DIFF
--- a/Simplenote/src/main/assets/dark_sepia.css
+++ b/Simplenote/src/main/assets/dark_sepia.css
@@ -1,0 +1,200 @@
+<style>
+@charset "UTF-8";
+* , body {
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background: transparent;
+}
+
+img {
+    border: 0;
+}
+
+* :focus {
+    outline: none;
+}
+
+html {
+    margin: 0;
+    padding: 0;
+    background: #23211f;
+    color: #dbdee0;
+    text-rendering: optimizeLegibility;
+}
+
+::-webkit-scrollbar {
+    width: 6px;
+}
+
+::-webkit-scrollbar-track {
+    background-color: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    border-radius: 6px;
+    background: #84878a;
+}
+
+/* Same styles as app.simplenote.com/publish */
+.note-detail-markdown {
+    user-select: auto;
+    font-family: 'Noto Serif', serif;
+    font-size: 18px;
+    line-height: 1.7;
+    word-wrap: break-word;
+    padding: 20px 20px 20px 24px;
+}
+
+.note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
+.note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
+.note-detail-markdown #title {
+    unicode-bidi: plaintext;
+    line-height: 1.15;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    margin: 1.7em 0 1em 0;
+}
+
+.note-detail-markdown h1, .note-detail-markdown #title {
+    font-size: 2em;
+}
+
+.note-detail-markdown h1:first-of-type, .note-detail-markdown #title:first-of-type {
+    margin-top: 0;
+}
+
+.note-detail-markdown h2 {
+    font-size: 1.8em;
+}
+
+.note-detail-markdown h3 {
+    font-size: 1.4em;
+}
+
+.note-detail-markdown h4 {
+    font-size: 1.2em;
+}
+
+.note-detail-markdown h5, .note-detail-markdown h6 {
+    font-size: 1em;
+    text-transform: uppercase;
+}
+
+.note-detail-markdown #title {
+    margin-bottom: 0.5em;
+    font-weight: bold;
+}
+
+.note-detail-markdown p, .note-detail-markdown ul, .note-detail-markdown ol,
+.note-detail-markdown blockquote, .note-detail-markdown pre, .note-detail-markdown table,
+.note-detail-markdown code, .note-detail-markdown img {
+    unicode-bidi: plaintext;
+    margin-bottom: 1.7em;
+    box-sizing: border-box;
+}
+
+.note-detail-markdown ul, .note-detail-markdown ol {
+    margin-inline-start: 2em;
+}
+
+.note-detail-markdown img {
+    display: block;
+    margin: 0 auto;
+    max-width: 100%;
+    height: auto;
+}
+
+.note-detail-markdown a {
+    color: #84a4f0;
+}
+
+.note-detail-markdown hr {
+    border: 0;
+    margin: 3.4em 0;
+    color: #84a4f0;
+    height: 1em;
+}
+
+.note-detail-markdown hr:before {
+    content: '...';
+    display: block;
+    width: 100%;
+    letter-spacing: 2em;
+    text-indent: 2em;
+    z-index: 1;
+    line-height: .5;
+    text-align: center;
+}
+
+.note-detail-markdown blockquote {
+    font-style: italic;
+    border-inline-start: 4px solid currentColor;
+    margin-inline-start: 0;
+    padding-inline-start: 1.7em;
+}
+
+.note-detail-markdown code {
+    color: #84878a;
+}
+
+.note-detail-markdown pre {
+    padding: 1em;
+    border-radius: 3px;
+    background: #f6f7f8;
+    white-space: pre-wrap;
+}
+
+.note-detail-markdown pre code {
+    unicode-bidi: isolate;
+    font-size: 85%;
+    color: #616870;
+    background: transparent;
+    width: 100%;
+    overflow-x: auto;
+    display: block;
+    margin-bottom: 0;
+}
+
+.note-detail-markdown p code {
+    unicode-bidi: isolate;
+}
+
+.note-detail-markdown table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    display: block;
+    width: 100%;
+}
+
+.note-detail-markdown table tr:nth-child(2n) {
+    background-color: #383d41;
+}
+
+.note-detail-markdown table th, .note-detail-markdown table td {
+    unicode-bidi: plaintext;
+    border: 1px solid #575e65;
+    padding: 6px 13px;
+}
+
+.note-detail-markdown table th {
+    font-weight: 600;
+}
+
+@media only screen and (max-width: 480px) {
+    .note-detail-markdown {
+        font-size: 16px;
+    }
+
+    .note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
+    .note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
+    .note-detail-markdown #title {
+        margin: 1.19em 0 0.7em 0;
+    }
+
+    .note-detail-markdown #title {
+        margin-bottom: 0;
+    }
+}
+</style>

--- a/Simplenote/src/main/assets/light_sepia.css
+++ b/Simplenote/src/main/assets/light_sepia.css
@@ -1,0 +1,200 @@
+<style>
+@charset "UTF-8";
+* , body {
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background: transparent;
+}
+
+img {
+    border: 0;
+}
+
+* :focus {
+    outline: none;
+}
+
+html {
+    margin: 0;
+    padding: 0;
+    background: #fdf9f2;
+    color: #2d3034;
+    text-rendering: optimizeLegibility;
+}
+
+::-webkit-scrollbar {
+    width: 6px;
+}
+
+::-webkit-scrollbar-track {
+    background-color: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    border-radius: 6px;
+    background: #84878a;
+}
+
+/* Same styles as app.simplenote.com/publish */
+.note-detail-markdown {
+    user-select: auto;
+    font-family: 'Noto Serif', serif;
+    font-size: 18px;
+    line-height: 1.7;
+    word-wrap: break-word;
+    padding: 20px 20px 20px 24px;
+}
+
+.note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
+.note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
+.note-detail-markdown #title {
+    unicode-bidi: plaintext;
+    line-height: 1.15;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    margin: 1.7em 0 1em 0;
+}
+
+.note-detail-markdown h1, .note-detail-markdown #title {
+    font-size: 2em;
+}
+
+.note-detail-markdown h1:first-of-type, .note-detail-markdown #title:first-of-type {
+    margin-top: 0;
+}
+
+.note-detail-markdown h2 {
+    font-size: 1.8em;
+}
+
+.note-detail-markdown h3 {
+    font-size: 1.4em;
+}
+
+.note-detail-markdown h4 {
+    font-size: 1.2em;
+}
+
+.note-detail-markdown h5, .note-detail-markdown h6 {
+    font-size: 1em;
+    text-transform: uppercase;
+}
+
+.note-detail-markdown #title {
+    margin-bottom: 0.5em;
+    font-weight: bold;
+}
+
+.note-detail-markdown p, .note-detail-markdown ul, .note-detail-markdown ol,
+.note-detail-markdown blockquote, .note-detail-markdown pre, .note-detail-markdown table,
+.note-detail-markdown code, .note-detail-markdown img {
+    unicode-bidi: plaintext;
+    margin-bottom: 1.7em;
+    box-sizing: border-box;
+}
+
+.note-detail-markdown ul, .note-detail-markdown ol {
+    margin-inline-start: 2em;
+}
+
+.note-detail-markdown img {
+    display: block;
+    margin: 0 auto;
+    max-width: 100%;
+    height: auto;
+}
+
+.note-detail-markdown a {
+    color: #3361cc;
+}
+
+.note-detail-markdown hr {
+    border: 0;
+    margin: 3.4em 0;
+    color: #3361cc;
+    height: 1em;
+}
+
+.note-detail-markdown hr:before {
+    content: '...';
+    display: block;
+    width: 100%;
+    letter-spacing: 2em;
+    text-indent: 2em;
+    z-index: 1;
+    line-height: .5;
+    text-align: center;
+}
+
+.note-detail-markdown blockquote {
+    font-style: italic;
+    border-inline-start: 4px solid currentColor;
+    margin-inline-start: 0;
+    padding-inline-start: 1.7em;
+}
+
+.note-detail-markdown code {
+    color: #899199;
+}
+
+.note-detail-markdown pre {
+    padding: 1em;
+    border-radius: 3px;
+    background: #f6f7f8;
+    white-space: pre-wrap;
+}
+
+.note-detail-markdown pre code {
+    unicode-bidi: isolate;
+    font-size: 85%;
+    color: #616870;
+    background: transparent;
+    width: 100%;
+    overflow-x: auto;
+    display: block;
+    margin-bottom: 0;
+}
+
+.note-detail-markdown p code {
+    unicode-bidi: isolate;
+}
+
+.note-detail-markdown table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    display: block;
+    width: 100%;
+}
+
+.note-detail-markdown table tr:nth-child(2n) {
+    background-color: #f6f7f8;
+}
+
+.note-detail-markdown table th, .note-detail-markdown table td {
+    unicode-bidi: plaintext;
+    border: 1px solid #c0c4c8;
+    padding: 6px 13px;
+}
+
+.note-detail-markdown table th {
+    font-weight: 600;
+}
+
+@media only screen and (max-width: 480px) {
+    .note-detail-markdown {
+        font-size: 16px;
+    }
+
+    .note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
+    .note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
+    .note-detail-markdown #title {
+        margin: 1.19em 0 0.7em 0;
+    }
+
+    .note-detail-markdown #title {
+        margin-bottom: 0;
+    }
+}
+</style>

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -42,6 +42,7 @@ import android.widget.Toast;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.fragment.app.ListFragment;
 import androidx.preference.PreferenceManager;
@@ -326,7 +327,10 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mSortLayoutContent.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                PopupMenu popup = new PopupMenu(mSortOrder.getContext(), mSortOrder, Gravity.START);
+                Context context = ThemeUtils.getStyle(requireContext()) == R.style.Style_Sepia ?
+                        new ContextThemeWrapper(requireContext(), R.style.ToolbarTheme_Popup_Sepia) :
+                        mSortOrder.getContext();
+                PopupMenu popup = new PopupMenu(context, mSortOrder, Gravity.START);
                 MenuInflater inflater = popup.getMenuInflater();
                 inflater.inflate(R.menu.search_sort, popup.getMenu());
                 popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/StyleActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/StyleActivity.java
@@ -36,6 +36,7 @@ import static com.automattic.simplenote.utils.ThemeUtils.STYLE_ARRAY;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_BLACK;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_CLASSIC;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_DEFAULT;
+import static com.automattic.simplenote.utils.ThemeUtils.STYLE_SEPIA;
 
 public class StyleActivity extends ThemedAppCompatActivity {
     private boolean mIsPremium;
@@ -183,6 +184,13 @@ public class StyleActivity extends ThemedAppCompatActivity {
                             R.style.Style_Classic)
                         ).inflate(R.layout.style_list_row_default, parent, false)
                     );
+                case STYLE_SEPIA:
+                    return new StyleHolder(LayoutInflater.from(
+                        new ContextThemeWrapper(
+                            parent.getContext(),
+                            R.style.Style_Sepia)
+                        ).inflate(R.layout.style_list_row_sepia, parent, false)
+                    );
                 case STYLE_DEFAULT:
                 default:
                     return new StyleHolder(LayoutInflater.from(
@@ -200,6 +208,8 @@ public class StyleActivity extends ThemedAppCompatActivity {
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? android.R.color.black : android.R.color.white;
                 case STYLE_CLASSIC:
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.blue_50 : R.color.blue_20;
+                case STYLE_SEPIA:
+                    return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.orange_50 : R.color.orange_20;
                 case STYLE_DEFAULT:
                 default:
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.simplenote_blue_50 : R.color.simplenote_blue_20;

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -22,6 +22,7 @@ import static com.automattic.simplenote.models.Note.PINNED_INDEX_NAME;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_BLACK;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_CLASSIC;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_DEFAULT;
+import static com.automattic.simplenote.utils.ThemeUtils.STYLE_SEPIA;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 @SuppressWarnings("unused")
@@ -173,6 +174,8 @@ public class PrefUtils {
                 return context.getString(R.string.style_black);
             case STYLE_CLASSIC:
                 return context.getString(R.string.style_classic);
+            case STYLE_SEPIA:
+                return context.getString(R.string.style_sepia);
             case STYLE_DEFAULT:
             default:
                 return context.getString(R.string.style_default);

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -20,12 +20,14 @@ import static android.content.res.Configuration.UI_MODE_NIGHT_MASK;
 import static android.content.res.Configuration.UI_MODE_NIGHT_YES;
 
 public class ThemeUtils {
-    public static final int STYLE_BLACK = 1;
-    public static final int STYLE_CLASSIC = 2;
+    public static final int STYLE_BLACK = 2;
+    public static final int STYLE_CLASSIC = 3;
     public static final int STYLE_DEFAULT = 0;
+    public static final int STYLE_SEPIA = 1;
 
     public static final int[] STYLE_ARRAY = {
         STYLE_DEFAULT,
+        STYLE_SEPIA,
         STYLE_BLACK,
         STYLE_CLASSIC
     };
@@ -119,6 +121,8 @@ public class ThemeUtils {
         switch (PrefUtils.getStyleIndexSelected(context)) {
             case STYLE_BLACK:
                 return isLight ? "light.css" : "dark_black.css";
+            case STYLE_SEPIA:
+                return isLight ? "light_sepia.css" : "dark_sepia.css";
             case STYLE_CLASSIC:
             case STYLE_DEFAULT:
             default:
@@ -135,6 +139,8 @@ public class ThemeUtils {
                     return R.style.Style_Black;
                 case STYLE_CLASSIC:
                     return R.style.Style_Classic;
+                case STYLE_SEPIA:
+                    return R.style.Style_Sepia;
                 case STYLE_DEFAULT:
                 default:
                     return R.style.Style_Default;

--- a/Simplenote/src/main/res/drawable-night/bg_style_sepia.xml
+++ b/Simplenote/src/main/res/drawable-night/bg_style_sepia.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <corners
+        android:radius="@dimen/corner_radius">
+    </corners>
+
+    <solid
+        android:color="?attr/mainBackgroundColor">
+    </solid>
+
+    <stroke
+        android:color="@color/style_stroke_dark"
+        android:width="@dimen/style_stroke">
+    </stroke>
+
+</shape>

--- a/Simplenote/src/main/res/drawable/bg_list_sepia.xml
+++ b/Simplenote/src/main/res/drawable/bg_list_sepia.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ripple
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/background_list_sepia_ripple">
+
+    <item
+        android:id="@android:id/mask"
+        android:drawable="?attr/mainBackgroundColor">
+    </item>
+
+    <item>
+
+        <selector>
+
+            <item
+                android:drawable="@color/background_list_sepia_activated"
+                android:state_activated="true">
+            </item>
+
+            <item
+                android:drawable="@android:color/transparent">
+            </item>
+
+        </selector>
+
+    </item>
+
+</ripple>

--- a/Simplenote/src/main/res/drawable/bg_list_style_sepia.xml
+++ b/Simplenote/src/main/res/drawable/bg_list_style_sepia.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:drawable="@drawable/bg_style_activated"
+        android:state_activated="true">
+    </item>
+
+    <item
+        android:drawable="@drawable/bg_style_sepia">
+    </item>
+
+</selector>

--- a/Simplenote/src/main/res/drawable/bg_style_sepia.xml
+++ b/Simplenote/src/main/res/drawable/bg_style_sepia.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <corners
+        android:radius="@dimen/corner_radius">
+    </corners>
+
+    <solid
+        android:color="@color/background_light_sepia">
+    </solid>
+
+    <stroke
+        android:color="@color/style_stroke_light"
+        android:width="@dimen/style_stroke">
+    </stroke>
+
+</shape>

--- a/Simplenote/src/main/res/layout/style_list_row_sepia.xml
+++ b/Simplenote/src/main/res/layout/style_list_row_sepia.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@drawable/bg_list_style_sepia"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/padding_small"
+    android:layout_marginEnd="@dimen/padding_large"
+    android:layout_marginStart="@dimen/padding_large"
+    android:layout_marginTop="@dimen/padding_small"
+    android:layout_width="match_parent"
+    app:cardCornerRadius="@dimen/corner_radius"
+    app:cardElevation="0dp"
+    style="@style/Style.Sepia">
+
+    <RelativeLayout
+        android:background="@drawable/bg_list_style_default"
+        android:foreground="?attr/selectableItemBackground"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:padding="@dimen/padding_large">
+
+        <com.automattic.simplenote.widgets.RobotoMediumTextView
+            android:id="@+id/preview_title"
+            android:ellipsize="end"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/padding_small"
+            android:layout_width="match_parent"
+            android:maxLines="1"
+            android:textColor="@color/style_preview_default_title"
+            android:textSize="@dimen/text_content_title"
+            android:textStyle="bold"
+            tools:text="@string/style_sepia">
+        </com.automattic.simplenote.widgets.RobotoMediumTextView>
+
+        <com.automattic.simplenote.widgets.RobotoRegularTextView
+            android:id="@+id/preview_content"
+            android:ellipsize="end"
+            android:layout_below="@id/preview_title"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:maxLines="2"
+            android:text="@string/style_preview"
+            android:textColor="@color/style_preview_default_content">
+        </com.automattic.simplenote.widgets.RobotoRegularTextView>
+
+        <ImageView
+            android:id="@+id/preview_locked"
+            android:background="@drawable/bg_style_locked"
+            android:contentDescription="@string/description_locked"
+            android:layout_centerInParent="true"
+            android:layout_height="@dimen/icon_locked"
+            android:layout_width="@dimen/icon_locked"
+            android:padding="@dimen/padding_medium"
+            android:src="@drawable/ic_lock_24dp"
+            android:visibility="gone"
+            tools:visibility="visible">
+        </ImageView>
+
+    </RelativeLayout>
+
+</androidx.cardview.widget.CardView>

--- a/Simplenote/src/main/res/values-night/colors.xml
+++ b/Simplenote/src/main/res/values-night/colors.xml
@@ -7,6 +7,8 @@
     <color name="background_list_black_ripple">@color/background_dark_black_2</color>
     <color name="background_list_classic_activated">@color/blue_70</color>
     <color name="background_list_classic_ripple">@color/blue_60</color>
+    <color name="background_list_sepia_activated">@color/background_dark_highlight_sepia</color>
+    <color name="background_list_sepia_ripple">@color/background_dark_highlight_sepia</color>
     <color name="background_list_default">@color/background_dark_highlight</color>
     <color name="style_preview_black_content">@android:color/white</color>
     <color name="style_preview_black_title">@android:color/white</color>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -161,8 +161,40 @@
         <item name="toolbarIconColor">@color/item_classic_dark</item>
     </style>
 
+    <style name="Style.Sepia" parent="Theme.Simplestyle">
+        <item name="android:navigationBarColor">?attr/mainBackgroundColor</item>
+        <item name="android:windowBackground">@color/background_dark_sepia</item>
+        <item name="actionModeBackgroundColor">@color/background_dark_sepia_4</item>
+        <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
+        <item name="actionModeTextColor">@color/item_sepia_dark</item>
+        <item name="chipCheckedOnBackgroundColor">@color/background_dark_sepia_24</item>
+        <item name="chipCheckedOffBackgroundColor">@color/background_dark_sepia_8</item>
+        <item name="colorAccent">@color/item_sepia_dark</item>
+        <item name="colorPrimary">@color/orange</item>
+        <item name="colorPrimaryDark">@color/background_dark_sepia_1</item>
+        <item name="drawerBackgroundColor">@color/background_dark_sepia_1</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_accent</item>
+        <item name="editorSearchHighlightBackgroundColor">@color/orange_60</item>
+        <item name="editorSearchHighlightForegroundColor">@color/orange_5</item>
+        <item name="emptyImageColor">@color/empty_dark_sepia</item>
+        <item name="fabColor">@color/item_sepia_dark</item>
+        <item name="fabIconColor">@color/gray_100</item>
+        <item name="iconTintColor">@color/item_sepia_dark</item>
+        <item name="listBackgroundSelector">@drawable/bg_list_sepia</item>
+        <item name="listSearchHighlightBackgroundColor">@color/orange_60</item>
+        <item name="listSearchHighlightForegroundColor">@color/orange_5</item>
+        <item name="mainBackgroundColor">@color/background_dark_sepia</item>
+        <item name="sheetBackgroundColor">@color/background_dark_sepia_8</item>
+        <item name="toolbarColor">@color/background_dark_sepia_4</item>
+        <item name="toolbarPopupTheme">@style/ToolbarTheme.Popup.Sepia</item>
+    </style>
+
     <style name="ToolbarTheme.Popup" parent="ThemeOverlay.MaterialComponents">
         <item name="android:backgroundTint">@color/background_dark_8</item>
+    </style>
+
+    <style name="ToolbarTheme.Popup.Sepia" parent="ThemeOverlay.MaterialComponents">
+        <item name="android:backgroundTint">@color/background_dark_sepia_8</item>
     </style>
 
 </resources>

--- a/Simplenote/src/main/res/values-v27/styles.xml
+++ b/Simplenote/src/main/res/values-v27/styles.xml
@@ -2,6 +2,32 @@
 
 <resources>
 
+    <style name="Style.Sepia" parent="Theme.Simplestyle">
+        <item name="android:navigationBarColor">?attr/mainBackgroundColor</item>
+        <item name="android:windowBackground">@color/background_light_sepia</item>
+        <item name="actionModeBackgroundColor">@color/background_light_sepia</item>
+        <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
+        <item name="actionModeTextColor">@color/item_sepia_light</item>
+        <item name="colorAccent">@color/item_sepia_light</item>
+        <item name="colorPrimary">@color/orange</item>
+        <item name="colorPrimaryDark">@color/background_light_sepia</item>
+        <item name="drawerBackgroundColor">@color/background_light_sepia</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_accent</item>
+        <item name="editorSearchHighlightBackgroundColor">@color/orange_5</item>
+        <item name="editorSearchHighlightForegroundColor">@color/orange_60</item>
+        <item name="emptyImageColor">@color/empty_light_sepia</item>
+        <item name="fabColor">@color/item_sepia_light</item>
+        <item name="fabIconColor">@android:color/white</item>
+        <item name="iconTintColor">@color/item_sepia_light</item>
+        <item name="listBackgroundSelector">@drawable/bg_list_sepia</item>
+        <item name="listSearchHighlightBackgroundColor">@color/orange_5</item>
+        <item name="listSearchHighlightForegroundColor">@color/orange_60</item>
+        <item name="mainBackgroundColor">@color/background_light_sepia</item>
+        <item name="sheetBackgroundColor">@color/background_light_sepia</item>
+        <item name="toolbarColor">@color/background_light_sepia</item>
+        <item name="toolbarPopupTheme">@style/ToolbarTheme.Popup.Sepia</item>
+    </style>
+
     <style name="Theme.Simplestyle" parent="Base.Theme.Simplestyle">
         <item name="android:navigationBarColor">@color/background_light</item>
         <item name="android:statusBarColor">@android:color/transparent</item>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -33,6 +33,16 @@
     <color name="background_dark_black_12">#37393b</color>
     <color name="background_dark_black_16">#3a3c3e</color>
     <color name="background_dark_black_24">#3d3f41</color>
+    <color name="background_dark_sepia_0">#1c1a17</color>
+    <color name="background_dark_sepia_1">#23211f</color>
+    <color name="background_dark_sepia_2">#282624</color>
+    <color name="background_dark_sepia_3">#2b2927</color>
+    <color name="background_dark_sepia_4">#2d2b29</color>
+    <color name="background_dark_sepia_6">#33302e</color>
+    <color name="background_dark_sepia_8">#343230</color>
+    <color name="background_dark_sepia_12">#393735</color>
+    <color name="background_dark_sepia_16">#3f3d3b</color>
+    <color name="background_dark_sepia_24">#42403e</color>
 
     <!-- PASSCODE -->
     <color name="passcodelock_background">@color/blue</color>
@@ -48,13 +58,18 @@
     <color name="background_dark">@color/background_dark_1</color>
     <color name="background_dark_highlight">@color/background_dark_8</color>
     <color name="background_dark_highlight_drawer">#4d5152</color>
+    <color name="background_dark_highlight_sepia">@color/background_dark_sepia_8</color>
+    <color name="background_dark_sepia">@color/background_dark_sepia_1</color>
     <color name="background_light">@android:color/white</color>
     <color name="background_light_highlight">@color/simplenote_blue_5</color>
+    <color name="background_light_sepia">#fdf9f2</color>
     <color name="background_list_black_activated">@color/gray_10</color>
     <color name="background_list_black_ripple">@color/gray_5</color>
     <color name="background_list_classic_activated">@color/blue_5</color>
     <color name="background_list_classic_ripple">@color/blue_0</color>
     <color name="background_list_default">@color/background_light_highlight</color>
+    <color name="background_list_sepia_activated">@color/orange_5</color>
+    <color name="background_list_sepia_ripple">@color/orange_0</color>
     <color name="chip_dark_checked_off">#24ffffff</color>
     <color name="chip_dark_checked_on">#33ffffff</color>
     <color name="chip_light_checked_off">#24000000</color>
@@ -63,7 +78,9 @@
     <color name="divider_light">@color/gray_5</color>
     <color name="empty_dark">@color/gray_60</color>
     <color name="empty_dark_black">#484848</color>
+    <color name="empty_dark_sepia">@color/background_dark_sepia_12</color>
     <color name="empty_light">@color/gray_5</color>
+    <color name="empty_light_sepia">#d5d0ca</color>
     <color name="item_black_dark">@android:color/white</color>
     <color name="item_black_light">@android:color/black</color>
     <color name="item_classic_dark">@color/blue_20</color>
@@ -74,6 +91,8 @@
     <color name="item_mono_light">@color/gray_50</color>
     <color name="item_publication_dark">@color/red_20</color>
     <color name="item_publication_light">@color/red_50</color>
+    <color name="item_sepia_dark">@color/orange_20</color>
+    <color name="item_sepia_light">@color/orange_50</color>
     <color name="ripple_overlay">#44000000</color>
     <color name="status_negative">@color/red</color>
     <color name="status_positive">@color/green</color>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -125,6 +125,7 @@
     <string name="style_dialog_locked_message">This style is locked. Premium membership is required to unlock it. Would you like to change your membership?</string>
     <string name="style_dialog_locked_title">Style Locked</string>
     <string name="style_preview">![Image](%1$s%2$s%3$shttps://img_url.com/jpg%4$s) Aliquam erat volutpat. Pellentesque ut odio suscipit.</string>
+    <string name="style_sepia">Sepia</string>
 
     <!-- Themes -->
     <string name="theme_light">Light</string>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -385,4 +385,33 @@
     <style name="Style.Default" parent="Theme.Simplestyle">
     </style>
 
+    <style name="Style.Sepia" parent="Theme.Simplestyle">
+        <item name="android:windowBackground">@color/background_light_sepia</item>
+        <item name="actionModeBackgroundColor">@color/background_light_sepia</item>
+        <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
+        <item name="actionModeTextColor">@color/item_sepia_light</item>
+        <item name="colorAccent">@color/item_sepia_light</item>
+        <item name="colorPrimary">@color/orange</item>
+        <item name="colorPrimaryDark">@color/background_light_sepia</item>
+        <item name="drawerBackgroundColor">@color/background_light_sepia</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_accent</item>
+        <item name="editorSearchHighlightBackgroundColor">@color/orange_5</item>
+        <item name="editorSearchHighlightForegroundColor">@color/orange_60</item>
+        <item name="emptyImageColor">@color/empty_light_sepia</item>
+        <item name="fabColor">@color/item_sepia_light</item>
+        <item name="fabIconColor">@android:color/white</item>
+        <item name="iconTintColor">@color/item_sepia_light</item>
+        <item name="listBackgroundSelector">@drawable/bg_list_sepia</item>
+        <item name="listSearchHighlightBackgroundColor">@color/orange_5</item>
+        <item name="listSearchHighlightForegroundColor">@color/orange_60</item>
+        <item name="mainBackgroundColor">@color/background_light_sepia</item>
+        <item name="sheetBackgroundColor">@color/background_light_sepia</item>
+        <item name="toolbarColor">@color/background_light_sepia</item>
+        <item name="toolbarPopupTheme">@style/ToolbarTheme.Popup.Sepia</item>
+    </style>
+
+    <style name="ToolbarTheme.Popup.Sepia" parent="ThemeOverlay.MaterialComponents">
+        <item name="android:backgroundTint">@color/background_light_sepia</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
### Fix
This is the third part in a series of pull requests to add a style setting to the app.  The pull requests are split into parts in an attempt to make the changes smaller.  This part adds the ***Sepia*** style.  See the screenshots below for illustration.

![add_style_setting_all_03](https://user-images.githubusercontent.com/3827611/90216661-68333d00-ddbc-11ea-805a-7dce2264dd5d.png)

#### Note
Contact me for an installable build.

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in drawer.
3. Tap ***Style*** item under ***Appearance*** section.
4. Notice ***Style*** screen with ***Default***, ***Sepia***, ***Black***, and ***Classic*** styles.
5. Tap ***Sepia*** style.
6. Notice ***Sepia*** style is selected and app has ***Sepia*** styling.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.  `RELEASE-NOTES.txt` will be updated once the styles feature is complete.