### PR TITLE
Add Style Setting (Part 4)

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/StyleActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/StyleActivity.java
@@ -36,6 +36,7 @@ import static com.automattic.simplenote.utils.ThemeUtils.STYLE_ARRAY;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_BLACK;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_CLASSIC;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_DEFAULT;
+import static com.automattic.simplenote.utils.ThemeUtils.STYLE_MONO;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_SEPIA;
 
 public class StyleActivity extends ThemedAppCompatActivity {
@@ -191,6 +192,13 @@ public class StyleActivity extends ThemedAppCompatActivity {
                             R.style.Style_Sepia)
                         ).inflate(R.layout.style_list_row_sepia, parent, false)
                     );
+                case STYLE_MONO:
+                    return new StyleHolder(LayoutInflater.from(
+                        new ContextThemeWrapper(
+                            parent.getContext(),
+                            R.style.Style_Mono)
+                        ).inflate(R.layout.style_list_row_mono, parent, false)
+                    );
                 case STYLE_DEFAULT:
                 default:
                     return new StyleHolder(LayoutInflater.from(
@@ -210,6 +218,8 @@ public class StyleActivity extends ThemedAppCompatActivity {
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.blue_50 : R.color.blue_20;
                 case STYLE_SEPIA:
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.orange_50 : R.color.orange_20;
+                case STYLE_MONO:
+                    return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.gray_50 : R.color.gray_20;
                 case STYLE_DEFAULT:
                 default:
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.simplenote_blue_50 : R.color.simplenote_blue_20;

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -22,6 +22,7 @@ import static com.automattic.simplenote.models.Note.PINNED_INDEX_NAME;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_BLACK;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_CLASSIC;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_DEFAULT;
+import static com.automattic.simplenote.utils.ThemeUtils.STYLE_MONO;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_SEPIA;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
@@ -176,6 +177,8 @@ public class PrefUtils {
                 return context.getString(R.string.style_classic);
             case STYLE_SEPIA:
                 return context.getString(R.string.style_sepia);
+            case STYLE_MONO:
+                return context.getString(R.string.style_mono);
             case STYLE_DEFAULT:
             default:
                 return context.getString(R.string.style_default);

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -20,13 +20,15 @@ import static android.content.res.Configuration.UI_MODE_NIGHT_MASK;
 import static android.content.res.Configuration.UI_MODE_NIGHT_YES;
 
 public class ThemeUtils {
-    public static final int STYLE_BLACK = 2;
-    public static final int STYLE_CLASSIC = 3;
+    public static final int STYLE_BLACK = 3;
+    public static final int STYLE_CLASSIC = 4;
     public static final int STYLE_DEFAULT = 0;
-    public static final int STYLE_SEPIA = 1;
+    public static final int STYLE_MONO = 1;
+    public static final int STYLE_SEPIA = 2;
 
     public static final int[] STYLE_ARRAY = {
         STYLE_DEFAULT,
+        STYLE_MONO,
         STYLE_SEPIA,
         STYLE_BLACK,
         STYLE_CLASSIC
@@ -125,6 +127,7 @@ public class ThemeUtils {
                 return isLight ? "light_sepia.css" : "dark_sepia.css";
             case STYLE_CLASSIC:
             case STYLE_DEFAULT:
+            case STYLE_MONO:
             default:
                 return isLight ? "light.css" : "dark.css";
         }
@@ -139,6 +142,8 @@ public class ThemeUtils {
                     return R.style.Style_Black;
                 case STYLE_CLASSIC:
                     return R.style.Style_Classic;
+                case STYLE_MONO:
+                    return R.style.Style_Mono;
                 case STYLE_SEPIA:
                     return R.style.Style_Sepia;
                 case STYLE_DEFAULT:

--- a/Simplenote/src/main/res/drawable/bg_list_mono.xml
+++ b/Simplenote/src/main/res/drawable/bg_list_mono.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ripple
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/background_list_mono_ripple">
+
+    <item
+        android:id="@android:id/mask"
+        android:drawable="?attr/mainBackgroundColor">
+    </item>
+
+    <item>
+
+        <selector>
+
+            <item
+                android:drawable="@color/background_list_mono_activated"
+                android:state_activated="true">
+            </item>
+
+            <item
+                android:drawable="@android:color/transparent">
+            </item>
+
+        </selector>
+
+    </item>
+
+</ripple>

--- a/Simplenote/src/main/res/layout/style_list_row_mono.xml
+++ b/Simplenote/src/main/res/layout/style_list_row_mono.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@drawable/bg_list_style_default"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/padding_small"
+    android:layout_marginEnd="@dimen/padding_large"
+    android:layout_marginStart="@dimen/padding_large"
+    android:layout_marginTop="@dimen/padding_small"
+    android:layout_width="match_parent"
+    app:cardCornerRadius="@dimen/corner_radius"
+    app:cardElevation="0dp"
+    style="@style/Style.Mono">
+
+    <RelativeLayout
+        android:background="@drawable/bg_list_style_default"
+        android:foreground="?attr/selectableItemBackground"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:padding="@dimen/padding_large">
+
+        <TextView
+            android:id="@+id/preview_title"
+            android:ellipsize="end"
+            android:fontFamily="monospace"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/padding_small"
+            android:layout_width="match_parent"
+            android:maxLines="1"
+            android:textColor="@color/style_preview_default_title"
+            android:textSize="@dimen/text_content_title"
+            android:textStyle="bold"
+            tools:text="@string/style_mono">
+        </TextView>
+
+        <TextView
+            android:id="@+id/preview_content"
+            android:ellipsize="end"
+            android:fontFamily="monospace"
+            android:layout_below="@id/preview_title"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:maxLines="2"
+            android:text="@string/style_preview"
+            android:textColor="@color/style_preview_default_content">
+        </TextView>
+
+        <ImageView
+            android:id="@+id/preview_locked"
+            android:background="@drawable/bg_style_locked"
+            android:contentDescription="@string/description_locked"
+            android:layout_centerInParent="true"
+            android:layout_height="@dimen/icon_locked"
+            android:layout_width="@dimen/icon_locked"
+            android:padding="@dimen/padding_medium"
+            android:src="@drawable/ic_lock_24dp"
+            android:visibility="gone"
+            tools:visibility="visible">
+        </ImageView>
+
+    </RelativeLayout>
+
+</androidx.cardview.widget.CardView>

--- a/Simplenote/src/main/res/values-night/colors.xml
+++ b/Simplenote/src/main/res/values-night/colors.xml
@@ -7,6 +7,8 @@
     <color name="background_list_black_ripple">@color/background_dark_black_2</color>
     <color name="background_list_classic_activated">@color/blue_70</color>
     <color name="background_list_classic_ripple">@color/blue_60</color>
+    <color name="background_list_mono_activated">@color/background_dark_highlight</color>
+    <color name="background_list_mono_ripple">@color/background_dark_highlight</color>
     <color name="background_list_sepia_activated">@color/background_dark_highlight_sepia</color>
     <color name="background_list_sepia_ripple">@color/background_dark_highlight_sepia</color>
     <color name="background_list_default">@color/background_dark_highlight</color>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -161,6 +161,23 @@
         <item name="toolbarIconColor">@color/item_classic_dark</item>
     </style>
 
+    <style name="Style.Mono" parent="Theme.Simplestyle">
+        <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
+        <item name="actionModeTextColor">@color/item_mono_dark</item>
+        <item name="colorAccent">@color/item_mono_dark</item>
+        <item name="colorPrimary">@color/gray</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_accent</item>
+        <item name="editorSearchHighlightBackgroundColor">@color/gray_60</item>
+        <item name="editorSearchHighlightForegroundColor">@color/gray_5</item>
+        <item name="fabColor">@color/item_mono_dark</item>
+        <item name="fabIconColor">@color/gray_100</item>
+        <item name="iconTintColor">@color/item_mono_dark</item>
+        <item name="listBackgroundSelector">@drawable/bg_list_mono</item>
+        <item name="listSearchHighlightBackgroundColor">@color/gray_60</item>
+        <item name="listSearchHighlightForegroundColor">@color/gray_5</item>
+        <item name="styleFontFamily">monospace</item>
+    </style>
+
     <style name="Style.Sepia" parent="Theme.Simplestyle">
         <item name="android:navigationBarColor">?attr/mainBackgroundColor</item>
         <item name="android:windowBackground">@color/background_dark_sepia</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -3,6 +3,7 @@
 <resources>
 
     <style name="Base.Theme.Simplestyle" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:alertDialogTheme">@style/Dialog</item>
         <item name="android:navigationBarColor">@color/background_dark</item>
         <item name="android:spinnerDropDownItemStyle">@style/SpinnerDropDownItem.Simplestyle</item>
         <item name="android:spinnerItemStyle">@style/SpinnerItem.Simplestyle</item>
@@ -14,6 +15,7 @@
         <item name="actionModeCloseDrawable">@drawable/ic_arrow_left_24dp</item>
         <item name="actionModeStyle">@style/ActionMode.Simplestyle</item>
         <item name="actionModeTextColor">@color/item_default_dark</item>
+        <item name="alertDialogTheme">@style/Dialog</item>
         <item name="bottomSheetDialogTheme">@style/Theme.MaterialComponents.BottomSheetDialog</item>
         <item name="chipCheckedOnBackgroundColor">@color/background_dark_24</item>
         <item name="chipCheckedOffBackgroundColor">@color/background_dark_8</item>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -68,6 +68,8 @@
     <color name="background_list_classic_activated">@color/blue_5</color>
     <color name="background_list_classic_ripple">@color/blue_0</color>
     <color name="background_list_default">@color/background_light_highlight</color>
+    <color name="background_list_mono_activated">@color/gray_5</color>
+    <color name="background_list_mono_ripple">@color/gray_0</color>
     <color name="background_list_sepia_activated">@color/orange_5</color>
     <color name="background_list_sepia_ripple">@color/orange_0</color>
     <color name="chip_dark_checked_off">#24ffffff</color>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -124,6 +124,7 @@
     <string name="style_default">Default</string>
     <string name="style_dialog_locked_message">This style is locked. Premium membership is required to unlock it. Would you like to change your membership?</string>
     <string name="style_dialog_locked_title">Style Locked</string>
+    <string name="style_mono">Mono</string>
     <string name="style_preview">![Image](%1$s%2$s%3$shttps://img_url.com/jpg%4$s) Aliquam erat volutpat. Pellentesque ut odio suscipit.</string>
     <string name="style_sepia">Sepia</string>
 

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -385,6 +385,23 @@
     <style name="Style.Default" parent="Theme.Simplestyle">
     </style>
 
+    <style name="Style.Mono" parent="Theme.Simplestyle">
+        <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
+        <item name="actionModeTextColor">@color/item_mono_light</item>
+        <item name="colorAccent">@color/item_mono_light</item>
+        <item name="colorPrimary">@color/gray</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_accent</item>
+        <item name="editorSearchHighlightBackgroundColor">@color/gray_5</item>
+        <item name="editorSearchHighlightForegroundColor">@color/gray_60</item>
+        <item name="fabColor">@color/item_mono_light</item>
+        <item name="fabIconColor">@android:color/white</item>
+        <item name="iconTintColor">@color/item_mono_light</item>
+        <item name="listBackgroundSelector">@drawable/bg_list_mono</item>
+        <item name="listSearchHighlightBackgroundColor">@color/gray_5</item>
+        <item name="listSearchHighlightForegroundColor">@color/gray_60</item>
+        <item name="styleFontFamily">monospace</item>
+    </style>
+
     <style name="Style.Sepia" parent="Theme.Simplestyle">
         <item name="android:windowBackground">@color/background_light_sepia</item>
         <item name="actionModeBackgroundColor">@color/background_light_sepia</item>


### PR DESCRIPTION
### Fix
This is the fourth part in a series of pull requests to add a style setting to the app.  The pull requests are split into parts in an attempt to make the changes smaller.  This part adds the ***Mono*** style.  See the screenshots below for illustration.

![add_style_setting_all_04_](https://user-images.githubusercontent.com/3827611/90299927-53ef4e80-de55-11ea-8378-1d03af7fcd38.png)

#### Note
Contact me for an installable build.

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in drawer.
3. Tap ***Style*** item under ***Appearance*** section.
4. Notice ***Style*** screen with ***Default***, ***Mono***, ***Sepia***, ***Black***, and ***Classic*** styles.
5. Tap ***Mono*** style.
6. Notice ***Mono*** style is selected and app has ***Mono*** styling.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.  `RELEASE-NOTES.txt` will be updated once the styles feature is complete.