### PR TITLE
Add App Log

### DIFF
--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     android:installLocation="auto">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/Simplenote/src/main/java/com/automattic/simplenote/AboutFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AboutFragment.java
@@ -22,6 +22,7 @@ import androidx.fragment.app.Fragment;
 
 import com.automattic.simplenote.utils.BrowserUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
+import com.automattic.simplenote.utils.PrefUtils;
 import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.widgets.SpinningImageButton;
 import com.automattic.simplenote.widgets.SpinningImageButton.SpeedListener;
@@ -60,7 +61,7 @@ public class AboutFragment extends Fragment implements SpeedListener {
         TextView copyright = view.findViewById(R.id.about_copyright);
 
         String colorLink = Integer.toHexString(ContextCompat.getColor(requireContext(), R.color.blue_5) & 0xffffff);
-        version.setText(String.format("%s %s", getString(R.string.version), BuildConfig.VERSION_NAME));
+        version.setText(PrefUtils.versionInfo());
         int thisYear = Calendar.getInstance().get(Calendar.YEAR);
         copyright.setText(String.format(Locale.getDefault(), getString(R.string.about_copyright), thisYear));
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
@@ -15,10 +15,9 @@ import androidx.fragment.app.FragmentManager;
 
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.utils.DateTimeUtils;
+import com.automattic.simplenote.utils.NoteUtils;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
-
-import java.text.NumberFormat;
 
 public class InfoBottomSheetDialog extends BottomSheetDialogBase {
     public static final String TAG = InfoBottomSheetDialog.class.getSimpleName();
@@ -68,19 +67,10 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
     public void show(FragmentManager manager, Note note) {
         if (mFragment.isAdded()) {
             showNow(manager, TAG);
-            mCountCharacters.setText(getCharactersCount(note.getContent()));
-            mCountWords.setText(getWordCount(note.getContent()));
+            mCountCharacters.setText(NoteUtils.getCharactersCount(note.getContent()));
+            mCountWords.setText(NoteUtils.getWordCount(note.getContent()));
             mDateTimeCreated.setText(DateTimeUtils.getDateTextString(requireContext(), note.getCreationDate()));
             mDateTimeModified.setText(DateTimeUtils.getDateTextString(requireContext(), note.getModificationDate()));
         }
-    }
-
-    private String getWordCount(String content) {
-        int words = (content.trim().length() == 0) ? 0 : content.trim().split("([\\W]+)").length;
-        return NumberFormat.getInstance().format(words);
-    }
-
-    private String getCharactersCount(String content) {
-        return NumberFormat.getInstance().format(content.length());
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -76,6 +76,7 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
         super.onCreate(savedInstanceState);
 
         AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(NoteEditorActivity.this));
+        AppLog.add(Type.SCREEN, "Created (NoteEditorActivity)");
         setContentView(R.layout.activity_note_editor);
 
         // No title, please.
@@ -220,9 +221,12 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
     @Override
     protected void onPause() {
         super.onPause();
+
         if (AppLockManager.getInstance().isAppLockFeatureEnabled()) {
             AppLockManager.getInstance().getAppLock().setExemptActivities(null);
         }
+
+        AppLog.add(Type.SCREEN, "Paused (NoteEditorActivity)");
     }
 
     @Override
@@ -230,6 +234,7 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
         super.onResume();
         disableScreenshotsIfLocked(this);
         AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(NoteEditorActivity.this));
+        AppLog.add(Type.SCREEN, "Resumed (NoteEditorActivity)");
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -21,7 +21,10 @@ import androidx.viewpager.widget.PagerAdapter;
 
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
+import com.automattic.simplenote.utils.AppLog;
+import com.automattic.simplenote.utils.AppLog.Type;
 import com.automattic.simplenote.utils.DisplayUtils;
+import com.automattic.simplenote.utils.NetworkUtils;
 import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.widgets.NoteEditorViewPager;
 import com.automattic.simplenote.widgets.RobotoMediumTextView;
@@ -72,6 +75,7 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
         ThemeUtils.setTheme(this);
         super.onCreate(savedInstanceState);
 
+        AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(NoteEditorActivity.this));
         setContentView(R.layout.activity_note_editor);
 
         // No title, please.
@@ -225,6 +229,7 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
     protected void onResume() {
         super.onResume();
         disableScreenshotsIfLocked(this);
+        AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(NoteEditorActivity.this));
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -219,6 +219,12 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
     }
 
     @Override
+    public void onBackPressed() {
+        AppLog.add(Type.ACTION, "Tapped back button in navigation bar (NoteEditorActivity)");
+        super.onBackPressed();
+    }
+
+    @Override
     protected void onPause() {
         super.onPause();
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1171,7 +1171,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
                 AppLog.add(
                     Type.SYNC,
-                    "Saved note locally (Title: " + mNote.getTitle() +
+                    "Saved note locally in NoteEditorFragment (Title: " + mNote.getTitle() +
                         " / Characters: " + NoteUtils.getCharactersCount(content) +
                         " / Words: " + NoteUtils.getWordCount(content) + ")"
                 );
@@ -1447,7 +1447,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         AppLog.add(
             Type.SYNC,
-            "Saved note callback (Title: " + note.getTitle() +
+            "Saved note callback in NoteEditorFragment (Title: " + note.getTitle() +
                 " / Characters: " + NoteUtils.getCharactersCount(note.getContent()) +
                 " / Words: " + NoteUtils.getWordCount(note.getContent()) + ")"
         );

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -394,6 +394,13 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             }
 
             mIsFromWidget = arguments.getBoolean(ARG_IS_FROM_WIDGET);
