### PR TITLE
Update Copy Clipboard

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -37,6 +37,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.view.ActionMode;
 import androidx.core.app.ShareCompat;
@@ -216,19 +217,26 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
                         mode.finish(); // Action picked, so close the CAB
                     }
+
                     return true;
                 case R.id.menu_copy:
                     if (mLinkText != null && getActivity() != null) {
-                        BrowserUtils.copyToClipboard(requireContext(), mLinkText);
-                        Snackbar.make(mRootView, R.string.link_copied, Snackbar.LENGTH_SHORT).show();
+                        if (BrowserUtils.copyToClipboard(requireContext(), mLinkText)) {
+                            Snackbar.make(mRootView, R.string.link_copied, Snackbar.LENGTH_SHORT).show();
+                        } else {
+                            Snackbar.make(mRootView, R.string.link_copied_failure, Snackbar.LENGTH_SHORT).show();
+                        }
+
                         mode.finish();
                     }
+
                     return true;
                 case R.id.menu_share:
                     if (mLinkText != null) {
                         showShare(mLinkText);
                         mode.finish();
                     }
+
                     return true;
                 default:
                     return false;
@@ -526,8 +534,12 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 insertChecklist();
                 return true;
             case R.id.menu_copy:
-                BrowserUtils.copyToClipboard(requireContext(), mNote.getPublishedUrl());
-                Snackbar.make(mRootView, R.string.link_copied, Snackbar.LENGTH_SHORT).show();
+                if (BrowserUtils.copyToClipboard(requireContext(), mNote.getPublishedUrl())) {
+                    Snackbar.make(mRootView, R.string.link_copied, Snackbar.LENGTH_SHORT).show();
+                } else {
+                    Snackbar.make(mRootView, R.string.link_copied_failure, Snackbar.LENGTH_SHORT).show();
+                }
+
                 return true;
             case R.id.menu_history:
                 showHistory();
