### PR TITLE
Remove trailing whitespaces from Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,7 +41,7 @@ SUPPORTED_LOCALES = [
 
 ########################################################################
 # Release Lanes
-########################################################################  
+########################################################################
   #####################################################################################
   # code_freeze
   # -----------------------------------------------------------------------------------
@@ -51,18 +51,18 @@ SUPPORTED_LOCALES = [
   # bundle exec fastlane code_freeze [update_release_branch_version:<update flag>] [skip_confirm:<skip confirm>]
   #
   # Example:
-  # bundle exec fastlane code_freeze 
+  # bundle exec fastlane code_freeze
   # bundle exec fastlane code_freeze update_release_branch_version:false
   # bundle exec fastlane code_freeze skip_confirm:true
   #####################################################################################
   desc "Creates a new release branch from the current develop"
   lane :code_freeze do | options |
     old_version = android_codefreeze_prechecks(options)
-   
+
     android_bump_version_release()
     new_version = android_get_app_version()
-    extract_release_notes_for_version(version: new_version, 
-      release_notes_file_path:"#{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt", 
+    extract_release_notes_for_version(version: new_version,
+      release_notes_file_path:"#{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt",
       extracted_notes_file_path:release_notes_path)
     android_update_release_notes(new_version: new_version)
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
@@ -75,7 +75,7 @@ SUPPORTED_LOCALES = [
   end
 
   #####################################################################################
-  # update_appstore_strings 
+  # update_appstore_strings
   # -----------------------------------------------------------------------------------
   # This lane gets the data from the txt files in the Simplenote/metadata/ folder
   # and updates the .po file that is then picked by GlotPress for translations.
@@ -87,7 +87,7 @@ SUPPORTED_LOCALES = [
   # fastlane update_appstore_strings version:10.3
   #####################################################################################
   desc "Updates the PlayStoreStrings.po file"
-  lane :update_appstore_strings do |options| 
+  lane :update_appstore_strings do |options|
     prj_folder = Dir.pwd + "/.."
 
     files = {
@@ -97,10 +97,10 @@ SUPPORTED_LOCALES = [
       play_store_app_title: prj_folder + "/Simplenote/metadata/title.txt"
     }
 
-    an_update_metadata_source(po_file_path: prj_folder + "/Simplenote/metadata/PlayStoreStrings.pot", 
-      source_files: files, 
+    an_update_metadata_source(po_file_path: prj_folder + "/Simplenote/metadata/PlayStoreStrings.pot",
+      source_files: files,
       release_version: options[:version])
-  end 
+  end
 
   #####################################################################################
   # new_beta_release
@@ -128,7 +128,7 @@ SUPPORTED_LOCALES = [
   #####################################################################################
   # new_hotfix_release
   # -----------------------------------------------------------------------------------
-  # This lane updates the release branch for a new hotix release. 
+  # This lane updates the release branch for a new hotix release.
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane new_hotfix_release [skip_confirm:<skip confirm>] [version:<version>]
@@ -150,11 +150,11 @@ SUPPORTED_LOCALES = [
   # This lane finalize a release: updates store metadata and runs the release checks
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane finalize_release [skip_confirm:<skip confirm>] 
+  # bundle exec fastlane finalize_release [skip_confirm:<skip confirm>]
   #
   # Example:
-  # bundle exec fastlane finalize_release 
-  # bundle exec fastlane finalize_release skip_confirm:true 
+  # bundle exec fastlane finalize_release
+  # bundle exec fastlane finalize_release skip_confirm:true
   #####################################################################################
   desc "Updates store metadata and runs the release checks"
   lane :finalize_release do | options |
@@ -172,23 +172,23 @@ SUPPORTED_LOCALES = [
     setfrozentag(repository:GHHELPER_REPO, milestone: version["name"], freeze: false)
     close_milestone(repository:GHHELPER_REPO, milestone: version["name"])
   end
-  
+
   #####################################################################################
   # build_pre_releases
   # -----------------------------------------------------------------------------------
-  # This lane builds the app it for both internal and external distribution 
+  # This lane builds the app it for both internal and external distribution
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane build_pre_releases [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
-  # bundle exec fastlane build_pre_releases 
+  # bundle exec fastlane build_pre_releases
   # bundle exec fastlane build_pre_releases skip_confirm:true
-  # bundle exec fastlane build_pre_releases create_release:true 
+  # bundle exec fastlane build_pre_releases create_release:true
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_pre_releases do | options |
-    android_build_prechecks(skip_confirm: options[:skip_confirm], 
+    android_build_prechecks(skip_confirm: options[:skip_confirm],
       alpha: false,
       beta: true,
       final: false)
@@ -199,15 +199,15 @@ SUPPORTED_LOCALES = [
   #####################################################################################
   # build_and_upload_beta
   # -----------------------------------------------------------------------------------
-  # This lane builds the app it for internal testing  
+  # This lane builds the app it for internal testing
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane build_and_upload_beta [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
-  # bundle exec fastlane build_and_upload_beta 
-  # bundle exec fastlane build_and_upload_beta skip_confirm:true 
-  # bundle exec fastlane build_and_upload_beta create_release:true 
+  # bundle exec fastlane build_and_upload_beta
+  # bundle exec fastlane build_and_upload_beta skip_confirm:true
+  # bundle exec fastlane build_and_upload_beta create_release:true
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_and_upload_beta do | options |
@@ -226,24 +226,24 @@ SUPPORTED_LOCALES = [
   #####################################################################################
   # build_and_upload_release
   # -----------------------------------------------------------------------------------
-  # This lane builds the final release of the app and uploads it 
+  # This lane builds the final release of the app and uploads it
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
-  # bundle exec fastlane build_and_upload_release 
-  # bundle exec fastlane build_and_upload_release skip_confirm:true 
-  # bundle exec fastlane build_and_upload_release create_release:true 
+  # bundle exec fastlane build_and_upload_release
+  # bundle exec fastlane build_and_upload_release skip_confirm:true
+  # bundle exec fastlane build_and_upload_release create_release:true
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_and_upload_release do | options |
-    android_build_prechecks(skip_confirm: options[:skip_confirm], 
+    android_build_prechecks(skip_confirm: options[:skip_confirm],
       alpha: false,
       beta: false,
       final: true)
     android_build_preflight()
-    
+
     # Create the file names
     version=android_get_release_version()
     build_and_upload_apk(version: version, flavor:"Vanilla", upload_track:"production")
@@ -255,14 +255,14 @@ SUPPORTED_LOCALES = [
 
 ########################################################################
 # Helper Lanes
-########################################################################  
+########################################################################
   desc "Get a list of pull request from `start_tag` to the current state"
   lane :get_pullrequests_list do | options |
     get_prs_list(repository:GHHELPER_REPO, start_tag:"#{options[:start_tag]}", report_path:"#{File.expand_path('~')}/simplenoteandroid_prs_list.txt")
   end
 
   #####################################################################################
-  # download_metadata_string 
+  # download_metadata_string
   # -----------------------------------------------------------------------------------
   # This lane downloads the translated metadata (release notes,
   # app store strings, title, etc.) from GlotPress and updates the local files
@@ -274,7 +274,7 @@ SUPPORTED_LOCALES = [
   # fastlane download_metadata_string build_number:573 version:10.3
   #####################################################################################
   desc "Downloads translated metadata from GlotPress"
-  lane :download_metadata_strings do |options| 
+  lane :download_metadata_strings do |options|
     values = options[:version].split('.')
     files = {
       "release_note_#{values[0].to_s.rjust(2, "0")}#{values[1]}" => {desc: "changelogs/#{options[:build_number]}.txt", max_size: 0},
@@ -285,26 +285,26 @@ SUPPORTED_LOCALES = [
 
     delete_old_changelogs(build: options[:build_number])
     download_path=Dir.pwd + "/metadata/android"
-    gp_downloadmetadata(project_url: "https://translate.wordpress.com/projects/simplenote/android/release-notes/", 
-      target_files: files, 
+    gp_downloadmetadata(project_url: "https://translate.wordpress.com/projects/simplenote/android/release-notes/",
+      target_files: files,
       locales: SUPPORTED_LOCALES.map {| hsh | [ hsh[:glotpress], hsh[:google_play] ]},
       source_locale: "en-US",
       download_path: download_path)
-    
+
     android_create_xml_release_notes(download_path: download_path, build_number: "#{options[:build_number]}", locales: SUPPORTED_LOCALES.map {| hsh | [ hsh[:glotpress], hsh[:google_play] ]})
     add_us_release_notes(relese_notes_path: download_path + "/release_notes.xml", version_name: options[:version])
     sh("git add #{download_path} && (git diff-index --quiet HEAD || git commit -m \"Update metadata translations for #{options[:version]}\") && git push")
-  end 
+  end
 
   #####################################################################################
   # build_and_upload_apk
   # -----------------------------------------------------------------------------------
-  # This lane builds and uploads an app apk 
+  # This lane builds and uploads an app apk
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane build_and_upload_apk version:<version>
-  #  [updload_track:<upload_track: [production | beta]>] 
-  #  [skip_confirm:<skip confirm>] 
+  #  [updload_track:<upload_track: [production | beta]>]
+  #  [skip_confirm:<skip confirm>]
   #####################################################################################
   desc "Builds an app apk and upload it"
   lane :build_and_upload_apk do | options |
@@ -349,7 +349,7 @@ SUPPORTED_LOCALES = [
       skip_upload_screenshots: true,
       json_key: './google-upload-credentials.json',
     ) unless upload_track.blank?
-  
+
     apk_file_path
   end
 
@@ -416,7 +416,7 @@ SUPPORTED_LOCALES = [
 
   private_lane :add_us_release_notes do | options |
     en_release_notes_path  = Dir.pwd + "/.." + "/Simplenote/metadata/release_notes.txt"
-    File.open(options[:relese_notes_path], "a") { |f| 
+    File.open(options[:relese_notes_path], "a") { |f|
       f.puts("<en-US>")
       f.puts("#{options[:version_name]}:")
       f.puts(File.open(en_release_notes_path).read)
@@ -433,8 +433,8 @@ SUPPORTED_LOCALES = [
   private_lane :create_gh_release do | options |
     version = options[:version]
     apk_file_path = universal_apk_file_path(version)
-    create_release(repository:GHHELPER_REPO, 
-      version: version["name"], 
+    create_release(repository:GHHELPER_REPO,
+      version: version["name"],
       release_notes_file_path:release_notes_path,
       release_assets:"#{apk_file_path}"
     )


### PR DESCRIPTION
### Fix
Every time I touch `Fastfile`, my editor barks at me because of trailing whitespaces.
This dedicated PR addresses them to avoid noise in the diff from other PRs.

### Test
Nothing to test here.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.