+
+            if (mIsFromWidget) {
+                AppLog.add(Type.ACTION, "Opened from widget (NoteEditorFragment)");
+            } else {
+                AppLog.add(Type.ACTION, "Opened from list (NoteEditorFragment)");
+            }
+
             new LoadNoteTask(this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, key);
         } else if (DisplayUtils.isLargeScreenLandscape(getActivity()) && savedInstanceState != null) {
             // Restore selected note when in dual pane mode
@@ -581,6 +588,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 deleteNote();
                 return true;
             case android.R.id.home:
+                AppLog.add(Type.ACTION, "Tapped back arrow in app bar (NoteEditorFragment)");
                 if (!isAdded()) {
                     return false;
                 }
@@ -977,6 +985,12 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             return;
         }
 
+        AppLog.add(
+            Type.ACTION,
+            "Edited note (Title: " + mNote.getTitle() +
+                " / Characters: " + NoteUtils.getCharactersCount(mNote.getContent()) +
+                " / Words: " + NoteUtils.getWordCount(mNote.getContent()) + ")"
+        );
         new SaveNoteTask(this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -50,6 +50,8 @@ import androidx.preference.PreferenceManager;
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
+import com.automattic.simplenote.utils.AppLog;
+import com.automattic.simplenote.utils.AppLog.Type;
 import com.automattic.simplenote.utils.AutoBullet;
 import com.automattic.simplenote.utils.BrowserUtils;
 import com.automattic.simplenote.utils.ContextUtils;
@@ -444,6 +446,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     public void onResume() {
         super.onResume();
         mNotesBucket.start();
+        AppLog.add(Type.SYNC, "Started note bucket (NoteEditorFragment)");
         mNotesBucket.addListener(this);
         mTagInput.setOnTagAddedListener(this);
 
@@ -504,6 +507,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         super.onDestroy();
         mNotesBucket.removeListener(this);
         mNotesBucket.stop();
+        AppLog.add(Type.SYNC, "Stopped note bucket (NoteEditorFragment)");
     }
 
     @Override
@@ -1146,6 +1150,13 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                     CATEGORY_NOTE,
                     "editor_save"
                 );
+
+                AppLog.add(
+                    Type.SYNC,
+                    "Saved note (Title: " + mNote.getTitle() +
+                        " / Characters: " + NoteUtils.getCharactersCount(content) +
+                        " / Words: " + NoteUtils.getWordCount(content) + ")"
+                );
             }
         } catch (BucketObjectMissingException exception) {
             exception.printStackTrace();
@@ -1413,6 +1424,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         if (mIsPaused) {
             mNotesBucket.removeListener(this);
             mNotesBucket.stop();
+            AppLog.add(Type.SYNC, "Stopped note bucket (NoteEditorFragment)");
         }
     }
 
@@ -1470,6 +1482,12 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 if (fragment.mNote != null) {
                     fragment.mIsMarkdownEnabled = fragment.mNote.isMarkdownEnabled();
                     fragment.mIsPreviewEnabled = fragment.mNote.isPreviewEnabled();
+                    AppLog.add(
+                        Type.SYNC,
+                        "Loaded note (Title: " + fragment.mNote.getTitle() +
+                            " / Characters: " + NoteUtils.getCharactersCount(fragment.mNote.getContent()) +
+                            " / Words: " + NoteUtils.getWordCount(fragment.mNote.getContent()) + ")"
+                    );
                 }
             } catch (BucketObjectMissingException e) {
                 // See if the note is in the object store

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -987,7 +987,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         AppLog.add(
             Type.ACTION,
-            "Edited note (Title: " + mNote.getTitle() +
+            "Edited note (ID: " + mNote.getSimperiumKey() +
+                " / Title: " + mNote.getTitle() +
                 " / Characters: " + NoteUtils.getCharactersCount(mNote.getContent()) +
                 " / Words: " + NoteUtils.getWordCount(mNote.getContent()) + ")"
         );
@@ -1171,7 +1172,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
                 AppLog.add(
                     Type.SYNC,
-                    "Saved note locally in NoteEditorFragment (Title: " + mNote.getTitle() +
+                    "Saved note locally in NoteEditorFragment (ID: " + mNote.getSimperiumKey() +
+                        " / Title: " + mNote.getTitle() +
                         " / Characters: " + NoteUtils.getCharactersCount(content) +
                         " / Words: " + NoteUtils.getWordCount(content) + ")"
                 );
@@ -1447,7 +1449,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         AppLog.add(
             Type.SYNC,
-            "Saved note callback in NoteEditorFragment (Title: " + note.getTitle() +
+            "Saved note callback in NoteEditorFragment (ID: " + note.getSimperiumKey() +
+                " / Title: " + note.getTitle() +
                 " / Characters: " + NoteUtils.getCharactersCount(note.getContent()) +
                 " / Words: " + NoteUtils.getWordCount(note.getContent()) + ")"
         );
@@ -1509,7 +1512,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                     fragment.mIsPreviewEnabled = fragment.mNote.isPreviewEnabled();
                     AppLog.add(
                         Type.SYNC,
-                        "Loaded note (Title: " + fragment.mNote.getTitle() +
+                        "Loaded note (ID: " + fragment.mNote.getSimperiumKey() +
+                            " / Title: " + fragment.mNote.getTitle() +
                             " / Characters: " + NoteUtils.getCharactersCount(fragment.mNote.getContent()) +
                             " / Words: " + NoteUtils.getWordCount(fragment.mNote.getContent()) + ")"
                     );

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -295,6 +295,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(requireContext()));
+        AppLog.add(Type.SCREEN, "Created (NoteEditorFragment)");
         mInfoBottomSheet = new InfoBottomSheetDialog(this);
         mShareBottomSheet = new ShareBottomSheetDialog(this, this);
         mHistoryBottomSheet = new HistoryBottomSheetDialog(this, this);
@@ -501,6 +502,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         mHighlighter.stop();
         saveNote();