@@ -1227,25 +1239,30 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         if (isSuccess && isAdded()) {
             if (mNote.isPublished()) {
-                if (mHideActionOnSuccess) {
-                    Snackbar.make(mRootView, R.string.publish_successful, Snackbar.LENGTH_LONG)
-                            .show();
+                @StringRes int text;
+
+                if (BrowserUtils.copyToClipboard(requireContext(), mNote.getPublishedUrl())) {
+                    text = R.string.publish_successful_link;
                 } else {
-                    Snackbar.make(mRootView, R.string.publish_successful, Snackbar.LENGTH_LONG)
-                            .setAction(
-                                R.string.undo,
-                                new View.OnClickListener() {
-                                    @Override
-                                    public void onClick(View v) {
-                                        mHideActionOnSuccess = true;
-                                        unpublishNote();
-                                    }
-                                }
-                            )
-                            .show();
+                    text = R.string.publish_successful;
                 }
 
-                BrowserUtils.copyToClipboard(requireContext(), mNote.getPublishedUrl());
+                if (mHideActionOnSuccess) {
+                    Snackbar.make(mRootView, text, Snackbar.LENGTH_LONG).show();
+                } else {
+                    Snackbar.make(mRootView, text, Snackbar.LENGTH_LONG)
+                        .setAction(
+                            R.string.undo,
+                            new View.OnClickListener() {
+                                @Override
+                                public void onClick(View v) {
+                                    mHideActionOnSuccess = true;
+                                    unpublishNote();
+                                }
+                            }
+                        )
+                        .show();
+                }
             } else {
                 if (mHideActionOnSuccess) {
                     Snackbar.make(mRootView, R.string.unpublish_successful, Snackbar.LENGTH_LONG)

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/BrowserUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/BrowserUtils.java
@@ -20,7 +20,7 @@ public class BrowserUtils {
         return (intent.resolveActivity(context.getPackageManager()) != null);
     }
 
-    public static void copyToClipboard(Context base, String url) {
+    public static boolean copyToClipboard(Context base, String url) {
         Context context = new ContextThemeWrapper(base, base.getTheme());
 
         try {
@@ -29,11 +29,12 @@ public class BrowserUtils {
 
             if (clipboard != null) {
                 clipboard.setPrimaryClip(clip);
+                return true;
+            } else {
+                return false;
             }
-
-            Toast.makeText(context, R.string.simperium_error_browser_copy_success, Toast.LENGTH_SHORT).show();
         } catch (Exception e) {
-            Toast.makeText(context, R.string.simperium_error_browser_copy_failure, Toast.LENGTH_SHORT).show();
+            return  false;
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/BrowserUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/BrowserUtils.java
@@ -55,7 +55,11 @@ public class BrowserUtils {
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        copyToClipboard(context, url);
+                        if (copyToClipboard(context, url)) {
+                            Toast.makeText(context, R.string.simperium_error_browser_copy_success, Toast.LENGTH_SHORT).show();
+                        } else {
+                            Toast.makeText(context, R.string.simperium_error_browser_copy_failure, Toast.LENGTH_SHORT).show();
+                        }
                     }
                 }
             )

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="view_in_browser">View in Browser</string>
     <string name="link">Link</string>
     <string name="link_copied">Link copied!</string>
+    <string name="link_copied_failure">Link could not be copied.</string>
     <string name="copy">Copy</string>
 
     <!-- account setup -->
@@ -156,7 +157,8 @@
     <string name="published">Published</string>
     <string name="publish_error">Could not create link.</string>
     <string name="unpublish_error">Could not remove link.</string>
-    <string name="publish_successful">Published. Link copied!</string>
+    <string name="publish_successful">Published.</string>
+    <string name="publish_successful_link">Published. Link copied!</string>
     <string name="unpublish_successful">Public link removed.</string>
     <string name="publishing">Publishing&#8230;</string>
     <string name="unpublishing">Removing public link&#8230;</string>


### PR DESCRIPTION
### Fix
Update the `BrowserUtils.copyToClipboard` method to return a `boolean` based on success or failure of copying the text to the clipboard.  These changes are to address that a toast message is shown over the snackbar when publishing/unpublishing a note.  See the screenshot below for illustration of the bug.

<kbd><a href="https://user-images.githubusercontent.com/3827611/90270715-df49ef00-de17-11ea-8a81-5afde2bfd16b.png"><img src="https://user-images.githubusercontent.com/3827611/90270715-df49ef00-de17-11ea-8a81-5afde2bfd16b.png" width="300"></a></kbd>

Now, the return value is used to show a single success or failure toast or snackbar.

### Test
In all test below, notice a toast is not shown over the snackbar.
#### Publish [Success]
1. Tap unpublished note in list.
2. Tap overflow menu action.
3. Tap ***Publish*** item in menu.
4. Notice snackbar is shown with  ***Publishing...*** message.
5. Notice snackbar is shown with ***Published. Link copied!*** message and ***Undo*** action.
6. Tap ***Undo*** action in snackbar.
7. Notice snackbar is shown with ***Removing public link...*** message.
8. Notice snackbar is shown with ***Public link removed.*** message.

#### Publish [Failure]
1. Tap unpublished note in list.
2. Tap overflow menu action.
3. Tap ***Publish*** item in menu.
4. Notice snackbar is shown with  ***Publishing...*** message.
5. Notice snackbar is shown with ***Could not create link.*** message and ***Retry*** action.
6. Tap ***Retry*** action in snackbar.
7. Notice snackbar is shown with ***Publishing...*** message.

#### Unpublish [Success]
1. Tap published note in list.
2. Tap overflow menu action.
3. Tap ***Publish*** item in menu.
4. Notice snackbar is shown with  ***Removing public link...*** message.
5. Notice snackbar is shown with ***Public link removed*** message and ***Undo*** action.
6. Tap ***Undo*** action in snackbar.
7. Notice snackbar is shown with ***Publishing...*** message.
8. Notice snackbar is shown with ***Published. Link copied!*** message.

#### Unpublish [Failure]
1. Tap published note in list.
2. Tap overflow menu action.
3. Tap ***Publish*** item in menu.
4. Notice snackbar is shown with  ***Removing public link...*** message.
5. Notice snackbar is shown with ***Could not create link.*** message and ***Retry*** action.
6. Tap ***Retry*** action in snackbar.
7. Notice snackbar is shown with ***Removing public link...*** message.

#### Copy Link
1. Tap published note in list.
2. Tap overflow menu action.
3. Tap ***Copy link*** item in menu.
4. Notice snackbar is shown with ***Link copied!*** message.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.