### PR TITLE
Add Style Setting (Part 6)

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/StyleActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/StyleActivity.java
@@ -36,6 +36,7 @@ import static com.automattic.simplenote.utils.ThemeUtils.STYLE_ARRAY;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_BLACK;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_CLASSIC;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_DEFAULT;
+import static com.automattic.simplenote.utils.ThemeUtils.STYLE_MATRIX;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_MONO;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_PUBLICATION;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_SEPIA;
@@ -186,12 +187,12 @@ public class StyleActivity extends ThemedAppCompatActivity {
                             R.style.Style_Classic)
                         ).inflate(R.layout.style_list_row_default, parent, false)
                     );
-                case STYLE_SEPIA:
+                case STYLE_MATRIX:
                     return new StyleHolder(LayoutInflater.from(
                         new ContextThemeWrapper(
                             parent.getContext(),
-                            R.style.Style_Sepia)
-                        ).inflate(R.layout.style_list_row_sepia, parent, false)
+                            R.style.Style_Matrix)
+                        ).inflate(R.layout.style_list_row_matrix, parent, false)
                     );
                 case STYLE_MONO:
                     return new StyleHolder(LayoutInflater.from(
@@ -206,6 +207,13 @@ public class StyleActivity extends ThemedAppCompatActivity {
                             parent.getContext(),
                             R.style.Style_Publication)
                         ).inflate(R.layout.style_list_row_publication, parent, false)
+                    );
+                case STYLE_SEPIA:
+                    return new StyleHolder(LayoutInflater.from(
+                        new ContextThemeWrapper(
+                            parent.getContext(),
+                            R.style.Style_Sepia)
+                        ).inflate(R.layout.style_list_row_sepia, parent, false)
                     );
                 case STYLE_DEFAULT:
                 default:
@@ -224,12 +232,14 @@ public class StyleActivity extends ThemedAppCompatActivity {
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? android.R.color.black : android.R.color.white;
                 case STYLE_CLASSIC:
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.blue_50 : R.color.blue_20;
-                case STYLE_SEPIA:
-                    return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.orange_50 : R.color.orange_20;
+                case STYLE_MATRIX:
+                    return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.green_50 : R.color.green_20;
                 case STYLE_MONO:
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.gray_50 : R.color.gray_20;
                 case STYLE_PUBLICATION:
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.red_50 : R.color.red_20;
+                case STYLE_SEPIA:
+                    return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.orange_50 : R.color.orange_20;
                 case STYLE_DEFAULT:
                 default:
                     return ThemeUtils.isLightTheme(StyleActivity.this) ? R.color.simplenote_blue_50 : R.color.simplenote_blue_20;

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -22,6 +22,7 @@ import static com.automattic.simplenote.models.Note.PINNED_INDEX_NAME;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_BLACK;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_CLASSIC;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_DEFAULT;
+import static com.automattic.simplenote.utils.ThemeUtils.STYLE_MATRIX;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_MONO;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_PUBLICATION;
 import static com.automattic.simplenote.utils.ThemeUtils.STYLE_SEPIA;
@@ -176,12 +177,14 @@ public class PrefUtils {
                 return context.getString(R.string.style_black);
             case STYLE_CLASSIC:
                 return context.getString(R.string.style_classic);
-            case STYLE_SEPIA:
-                return context.getString(R.string.style_sepia);
+            case STYLE_MATRIX:
+                return context.getString(R.string.style_matrix);
             case STYLE_MONO:
                 return context.getString(R.string.style_mono);
             case STYLE_PUBLICATION:
                 return context.getString(R.string.style_publication);
+            case STYLE_SEPIA:
+                return context.getString(R.string.style_sepia);
             case STYLE_DEFAULT:
             default:
                 return context.getString(R.string.style_default);

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -20,15 +20,17 @@ import static android.content.res.Configuration.UI_MODE_NIGHT_MASK;
 import static android.content.res.Configuration.UI_MODE_NIGHT_YES;
 
 public class ThemeUtils {
-    public static final int STYLE_BLACK = 4;
-    public static final int STYLE_CLASSIC = 5;
+    public static final int STYLE_BLACK = 5;
+    public static final int STYLE_CLASSIC = 6;
     public static final int STYLE_DEFAULT = 0;
-    public static final int STYLE_MONO = 2;
-    public static final int STYLE_PUBLICATION = 1;
-    public static final int STYLE_SEPIA = 3;
+    public static final int STYLE_MONO = 3;
+    public static final int STYLE_PUBLICATION = 2;
+    public static final int STYLE_MATRIX = 1;
+    public static final int STYLE_SEPIA = 4;
 
     public static final int[] STYLE_ARRAY = {
         STYLE_DEFAULT,
+        STYLE_MATRIX,
         STYLE_PUBLICATION,
         STYLE_MONO,
         STYLE_SEPIA,
@@ -124,6 +126,7 @@ public class ThemeUtils {
 
         switch (PrefUtils.getStyleIndexSelected(context)) {
             case STYLE_BLACK:
+            case STYLE_MATRIX:
                 return isLight ? "light.css" : "dark_black.css";
             case STYLE_SEPIA:
                 return isLight ? "light_sepia.css" : "dark_sepia.css";
@@ -145,6 +148,8 @@ public class ThemeUtils {
                     return R.style.Style_Black;
                 case STYLE_CLASSIC:
                     return R.style.Style_Classic;
+                case STYLE_MATRIX:
+                    return R.style.Style_Matrix;
                 case STYLE_MONO:
                     return R.style.Style_Mono;
                 case STYLE_PUBLICATION:

--- a/Simplenote/src/main/res/drawable/bg_list_matrix.xml
+++ b/Simplenote/src/main/res/drawable/bg_list_matrix.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ripple
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/background_list_matrix_ripple">
+
+    <item
+        android:id="@android:id/mask"
+        android:drawable="?attr/mainBackgroundColor">
+    </item>
+
+    <item>
+
+        <selector>
+
+            <item
+                android:drawable="@color/background_list_matrix_activated"
+                android:state_activated="true">
+            </item>
+
+            <item
+                android:drawable="@android:color/transparent">
+            </item>
+
+        </selector>
+
+    </item>
+
+</ripple>

--- a/Simplenote/src/main/res/drawable/bg_list_style_matrix.xml
+++ b/Simplenote/src/main/res/drawable/bg_list_style_matrix.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:drawable="@drawable/bg_style_activated"
+        android:state_activated="true">
+    </item>
+
+    <item
+        android:drawable="@drawable/bg_style_black">
+    </item>
+
+</selector>

--- a/Simplenote/src/main/res/layout/style_list_row_matrix.xml
+++ b/Simplenote/src/main/res/layout/style_list_row_matrix.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@drawable/bg_list_style_matrix"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/padding_small"
+    android:layout_marginEnd="@dimen/padding_large"
+    android:layout_marginStart="@dimen/padding_large"
+    android:layout_marginTop="@dimen/padding_small"
+    android:layout_width="match_parent"
+    app:cardCornerRadius="@dimen/corner_radius"
+    app:cardElevation="0dp"
+    style="@style/Style.Matrix">
+
+    <RelativeLayout
+        android:background="@drawable/bg_list_style_default"
+        android:foreground="?attr/selectableItemBackground"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:padding="@dimen/padding_large">
+
+        <TextView
+            android:id="@+id/preview_title"
+            android:ellipsize="end"
+            android:fontFamily="?attr/styleFontFamily"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/padding_small"
+            android:layout_width="match_parent"
+            android:maxLines="1"
+            android:textColor="@color/style_preview_default_title"
+            android:textSize="@dimen/text_content_title"
+            android:textStyle="bold"
+            tools:fontFamily="monospace"
+            tools:text="@string/style_matrix">
+        </TextView>
+
+        <TextView
+            android:id="@+id/preview_content"
+            android:ellipsize="end"
+            android:fontFamily="?attr/styleFontFamily"
+            android:layout_below="@id/preview_title"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:maxLines="2"
+            android:text="@string/style_preview"
+            android:textColor="@color/style_preview_default_content"
+            tools:fontFamily="monospace">
+        </TextView>
+
+        <ImageView
+            android:id="@+id/preview_locked"
+            android:background="@drawable/bg_style_locked"
+            android:contentDescription="@string/description_locked"
+            android:layout_centerInParent="true"
+            android:layout_height="@dimen/icon_locked"
+            android:layout_width="@dimen/icon_locked"
+            android:padding="@dimen/padding_medium"
+            android:src="@drawable/ic_lock_24dp"
+            android:visibility="gone"
+            tools:visibility="visible">
+        </ImageView>
+
+    </RelativeLayout>
+
+</androidx.cardview.widget.CardView>

--- a/Simplenote/src/main/res/values-night/colors.xml
+++ b/Simplenote/src/main/res/values-night/colors.xml
@@ -14,6 +14,8 @@
     <color name="background_list_sepia_activated">@color/background_dark_highlight_sepia</color>
     <color name="background_list_sepia_ripple">@color/background_dark_highlight_sepia</color>
     <color name="background_list_default">@color/background_dark_highlight</color>
+    <color name="background_list_matrix_activated">@color/background_dark_black_8</color>
+    <color name="background_list_matrix_ripple">@color/background_dark_black_2</color>
     <color name="style_preview_black_content">@android:color/white</color>
     <color name="style_preview_black_title">@android:color/white</color>
     <color name="style_preview_default_content">@color/text_content_dark</color>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -171,7 +171,7 @@
         <item name="colorAccent">@color/item_matrix_dark</item>
         <item name="colorPrimary">@color/green</item>
         <item name="colorPrimaryDark">@color/background_dark_matrix</item>
-        <item name="drawerBackgroundColor">@color/background_dark_matrix</item>
+        <item name="drawerBackgroundColor">@color/background_dark_0</item>
         <item name="drawerBackgroundSelector">@color/bg_drawer_selector_dark</item>
         <item name="editorSearchHighlightBackgroundColor">@color/green_60</item>
         <item name="editorSearchHighlightForegroundColor">@color/green_5</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -163,6 +163,31 @@
         <item name="toolbarIconColor">@color/item_classic_dark</item>
     </style>
 
+    <style name="Style.Matrix" parent="Theme.Simplestyle">
+        <item name="android:windowBackground">@color/background_dark_matrix</item>
+        <item name="actionModeBackgroundColor">@color/background_dark_matrix</item>
+        <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
+        <item name="actionModeTextColor">@color/item_matrix_dark</item>
+        <item name="colorAccent">@color/item_matrix_dark</item>
+        <item name="colorPrimary">@color/green</item>
+        <item name="colorPrimaryDark">@color/background_dark_matrix</item>
+        <item name="drawerBackgroundColor">@color/background_dark_matrix</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_dark</item>
+        <item name="editorSearchHighlightBackgroundColor">@color/green_60</item>
+        <item name="editorSearchHighlightForegroundColor">@color/green_5</item>
+        <item name="emptyImageColor">@color/empty_dark_black</item>
+        <item name="fabColor">@color/item_matrix_dark</item>
+        <item name="fabIconColor">@color/gray_100</item>
+        <item name="iconTintColor">@color/item_matrix_dark</item>
+        <item name="listBackgroundSelector">@drawable/bg_list_matrix</item>
+        <item name="listSearchHighlightBackgroundColor">@color/green_60</item>
+        <item name="listSearchHighlightForegroundColor">@color/green_5</item>
+        <item name="mainBackgroundColor">@color/background_dark_matrix</item>
+        <item name="sheetBackgroundColor">@color/background_dark_black_8</item>
+        <item name="styleFontFamily">monospace</item>
+        <item name="toolbarColor">@color/background_dark_matrix</item>
+    </style>
+
     <style name="Style.Mono" parent="Theme.Simplestyle">
         <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
         <item name="actionModeTextColor">@color/item_mono_dark</item>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -59,6 +59,7 @@
     <color name="background_dark_highlight">@color/background_dark_8</color>
     <color name="background_dark_highlight_drawer">#4d5152</color>
     <color name="background_dark_highlight_sepia">@color/background_dark_sepia_8</color>
+    <color name="background_dark_matrix">@color/background_dark_black_1</color>
     <color name="background_dark_sepia">@color/background_dark_sepia_1</color>
     <color name="background_light">@android:color/white</color>
     <color name="background_light_highlight">@color/simplenote_blue_5</color>
@@ -68,6 +69,8 @@
     <color name="background_list_classic_activated">@color/blue_5</color>
     <color name="background_list_classic_ripple">@color/blue_0</color>
     <color name="background_list_default">@color/background_light_highlight</color>
+    <color name="background_list_matrix_activated">@color/green_5</color>
+    <color name="background_list_matrix_ripple">@color/green_0</color>
     <color name="background_list_mono_activated">@color/gray_5</color>
     <color name="background_list_mono_ripple">@color/gray_0</color>
     <color name="background_list_publication_activated">@color/red_5</color>
@@ -91,6 +94,8 @@
     <color name="item_classic_light">@color/blue_50</color>
     <color name="item_default_dark">@color/simplenote_blue_20</color>
     <color name="item_default_light">@color/simplenote_blue_50</color>
+    <color name="item_matrix_dark">@color/green_20</color>
+    <color name="item_matrix_light">@color/green_50</color>
     <color name="item_mono_dark">@color/gray_20</color>
     <color name="item_mono_light">@color/gray_50</color>
     <color name="item_publication_dark">@color/red_20</color>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -124,6 +124,7 @@
     <string name="style_default">Default</string>
     <string name="style_dialog_locked_message">This style is locked. Premium membership is required to unlock it. Would you like to change your membership?</string>
     <string name="style_dialog_locked_title">Style Locked</string>
+    <string name="style_matrix">Matrix</string>
     <string name="style_mono">Mono</string>
     <string name="style_preview">![Image](%1$s%2$s%3$shttps://img_url.com/jpg%4$s) Aliquam erat volutpat. Pellentesque ut odio suscipit.</string>
     <string name="style_publication">Publication</string>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -385,6 +385,30 @@
     <style name="Style.Default" parent="Theme.Simplestyle">
     </style>
 
+    <style name="Style.Matrix" parent="Theme.Simplestyle">
+        <item name="android:windowBackground">@color/background_light</item>
+        <item name="actionModeBackgroundColor">@color/background_light</item>
+        <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
+        <item name="actionModeTextColor">@color/item_matrix_light</item>
+        <item name="colorAccent">@color/item_matrix_light</item>
+        <item name="colorPrimary">@color/green</item>
+        <item name="colorPrimaryDark">@color/background_light</item>
+        <item name="drawerBackgroundColor">@color/background_light</item>
+        <item name="drawerBackgroundSelector">@color/bg_drawer_selector_accent</item>
+        <item name="editorSearchHighlightBackgroundColor">@color/green_5</item>
+        <item name="editorSearchHighlightForegroundColor">@color/green_60</item>
+        <item name="emptyImageColor">@color/empty_light</item>
+        <item name="fabColor">@color/item_matrix_light</item>
+        <item name="fabIconColor">@android:color/white</item>
+        <item name="iconTintColor">@color/item_matrix_light</item>
+        <item name="listBackgroundSelector">@drawable/bg_list_matrix</item>
+        <item name="listSearchHighlightBackgroundColor">@color/green_5</item>
+        <item name="listSearchHighlightForegroundColor">@color/green_60</item>
+        <item name="mainBackgroundColor">@color/background_light</item>
+        <item name="toolbarColor">@color/background_light</item>
+        <item name="styleFontFamily">monospace</item>
+    </style>
+
     <style name="Style.Mono" parent="Theme.Simplestyle">
         <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
         <item name="actionModeTextColor">@color/item_mono_light</item>


### PR DESCRIPTION
### Fix
This is the sixth part in a series of pull requests to add a style setting to the app.  The pull requests are split into parts in an attempt to make the changes smaller.  This part adds the ***Matrix*** style.  See the screenshots below for illustration.

![add_style_setting_all_06_](https://user-images.githubusercontent.com/3827611/91179189-69f5de00-e6a3-11ea-9045-e4cba5c1f534.png)

#### Note
The dialog background color is not as shown in the screenshots above with **_Dark_** theme.  That will be fixed in a subsequent pull request.  Contact me for an installable build.

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in drawer.
3. Tap ***Style*** item under ***Appearance*** section.
4. Notice ***Style*** screen with ***Default***, ***Matrix***, ***Publication***, ***Mono***, ***Sepia***, ***Black***, and ***Classic*** styles.
5. Tap ***Matrix*** style.
6. Notice ***Matrix*** style is selected and app has ***Matrix*** styling.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.  `RELEASE-NOTES.txt` will be updated once the styles feature is complete.