+        AppLog.add(Type.SCREEN, "Paused (NoteEditorFragment)");
     }
 
     @Override
@@ -509,6 +511,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mNotesBucket.removeListener(this);
         mNotesBucket.stop();
         AppLog.add(Type.SYNC, "Stopped note bucket (NoteEditorFragment)");
+        AppLog.add(Type.SCREEN, "Destroyed (NoteEditorFragment)");
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1171,7 +1171,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
                 AppLog.add(
                     Type.SYNC,
-                    "Saved note (Title: " + mNote.getTitle() +
+                    "Saved note locally (Title: " + mNote.getTitle() +
                         " / Characters: " + NoteUtils.getCharactersCount(content) +
                         " / Words: " + NoteUtils.getWordCount(content) + ")"
                 );
@@ -1444,6 +1444,13 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             mNotesBucket.stop();
             AppLog.add(Type.SYNC, "Stopped note bucket (NoteEditorFragment)");
         }
+
+        AppLog.add(
+            Type.SYNC,
+            "Saved note callback (Title: " + note.getTitle() +
+                " / Characters: " + NoteUtils.getCharactersCount(note.getContent()) +
+                " / Words: " + NoteUtils.getWordCount(note.getContent()) + ")"
+        );
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -294,6 +294,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(requireContext()));
         mInfoBottomSheet = new InfoBottomSheetDialog(this);
         mShareBottomSheet = new ShareBottomSheetDialog(this, this);
         mHistoryBottomSheet = new HistoryBottomSheetDialog(this, this);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -54,10 +54,13 @@ import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Preferences;
 import com.automattic.simplenote.models.Suggestion;
 import com.automattic.simplenote.models.Tag;
+import com.automattic.simplenote.utils.AppLog;
+import com.automattic.simplenote.utils.AppLog.Type;
 import com.automattic.simplenote.utils.ChecklistUtils;
 import com.automattic.simplenote.utils.DateTimeUtils;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
+import com.automattic.simplenote.utils.NetworkUtils;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.automattic.simplenote.utils.SearchSnippetFormatter;
 import com.automattic.simplenote.utils.SearchTokenizer;
@@ -251,6 +254,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(requireContext()));
         mBucketPreferences = ((Simplenote) requireActivity().getApplication()).getPreferencesBucket();
         mBucketTag = ((Simplenote) requireActivity().getApplication()).getTagsBucket();
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -255,6 +255,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(requireContext()));
+        AppLog.add(Type.SCREEN, "Created (NoteListFragment)");
         mBucketPreferences = ((Simplenote) requireActivity().getApplication()).getPreferencesBucket();
         mBucketTag = ((Simplenote) requireActivity().getApplication()).getTagsBucket();
     }
@@ -566,6 +567,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mBucketPreferences.removeOnNetworkChangeListener(this);
         mBucketPreferences.removeOnSaveObjectListener(this);
         mBucketPreferences.stop();
+        AppLog.add(Type.SCREEN, "Paused (NoteListFragment)");
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -73,6 +73,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        AppLog.add(Type.SCREEN, "Created (NoteMarkdownFragment)");
         mNotesBucket = ((Simplenote) requireActivity().getApplication()).getNotesBucket();
 
         // Load note if we were passed an ID.
@@ -153,6 +154,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
         mNotesBucket.removeListener(this);
         mNotesBucket.stop();
         AppLog.add(Type.SYNC, "Stopped note bucket (NoteMarkdownFragment)");
+        AppLog.add(Type.SCREEN, "Destroyed (NoteMarkdownFragment)");
     }
 
     @Override
@@ -162,6 +164,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
         AppLog.add(Type.SYNC, "Started note bucket (NoteMarkdownFragment)");
         mNotesBucket.addListener(this);
         AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(requireContext()));
+        AppLog.add(Type.SCREEN, "Resumed (NoteMarkdownFragment)");
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -20,6 +20,7 @@ import com.automattic.simplenote.utils.AppLog;
 import com.automattic.simplenote.utils.AppLog.Type;
 import com.automattic.simplenote.utils.ContextUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
+import com.automattic.simplenote.utils.NetworkUtils;
 import com.automattic.simplenote.utils.NoteUtils;
 import com.automattic.simplenote.utils.ThemeUtils;
 import com.commonsware.cwac.anddown.AndDown;
@@ -160,6 +161,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
         mNotesBucket.start();
         AppLog.add(Type.SYNC, "Started note bucket (NoteMarkdownFragment)");
         mNotesBucket.addListener(this);
+        AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(requireContext()));
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -188,7 +188,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
 
         AppLog.add(
             Type.SYNC,
-            "Saved note callback (Title: " + note.getTitle() +
+            "Saved note callback in NoteMarkdownFragment (Title: " + note.getTitle() +
                 " / Characters: " + NoteUtils.getCharactersCount(note.getContent()) +
                 " / Words: " + NoteUtils.getWordCount(note.getContent()) + ")"
         );

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -188,7 +188,8 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
 
         AppLog.add(
             Type.SYNC,
-            "Saved note callback in NoteMarkdownFragment (Title: " + note.getTitle() +
+            "Saved note callback in NoteMarkdownFragment (ID: " + note.getSimperiumKey() +
+                " / Title: " + note.getTitle() +
                 " / Characters: " + NoteUtils.getCharactersCount(note.getContent()) +
                 " / Words: " + NoteUtils.getWordCount(note.getContent()) + ")"
         );

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -185,6 +185,13 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
             mNote = note;
             requireActivity().invalidateOptionsMenu();
         }
+
+        AppLog.add(
+            Type.SYNC,
+            "Saved note callback (Title: " + note.getTitle() +
+                " / Characters: " + NoteUtils.getCharactersCount(note.getContent()) +
+                " / Words: " + NoteUtils.getWordCount(note.getContent()) + ")"
+        );
     }
 
     public void updateMarkdown(String text) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -16,6 +16,8 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
 import com.automattic.simplenote.models.Note;
