### PR TITLE
Add Style Setting (Part 5)

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/StyleActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/StyleActivity.java
@@ -37,6 +37,7 @@ import static com.automattic.simplenote.utils.ThemeUtils.STYLE_BLACK;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_CLASSIC;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_DEFAULT;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_MONO;
+import static com.automattic.simplenote.utils.ThemeUtils.STYLE_PUBLICATION;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_SEPIA;
 
 public class StyleActivity extends ThemedAppCompatActivity {
@@ -199,6 +200,13 @@ public class StyleActivity extends ThemedAppCompatActivity {
                             R.style.Style_Mono)
                         ).inflate(R.layout.style_list_row_mono, parent, false)
                     );
+                case STYLE_PUBLICATION:
+                    return new StyleHolder(LayoutInflater.from(
+                        new ContextThemeWrapper(
+                            parent.getContext(),
+                            R.style.Style_Publication)
+                        ).inflate(R.layout.style_list_row_publication, parent, false)
+                    );
                 case STYLE_DEFAULT:
                 default:
                     return new StyleHolder(LayoutInflater.from(
@@ -220,6 +228,8 @@ public class StyleActivity extends ThemedAppCompatActivity {
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.orange_50 : R.color.orange_20;
                 case STYLE_MONO:
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.gray_50 : R.color.gray_20;
+                case STYLE_PUBLICATION:
+                    return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.red_50 : R.color.red_20;
                 case STYLE_DEFAULT:
                 default:
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.simplenote_blue_50 : R.color.simplenote_blue_20;

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -23,6 +23,7 @@ import static com.automattic.simplenote.utils.ThemeUtils.STYLE_BLACK;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_CLASSIC;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_DEFAULT;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_MONO;
+import static com.automattic.simplenote.utils.ThemeUtils.STYLE_PUBLICATION;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_SEPIA;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
@@ -179,6 +180,8 @@ public class PrefUtils {
                 return context.getString(R.string.style_sepia);
             case STYLE_MONO:
                 return context.getString(R.string.style_mono);
+            case STYLE_PUBLICATION:
+                return context.getString(R.string.style_publication);
             case STYLE_DEFAULT:
             default:
                 return context.getString(R.string.style_default);

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -20,14 +20,16 @@ import static android.content.res.Configuration.UI_MODE_NIGHT_MASK;
 import static android.content.res.Configuration.UI_MODE_NIGHT_YES;
 
 public class ThemeUtils {
-    public static final int STYLE_BLACK = 3;
-    public static final int STYLE_CLASSIC = 4;
+    public static final int STYLE_BLACK = 4;
+    public static final int STYLE_CLASSIC = 5;
     public static final int STYLE_DEFAULT = 0;
-    public static final int STYLE_MONO = 1;
-    public static final int STYLE_SEPIA = 2;
+    public static final int STYLE_MONO = 2;
+    public static final int STYLE_PUBLICATION = 1;
+    public static final int STYLE_SEPIA = 3;
 
     public static final int[] STYLE_ARRAY = {
         STYLE_DEFAULT,
+        STYLE_PUBLICATION,
         STYLE_MONO,
         STYLE_SEPIA,
         STYLE_BLACK,
@@ -128,6 +130,7 @@ public class ThemeUtils {
             case STYLE_CLASSIC:
             case STYLE_DEFAULT:
             case STYLE_MONO:
+            case STYLE_PUBLICATION:
             default:
                 return isLight ? "light.css" : "dark.css";
         }
@@ -144,6 +147,8 @@ public class ThemeUtils {
                     return R.style.Style_Classic;
                 case STYLE_MONO:
                     return R.style.Style_Mono;
+                case STYLE_PUBLICATION:
+                    return R.style.Style_Publication;
                 case STYLE_SEPIA:
                     return R.style.Style_Sepia;
                 case STYLE_DEFAULT:

--- a/Simplenote/src/main/res/drawable/bg_list_publication.xml
+++ b/Simplenote/src/main/res/drawable/bg_list_publication.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ripple
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/background_list_publication_ripple">
+
+    <item
+        android:id="@android:id/mask"
+        android:drawable="?attr/mainBackgroundColor">
+    </item>
+
+    <item>
+
+        <selector>
+
+            <item
+                android:drawable="@color/background_list_publication_activated"
+                android:state_activated="true">
+            </item>
+
+            <item
+                android:drawable="@android:color/transparent">
+            </item>
+
+        </selector>
+
+    </item>
+
+</ripple>

--- a/Simplenote/src/main/res/layout/style_list_row_publication.xml
+++ b/Simplenote/src/main/res/layout/style_list_row_publication.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@drawable/bg_list_style_default"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/padding_small"
+    android:layout_marginEnd="@dimen/padding_large"
+    android:layout_marginStart="@dimen/padding_large"
+    android:layout_marginTop="@dimen/padding_small"
+    android:layout_width="match_parent"
+    app:cardCornerRadius="@dimen/corner_radius"
+    app:cardElevation="0dp"
+    style="@style/Style.Publication">
+
+    <RelativeLayout
+        android:background="@drawable/bg_list_style_default"
+        android:foreground="?attr/selectableItemBackground"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:padding="@dimen/padding_large">
+
+        <TextView
+            android:id="@+id/preview_title"
+            android:ellipsize="end"
+            android:fontFamily="serif"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/padding_small"
+            android:layout_width="match_parent"
+            android:maxLines="1"
+            android:textColor="@color/style_preview_default_title"
+            android:textSize="@dimen/text_content_title"
+            android:textStyle="bold"
+            tools:text="@string/style_publication">
+        </TextView>
+
+        <TextView
+            android:id="@+id/preview_content"
+            android:ellipsize="end"
+            android:fontFamily="serif"
+            android:layout_below="@id/preview_title"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:maxLines="2"
+            android:text="@string/style_preview"
+            android:textColor="@color/style_preview_default_content">
+        </TextView>
+
+        <ImageView
+            android:id="@+id/preview_locked"
+            android:background="@drawable/bg_style_locked"
+            android:contentDescription="@string/description_locked"
+            android:layout_centerInParent="true"
+            android:layout_height="@dimen/icon_locked"
+            android:layout_width="@dimen/icon_locked"
+            android:padding="@dimen/padding_medium"
+            android:src="@drawable/ic_lock_24dp"
+            android:visibility="gone"
+            tools:visibility="visible">
+        </ImageView>
+
+    </RelativeLayout>
+
+</androidx.cardview.widget.CardView>

--- a/Simplenote/src/main/res/values-night/colors.xml
+++ b/Simplenote/src/main/res/values-night/colors.xml
@@ -9,6 +9,8 @@
     <color name="background_list_classic_ripple">@color/blue_60</color>
     <color name="background_list_mono_activated">@color/background_dark_highlight</color>
     <color name="background_list_mono_ripple">@color/background_dark_highlight</color>
+    <color name="background_list_publication_activated">@color/background_dark_highlight</color>
+    <color name="background_list_publication_ripple">@color/background_dark_highlight</color>
     <color name="background_list_sepia_activated">@color/background_dark_highlight_sepia</color>
     <color name="background_list_sepia_ripple">@color/background_dark_highlight_sepia</color>
     <color name="background_list_default">@color/background_dark_highlight</color>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -180,6 +180,23 @@
         <item name="styleFontFamily">monospace</item>
     </style>
 
+    <style name="Style.Publication" parent="Theme.Simplestyle">
+        <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
+        <item name="actionModeTextColor">@color/item_publication_dark</item>
+        <item name="colorAccent">@color/item_publication_dark</item>
+        <item name="colorPrimary">@color/red</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_accent</item>
+        <item name="editorSearchHighlightBackgroundColor">@color/red_60</item>
+        <item name="editorSearchHighlightForegroundColor">@color/red_5</item>
+        <item name="fabColor">@color/item_publication_dark</item>
+        <item name="fabIconColor">@color/gray_100</item>
+        <item name="iconTintColor">@color/item_publication_dark</item>
+        <item name="listBackgroundSelector">@drawable/bg_list_publication</item>
+        <item name="listSearchHighlightBackgroundColor">@color/red_60</item>
+        <item name="listSearchHighlightForegroundColor">@color/red_5</item>
+        <item name="styleFontFamily">serif</item>
+    </style>
+
     <style name="Style.Sepia" parent="Theme.Simplestyle">
         <item name="android:navigationBarColor">?attr/mainBackgroundColor</item>
         <item name="android:windowBackground">@color/background_dark_sepia</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -168,7 +168,7 @@
         <item name="actionModeTextColor">@color/item_mono_dark</item>
         <item name="colorAccent">@color/item_mono_dark</item>
         <item name="colorPrimary">@color/gray</item>
-        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_accent</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_dark</item>
         <item name="editorSearchHighlightBackgroundColor">@color/gray_60</item>
         <item name="editorSearchHighlightForegroundColor">@color/gray_5</item>
         <item name="fabColor">@color/item_mono_dark</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -185,7 +185,7 @@
         <item name="actionModeTextColor">@color/item_publication_dark</item>
         <item name="colorAccent">@color/item_publication_dark</item>
         <item name="colorPrimary">@color/red</item>
-        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_accent</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_dark</item>
         <item name="editorSearchHighlightBackgroundColor">@color/red_60</item>
         <item name="editorSearchHighlightForegroundColor">@color/red_5</item>
         <item name="fabColor">@color/item_publication_dark</item>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -70,6 +70,8 @@
     <color name="background_list_default">@color/background_light_highlight</color>
     <color name="background_list_mono_activated">@color/gray_5</color>
     <color name="background_list_mono_ripple">@color/gray_0</color>
+    <color name="background_list_publication_activated">@color/red_5</color>
+    <color name="background_list_publication_ripple">@color/red_0</color>
     <color name="background_list_sepia_activated">@color/orange_5</color>
     <color name="background_list_sepia_ripple">@color/orange_0</color>
     <color name="chip_dark_checked_off">#24ffffff</color>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -126,6 +126,7 @@
     <string name="style_dialog_locked_title">Style Locked</string>
     <string name="style_mono">Mono</string>
     <string name="style_preview">![Image](%1$s%2$s%3$shttps://img_url.com/jpg%4$s) Aliquam erat volutpat. Pellentesque ut odio suscipit.</string>
+    <string name="style_publication">Publication</string>
     <string name="style_sepia">Sepia</string>
 
     <!-- Themes -->

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -402,6 +402,23 @@
         <item name="styleFontFamily">monospace</item>
     </style>
 
+    <style name="Style.Publication" parent="Theme.Simplestyle">
+        <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
+        <item name="actionModeTextColor">@color/item_publication_light</item>
+        <item name="colorAccent">@color/item_publication_light</item>
+        <item name="colorPrimary">@color/red</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_accent</item>
+        <item name="editorSearchHighlightBackgroundColor">@color/red_5</item>
+        <item name="editorSearchHighlightForegroundColor">@color/red_60</item>
+        <item name="fabColor">@color/item_publication_light</item>
+        <item name="fabIconColor">@android:color/white</item>
+        <item name="iconTintColor">@color/item_publication_light</item>
+        <item name="listBackgroundSelector">@drawable/bg_list_publication</item>
+        <item name="listSearchHighlightBackgroundColor">@color/red_5</item>
+        <item name="listSearchHighlightForegroundColor">@color/red_60</item>
+        <item name="styleFontFamily">serif</item>
+    </style>
+
     <style name="Style.Sepia" parent="Theme.Simplestyle">
         <item name="android:windowBackground">@color/background_light_sepia</item>
         <item name="actionModeBackgroundColor">@color/background_light_sepia</item>


### PR DESCRIPTION
### Fix
This is the fifth part in a series of pull requests to add a style setting to the app.  The pull requests are split into parts in an attempt to make the changes smaller.  This part adds the ***Publication*** style.  See the screenshots below for illustration.

![add_style_setting_all_05_](https://user-images.githubusercontent.com/3827611/90844218-a67eae00-e320-11ea-8f9a-306d37c9ab83.png)

#### Note
Contact me for an installable build.

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in drawer.
3. Tap ***Style*** item under ***Appearance*** section.
4. Notice ***Style*** screen with ***Default***, ***Publication***, ***Mono***, ***Sepia***, ***Black***, and ***Classic*** styles.
5. Tap ***Publication*** style.
6. Notice ***Publication*** style is selected and app has ***Publication*** styling.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.  `RELEASE-NOTES.txt` will be updated once the styles feature is complete.