+import com.automattic.simplenote.utils.AppLog;
+import com.automattic.simplenote.utils.AppLog.Type;
 import com.automattic.simplenote.utils.ContextUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.NoteUtils;
@@ -149,12 +151,14 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
         super.onDestroy();
         mNotesBucket.removeListener(this);
         mNotesBucket.stop();
+        AppLog.add(Type.SYNC, "Stopped note bucket (NoteMarkdownFragment)");
     }
 
     @Override
     public void onResume() {
         super.onResume();
         mNotesBucket.start();
+        AppLog.add(Type.SYNC, "Started note bucket (NoteMarkdownFragment)");
         mNotesBucket.addListener(this);
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -40,6 +40,8 @@ import androidx.preference.PreferenceManager;
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
+import com.automattic.simplenote.utils.AppLog;
+import com.automattic.simplenote.utils.AppLog.Type;
 import com.automattic.simplenote.utils.CrashUtils;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
@@ -290,7 +292,9 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         disableScreenshotsIfLocked(this);
 
         mNotesBucket.start();
+        AppLog.add(Type.SYNC, "Started note bucket (NotesActivity)");
         mTagsBucket.start();
+        AppLog.add(Type.SYNC, "Started tag bucket (NotesActivity)");
 
         mNotesBucket.addOnNetworkChangeListener(this);
         mNotesBucket.addOnSaveObjectListener(this);
@@ -338,11 +342,13 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         super.onPause();  // Always call the superclass method first
         mTagsBucket.removeListener(mTagsMenuUpdater);
         mTagsBucket.stop();
+        AppLog.add(Type.SYNC, "Stopped tag bucket (NotesActivity)");
 
         mNotesBucket.removeOnNetworkChangeListener(this);
         mNotesBucket.removeOnSaveObjectListener(this);
         mNotesBucket.removeOnDeleteObjectListener(this);
         mNotesBucket.stop();
+        AppLog.add(Type.SYNC, "Stopped note bucket (NotesActivity)");
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -47,6 +47,7 @@ import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
 import com.automattic.simplenote.utils.NetworkUtils;
+import com.automattic.simplenote.utils.NoteUtils;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.automattic.simplenote.utils.StrUtils;
 import com.automattic.simplenote.utils.TagsAdapter;
@@ -1666,6 +1667,13 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 getResources().getInteger(R.integer.time_animation)
             );
         }
+
+        AppLog.add(
+            Type.SYNC,
+            "Saved note callback (Title: " + note.getTitle() +
+                " / Characters: " + NoteUtils.getCharactersCount(note.getContent()) +
+                " / Words: " + NoteUtils.getWordCount(note.getContent()) + ")"
+        );
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -46,6 +46,7 @@ import com.automattic.simplenote.utils.CrashUtils;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
+import com.automattic.simplenote.utils.NetworkUtils;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.automattic.simplenote.utils.StrUtils;
 import com.automattic.simplenote.utils.TagsAdapter;
@@ -176,6 +177,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         ThemeUtils.setTheme(this);
         super.onCreate(savedInstanceState);
 
+        AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(NotesActivity.this));
         setContentView(R.layout.activity_notes);
 
         mFragmentsContainer = findViewById(R.id.note_fragment_container);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1670,7 +1670,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
         AppLog.add(
             Type.SYNC,
-            "Saved note callback (Title: " + note.getTitle() +
+            "Saved note callback in NotesActivity (Title: " + note.getTitle() +
                 " / Characters: " + NoteUtils.getCharactersCount(note.getContent()) +
                 " / Words: " + NoteUtils.getWordCount(note.getContent()) + ")"
         );

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1670,7 +1670,8 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
         AppLog.add(
             Type.SYNC,
-            "Saved note callback in NotesActivity (Title: " + note.getTitle() +
+            "Saved note callback in NotesActivity (ID: " + note.getSimperiumKey() +
+                " / Title: " + note.getTitle() +
                 " / Characters: " + NoteUtils.getCharactersCount(note.getContent()) +
                 " / Words: " + NoteUtils.getWordCount(note.getContent()) + ")"
         );

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -178,6 +178,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         super.onCreate(savedInstanceState);
 
         AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(NotesActivity.this));
+        AppLog.add(Type.SCREEN, "Created (NotesActivity)");
         setContentView(R.layout.activity_notes);
 
         mFragmentsContainer = findViewById(R.id.note_fragment_container);
@@ -351,6 +352,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         mNotesBucket.removeOnDeleteObjectListener(this);
         mNotesBucket.stop();
         AppLog.add(Type.SYNC, "Stopped note bucket (NotesActivity)");
+        AppLog.add(Type.SCREEN, "Paused (NotesActivity)");
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -281,7 +281,9 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
         application.getPreferencesBucket().reset();
 
         application.getNotesBucket().stop();
+        AppLog.add(Type.SYNC, "Stopped note bucket (PreferencesFragment)");
         application.getTagsBucket().stop();
+        AppLog.add(Type.SYNC, "Stopped tag bucket (PreferencesFragment)");
         application.getPreferencesBucket().stop();
 
         AnalyticsTracker.track(

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -13,6 +13,7 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.core.app.ShareCompat;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
@@ -22,6 +23,8 @@ import androidx.preference.SwitchPreferenceCompat;
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Preferences;
+import com.automattic.simplenote.utils.AppLog;
+import com.automattic.simplenote.utils.AppLog.Type;
 import com.automattic.simplenote.utils.BrowserUtils;
 import com.automattic.simplenote.utils.CrashUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
@@ -170,10 +173,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
             }
         });
 
-        Preference versionPref = findPreference("pref_key_build");
-        versionPref.setSummary(PrefUtils.versionInfo());
-
-        SwitchPreferenceCompat switchPreference = (SwitchPreferenceCompat) findPreference("pref_key_condensed_note_list");
+        SwitchPreferenceCompat switchPreference = findPreference("pref_key_condensed_note_list");
         switchPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object o) {
@@ -216,6 +216,19 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
         });
 
         updateAnalyticsSwitchState();
+
+        findPreference("pref_key_logs").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                startActivity(
+                    ShareCompat.IntentBuilder.from(requireActivity())
+                        .setText(AppLog.get())
+                        .setType("text/plain")
+                        .createChooserIntent()
+                );
+                return true;
+            }
+        });
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -161,10 +161,12 @@ public class Simplenote extends Application {
 
                         if (mNotesBucket != null) {
                             mNotesBucket.stop();
+                            AppLog.add(Type.SYNC, "Stopped note bucket (Simplenote)");
                         }
 
                         if (mTagsBucket != null) {
                             mTagsBucket.stop();
+                            AppLog.add(Type.SYNC, "Stopped tag bucket (Simplenote)");
                         }
 
                         if (mPreferencesBucket != null) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.ComponentCallbacks2;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 
@@ -16,7 +17,10 @@ import com.automattic.simplenote.models.NoteCountIndexer;
 import com.automattic.simplenote.models.NoteTagger;
 import com.automattic.simplenote.models.Preferences;
 import com.automattic.simplenote.models.Tag;
+import com.automattic.simplenote.utils.AppLog;
+import com.automattic.simplenote.utils.AppLog.Type;
 import com.automattic.simplenote.utils.CrashUtils;
+import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.simperium.Simperium;
 import com.simperium.client.Bucket;
@@ -81,6 +85,8 @@ public class Simplenote extends Application {
         AnalyticsTracker.registerTracker(new AnalyticsTrackerNosara(this));
         AnalyticsTracker.refreshMetadata(mSimperium.getUser().getEmail());
         CrashUtils.setCurrentUser(mSimperium.getUser());
+
+        AppLog.add(Type.DEVICE, getDeviceInfo());
     }
 
     @SuppressWarnings("unused")
@@ -100,6 +106,14 @@ public class Simplenote extends Application {
         } catch (BucketObjectMissingException e) {
             return true;
         }
+    }
+
+    private String getDeviceInfo() {
+        String architecture = Build.DEVICE != null && Build.DEVICE.matches(".+_cheets|cheets_.+") ? "Chrome OS " : "Android ";
+        String device = "Device: " + Build.MANUFACTURER + " " + Build.MODEL + " (" + Build.DEVICE + ")";
+        String system = "System: " + architecture + Build.VERSION.RELEASE + " (" + Build.VERSION.SDK_INT + ")";
+        String app = "App: Simplenote " + PrefUtils.versionInfo();
+        return device + "\n" + system + "\n" + app + "\n\n";
     }
 
     public Simperium getSimperium() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -182,6 +182,7 @@ public class Simplenote extends Application {
                         "application_closed"
                 );
                 AnalyticsTracker.flush();
+                AppLog.add(Type.ACTION, "App closed");
             } else {
                 mIsInBackground = false;
             }
@@ -207,6 +208,7 @@ public class Simplenote extends Application {
                 );
 
                 mIsInBackground = false;
+                AppLog.add(Type.ACTION, "App opened");
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -87,6 +87,7 @@ public class Simplenote extends Application {
         CrashUtils.setCurrentUser(mSimperium.getUser());
 
         AppLog.add(Type.DEVICE, getDeviceInfo());
+        AppLog.add(Type.ACCOUNT, getAccountInfo());
     }
 
     @SuppressWarnings("unused")
@@ -106,6 +107,13 @@ public class Simplenote extends Application {
         } catch (BucketObjectMissingException e) {
             return true;
         }
+    }
+
+    private String getAccountInfo() {
+        String email = "Email: " + (mSimperium != null && mSimperium.getUser() != null ? mSimperium.getUser().getEmail() : "?");
+        String notes = "Notes: " + (mNotesBucket != null ? mNotesBucket.count() : "?");
+        String tags = "Tags: " + (mTagsBucket != null ? mTagsBucket.count() : "?");
+        return email + "\n" + notes + "\n" + tags + "\n\n";
     }
 
     private String getDeviceInfo() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -88,6 +88,7 @@ public class Simplenote extends Application {
 
         AppLog.add(Type.DEVICE, getDeviceInfo());
         AppLog.add(Type.ACCOUNT, getAccountInfo());
+        AppLog.add(Type.LAYOUT, DisplayUtils.getDisplaySizeAndOrientation(Simplenote.this));
     }
 
     @SuppressWarnings("unused")
@@ -186,6 +187,7 @@ public class Simplenote extends Application {
 
         @Override
         public void onConfigurationChanged(Configuration newConfig) {
+            AppLog.add(Type.LAYOUT, DisplayUtils.getDisplaySizeAndOrientation(Simplenote.this));
         }
 
         @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/AppLog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/AppLog.java
@@ -1,0 +1,51 @@
+package com.automattic.simplenote.utils;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class AppLog {
+    private static final int LOG_MAX = 100;
+
+    private static LinkedHashMap<Integer, String> mQueue  = new LinkedHashMap<Integer, String>() {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<Integer, String> eldest) {
+            return this.size() > LOG_MAX;
+        }
+    };
+
+    public enum Type {
+        ACCOUNT,
+        ACTION,
+        DEVICE,
+        LAYOUT,
+        NETWORK,
+        SCREEN,
+        SYNC
+    }
+
+    public static void add(Type type, String message) {
+        String log;
+
+        if (type == Type.ACCOUNT || type == Type.DEVICE) {
+            log = message;
+        } else {
+            String timestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US).format(new Date());
+            log = timestamp + " - " + type.toString() + ": " + message + "\n";
+        }
+
+        mQueue.put(mQueue.size(), log);
+    }
+
+    public static String get() {
+        StringBuilder queue = new StringBuilder();
+
+        for (Map.Entry<Integer, String> entry : mQueue.entrySet()) {
+            queue.append(entry.getValue());
+        }
+
+        return queue.toString();
+    }
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DisplayUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DisplayUtils.java
@@ -31,6 +31,24 @@ public class DisplayUtils {
         return size;
     }
 
+    @SuppressWarnings("ConstantConditions")
+    public static String getDisplaySizeAndOrientation(Context context) {
+        boolean isLarge = isLarge(context) || isXLarge(context);
+        boolean isLandscape = isLandscape(context);
+
+        if (isLarge && isLandscape) {
+            return "Large, landscape";
+        } else if (isLarge && !isLandscape) {
+            return "Large, portrait";
+        } else if (!isLarge && isLandscape) {
+            return "Small, landscape";
+        } else if (!isLarge && !isLandscape) {
+            return "Small, portrait";
+        } else {
+            return "Unknown";
+        }
+    }
+
     public static int dpToPx(Context context, int dp) {
         float px = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp,
                 context.getResources().getDisplayMetrics());

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/NetworkUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/NetworkUtils.java
@@ -2,11 +2,44 @@ package com.automattic.simplenote.utils;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
+import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
+import android.net.wifi.WifiManager;
+
+import java.text.DecimalFormat;
 
 public class NetworkUtils {
+    private static final int TYPE_NONE = -1;
+    private static final int TYPE_NULL = -2;
+
     /**
-     * @return information on the active network connection
+     * @return {@link String} formatting speed of network in bps (e.g. 12.34 Kbps)
+     */
+    private static String formatSpeedFromKbps(int speed) {
+        if (speed <= 0) {
+            return "0.00";
+        }
+
+        String[] units = new String[] { "Kbps", "Mbps", "Gbps", "Tbps" };
+        int index = (int) (Math.log10(speed) / Math.log10(1024));
+        return new DecimalFormat("#,##0.00").format(speed / Math.pow(1024, index)) + " " + units[index];
+    }
+
+    /**
+     * @return {@link String} formatting speed of network in bps (e.g. 12.34 Mbps)
+     */
+    private static String formatSpeedFromMbps(int speed) {
+        if (speed <= 0) {
+            return "0.00";
+        }
+
+        String[] units = new String[] { "Mbps", "Gbps", "Tbps" };
+        int index = (int) (Math.log10(speed) / Math.log10(1024));
+        return new DecimalFormat("#,##0.00").format(speed / Math.pow(1024, index)) + " " + units[index];
+    }
+
+    /**
+     * @return {@link NetworkInfo} on the active network connection
      */
     private static NetworkInfo getActiveNetworkInfo(Context context) {
         if (context == null) {
@@ -15,6 +48,96 @@ public class NetworkUtils {
 
         ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         return cm != null ? cm.getActiveNetworkInfo() : null;
+    }
+
+    /**
+     * @return {@link String} type and speed of network (e.g. WIFI (123.45 Mbps))
+     */
+    public static String getNetworkInfo(Context context) {
+        String type = getNetworkTypeString(context);
+        String speed;
+
+        switch (getNetworkType(context)) {
+            case ConnectivityManager.TYPE_MOBILE:
+                speed = getNetworkSpeed(context);
+                break;
+            case ConnectivityManager.TYPE_WIFI:
+                speed = getNetworkSpeedWifi(context);
+                break;
+            case TYPE_NONE:
+            case TYPE_NULL:
+            default:
+                speed = "?";
+                break;
+        }
+
+        return type + " (" + speed + ")";
+    }
+
+    /**
+     * @return {@link String} speed of network in Kbps (e.g. 12.34)
+     */
+    public static String getNetworkSpeed(Context context) {
+        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        if (cm == null) {
+            return "Could not get network speed";
+        }
+
+        NetworkCapabilities nc = cm.getNetworkCapabilities(cm.getActiveNetwork());
+
+        if (nc == null) {
+            return "Could not get network speed";
+        }
+
+        return formatSpeedFromKbps(nc.getLinkDownstreamBandwidthKbps());
+    }
+
+    /**
+     * @return {@link String} speed of network in Mbps (e.g. 12.34)
+     */
+    public static String getNetworkSpeedWifi(Context context) {
+        WifiManager wm = (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+
+        if (wm == null) {
+            return "Could not get network speed";
+        }
+
+        return formatSpeedFromMbps(wm.getConnectionInfo().getLinkSpeed());
+    }
+
+    /**
+     * @return integer constant of the network type
+     */
+    public static int getNetworkType(Context context) {
+        NetworkInfo info = getActiveNetworkInfo(context);
+
+        if (info == null) {
+            return TYPE_NULL;
+        }
+
+        if (!info.isConnected()) {
+            return TYPE_NONE;
+        }
+
+        return info.getType();
+    }
+
+    /**
+     * @return {@link String} representation of the network type
+     */
+    public static String getNetworkTypeString(Context context) {
+        switch (getNetworkType(context)) {
+            case ConnectivityManager.TYPE_MOBILE:
+                return "MOBILE";
+            case ConnectivityManager.TYPE_WIFI:
+                return "WIFI";
+            case TYPE_NONE:
+                return "No network connection";
+            case TYPE_NULL:
+            default:
+                return "Could not get network type";
+        }
     }
 
     /**

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
@@ -7,10 +7,10 @@ import com.automattic.simplenote.Simplenote;
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 
+import java.text.NumberFormat;
 import java.util.Calendar;
 
 public class NoteUtils {
-
     public static void setNotePin(Note note, boolean isPinned) {
         if (note != null && isPinned != note.isPinned()) {
             note.setPinned(isPinned);
@@ -43,5 +43,14 @@ public class NoteUtils {
                     "trash_menu_item"
             );
         }
+    }
+
+    public static String getCharactersCount(String content) {
+        return NumberFormat.getInstance().format(content.length());
+    }
+
+    public static String getWordCount(String content) {
+        int words = (content.trim().length() == 0) ? 0 : content.trim().split("([\\W]+)").length;
+        return NumberFormat.getInstance().format(words);
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -131,15 +131,21 @@ public class PrefUtils {
     }
 
     public static CharSequence versionInfo() {
+        String version;
 
         if (BuildConfig.DEBUG) {
-            String info = "<strong>" + BuildConfig.VERSION_NAME + "</strong> " +
-                    BuildConfig.BUILD_TYPE + " (Build " + BuildConfig.VERSION_CODE + ")" +
-                    "\n<em>" + BuildConfig.BUILD_HASH + "</em>";
-            return HtmlCompat.fromHtml(info);
+            version =
+                BuildConfig.VERSION_NAME +
+                " (" + BuildConfig.VERSION_CODE + ") " +
+                BuildConfig.BUILD_TYPE +
+                " (" + BuildConfig.BUILD_HASH + ")";
+        } else {
+            version =
+                BuildConfig.VERSION_NAME +
+                " (" + BuildConfig.VERSION_CODE + ")";
         }
 
-        return BuildConfig.VERSION_NAME;
+        return version;
     }
 
     public static int getFontSize(Context context) {

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -30,7 +30,8 @@
     <string name="no">No</string>
     <string name="word">Word</string>
     <string name="website">Visit simplenote.com</string>
-    <string name="more_info">More Information</string>
+    <string name="more">More</string>
+    <string name="send_logs">Send logs</string>
     <string name="note_selected">%d note selected</string>
     <string name="notes_selected">%d notes selected</string>
     <string name="note_added">Note added</string>
@@ -124,10 +125,9 @@
     <string name="theme_auto">Dark at night only</string>
     <string name="theme_system">System default</string>
     <string name="theme">Theme</string>
-    <string name="version">Version</string>
 
     <!-- About screen -->
-    <string name="about">About Simplenote</string>
+    <string name="about">About</string>
     <string name="about_copyright">&#169; Automattic %1$d</string>
     <string name="about_contribute_subtitle">github.com</string>
     <string name="about_contribute_title">Contribute</string>

--- a/Simplenote/src/main/res/xml/preferences.xml
+++ b/Simplenote/src/main/res/xml/preferences.xml
@@ -97,20 +97,26 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="@string/more_info">
+        android:title="@string/more">
+
         <Preference
             android:key="pref_key_about"
             android:persistent="false"
-            android:title="@string/about"/>
+            android:title="@string/about">
+        </Preference>
+
+        <Preference
+            android:key="pref_key_logs"
+            android:persistent="false"
+            android:title="@string/send_logs">
+        </Preference>
+
         <Preference
             android:key="pref_key_website"
             android:persistent="false"
-            android:title="@string/website"/>
-        <Preference
-            android:key="pref_key_build"
-            android:persistent="false"
-            android:selectable="false"
-            android:title="@string/version"/>
+            android:title="@string/website">
+        </Preference>
+
     </PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
### Fix
Add application logging to assist in troubleshooting data loss reports as described in https://github.com/Automattic/simplenote-android/issues/992 and https://github.com/Automattic/simplenote-android/issues/1101 among other issues.  The logs are not saved to device storage, but instead are stored in memory while the app is alive.  Once the app is killed by the operating system, the logs are cleared.  The logs are queued with a maximum of one hundred events to keep the memory footprint small.  The logs remain on the device and are never sent to anywhere unless explicitly done so by the user.  These aspects ensure an opt-in behavior and keeps the user in control of their information.  In order to share the logs, the **_Send logs_** item was added to the **_Settings_** screen.  When the **_Send logs_** item is tapped, a **_Share_** sheet is shown allowing the user to share the logs however they choose.  Since this feature is intended to help diagnose issues with data loss while editing/creating notes, the logs are focused on editor and syncing events.  See the details below for example logs.

<details>
<summary>
Log
</summary>
<pre>
Device: Google Pixel 4 (flame)
System: Android 10 (29)
App: Simplenote 2.9-rc-1 (111)<br>
Email: heckofatest@gmail.com
Notes: 21
Tags: 5<br>
2020-08-18 13:51:08.453 - LAYOUT: Small, portrait
2020-08-18 13:51:08.510 - NETWORK: WIFI (780.00 Mbps)
2020-08-18 13:51:08.511 - SCREEN: Created (NotesActivity)
2020-08-18 13:51:08.609 - NETWORK: WIFI (780.00 Mbps)
2020-08-18 13:51:08.610 - SCREEN: Created (NoteListFragment)
2020-08-18 13:51:08.662 - ACTION: App opened
2020-08-18 13:51:08.662 - SYNC: Started note bucket (NotesActivity)
2020-08-18 13:51:08.663 - SYNC: Started tag bucket (NotesActivity)
2020-08-18 13:51:10.155 - SCREEN: Paused (NoteListFragment)
2020-08-18 13:51:10.156 - SYNC: Stopped tag bucket (NotesActivity)
2020-08-18 13:51:10.157 - SYNC: Stopped note bucket (NotesActivity)
2020-08-18 13:51:10.157 - SCREEN: Paused (NotesActivity)
2020-08-18 13:51:10.171 - NETWORK: MOBILE (53.14 Mbps)
2020-08-18 13:51:10.171 - SCREEN: Created (NoteEditorActivity)
2020-08-18 13:51:10.218 - NETWORK: MOBILE (53.14 Mbps)
2020-08-18 13:51:10.218 - SCREEN: Resumed (NoteEditorActivity)
2020-08-18 13:51:10.231 - NETWORK: MOBILE (53.14 Mbps)
2020-08-18 13:51:10.231 - SCREEN: Created (NoteEditorFragment)
2020-08-18 13:51:10.262 - ACTION: Opened from list (NoteEditorFragment)
2020-08-18 13:51:10.265 - SCREEN: Created (NoteMarkdownFragment)
2020-08-18 13:51:10.266 - SYNC: Loaded note (Title: Logs / Characters: 6 / Words: 1)
2020-08-18 13:51:10.369 - SYNC: Started note bucket (NoteEditorFragment)
2020-08-18 13:51:14.243 - ACTION: Edited note (Title: Logs / Characters: 6 / Words: 1)
2020-08-18 13:51:14.260 - SYNC: Saved note (Title: Logs / Characters: 10 / Words: 2)
2020-08-18 13:51:16.712 - SCREEN: Paused (NoteEditorFragment)
2020-08-18 13:51:16.718 - SCREEN: Paused (NoteEditorActivity)
2020-08-18 13:51:16.740 - ACTION: Edited note (Title: Logs / Characters: 10 / Words: 2)
2020-08-18 13:51:17.176 - ACTION: App closed
2020-08-18 13:51:19.107 - ACTION: App opened
2020-08-18 13:51:19.109 - NETWORK: WIFI (650.00 Mbps)
2020-08-18 13:51:19.110 - SCREEN: Resumed (NoteEditorActivity)
2020-08-18 13:51:19.110 - SYNC: Started note bucket (NoteEditorFragment)
2020-08-18 13:51:20.595 - LAYOUT: Small, landscape
2020-08-18 13:51:22.667 - SYNC: Saved note (Title: Logs / Characters: 6 / Words: 1)
2020-08-18 13:51:22.668 - SCREEN: Paused (NoteEditorFragment)
2020-08-18 13:51:22.672 - SCREEN: Paused (NoteEditorActivity)
2020-08-18 13:51:22.679 - SYNC: Stopped note bucket (NoteEditorFragment)
2020-08-18 13:51:22.679 - ACTION: Edited note (Title: Logs / Characters: 6 / Words: 1)
2020-08-18 13:51:23.272 - ACTION: App closed
2020-08-18 13:51:24.050 - LAYOUT: Small, portrait
2020-08-18 13:51:27.204 - SYNC: Stopped note bucket (Simplenote)
2020-08-18 13:51:27.207 - SYNC: Stopped tag bucket (Simplenote)
2020-08-18 13:51:28.603 - ACTION: App opened
2020-08-18 13:51:28.605 - NETWORK: WIFI (650.00 Mbps)
2020-08-18 13:51:28.605 - SCREEN: Resumed (NoteEditorActivity)
2020-08-18 13:51:28.607 - SYNC: Started note bucket (NoteEditorFragment)
2020-08-18 13:51:29.307 - ACTION: Tapped back arrow in app bar (NoteEditorFragment)
2020-08-18 13:51:29.322 - SCREEN: Paused (NoteEditorFragment)
2020-08-18 13:51:29.323 - SCREEN: Paused (NoteEditorActivity)
2020-08-18 13:51:29.333 - ACTION: Edited note (Title: Logs / Characters: 6 / Words: 1)
2020-08-18 13:51:29.338 - SYNC: Started note bucket (NotesActivity)
2020-08-18 13:51:29.340 - SYNC: Started tag bucket (NotesActivity)
2020-08-18 13:51:29.844 - SYNC: Stopped note bucket (NoteEditorFragment)
2020-08-18 13:51:29.845 - SCREEN: Destroyed (NoteEditorFragment)
2020-08-18 13:51:29.848 - SYNC: Stopped note bucket (NoteMarkdownFragment)
2020-08-18 13:51:29.848 - SCREEN: Destroyed (NoteMarkdownFragment)
2020-08-18 13:51:31.653 - SCREEN: Paused (NoteListFragment)
2020-08-18 13:51:31.654 - SYNC: Stopped tag bucket (NotesActivity)
2020-08-18 13:51:31.654 - SYNC: Stopped note bucket (NotesActivity)
2020-08-18 13:51:31.654 - SCREEN: Paused (NotesActivity)
</pre>
</details>

There are seven types of log events based on the information of the event.  See the table below for details.

Type|Description
-|-
`ACCOUNT`|The user's email address, number of notes, and number of tags for the logged in account.
`ACTION`|The behavior performed by the user (e.g. editing a note, tapping back arrow).
`DEVICE`|The make, model, Android version, and Simplenote version installed on the device.
`LAYOUT`|The display size and orientation of the device.
`NETWORK`|The type and speed of the network connection.
`SCREEN`|The screen shown in the app (e.g. Note List, Note Editor).
`SYNC`|The events related to syncing (e.g. bucket start/stop, saving a note).

All the strings in these changes are intentionally hard-coded since none of those strings are user-facing and do not require translation.  Also, adding them to `strings.xml` and having them translated may cause confusion and difficult diagnosis when they are read by support or developers since they may not know the language.  The one exception is [`send_logs`](https://github.com/Automattic/simplenote-android/compare/add-app-log?expand=1#diff-19bb70917c478f507b793b466bd7d82eR34), which is user-facing and should be translated.

### Test
Since the application logging addresses multiple screens, the best testing method is to perform various tasks related to editing notes.  Once you have visited multiple screens and edited notes, follow the steps below to share/view the application log.
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Tap ***Send logs*** item under ***More*** section.
4. Notice ***Share*** sheet is shown.
5. Choose any option in ***Share*** sheet to share/view application log.
6. Notice application log is as shown above.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.