### PR TITLE
Add Sync Worker

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,10 +1,11 @@
-3.0
+2.10
 -----
- 
+* Added syncing in the background to avoid data loss when exiting the app
+
 2.9
 -----
 * Fixed a bug with duplicate tags and special characters in tag names
- 
+
 2.8
 -----
 * Added hotkey shortcuts for devices with hardware keyboards

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -91,6 +91,7 @@ dependencies {
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation 'androidx.preference:preference:1.1.0'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
+    implementation 'androidx.work:work-runtime:2.4.0'
     // Google Play Services
     implementation 'com.google.android.gms:play-services-wearable:17.0.0'
     // Third Party

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.work.BackoffPolicy;
 import androidx.work.Constraints;
@@ -202,7 +203,7 @@ public class Simplenote extends Application {
         }
 
         @Override
-        public void onConfigurationChanged(Configuration newConfig) {
+        public void onConfigurationChanged(@NonNull Configuration newConfig) {
             AppLog.add(Type.LAYOUT, DisplayUtils.getDisplaySizeAndOrientation(Simplenote.this));
         }
 
@@ -213,7 +214,7 @@ public class Simplenote extends Application {
         // ActivityLifeCycle callbacks
         @SuppressLint("LongLogTag")
         @Override
-        public void onActivityResumed(Activity activity) {
+        public void onActivityResumed(@NonNull Activity activity) {
             if (mIsInBackground) {
                 AnalyticsTracker.track(
                         AnalyticsTracker.Stat.APPLICATION_OPENED,
@@ -229,16 +230,16 @@ public class Simplenote extends Application {
         }
 
         @Override
-        public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+        public void onActivityCreated(@NonNull Activity activity, Bundle savedInstanceState) {
         }
 
         @Override
-        public void onActivityStarted(Activity activity) {
+        public void onActivityStarted(@NonNull Activity activity) {
         }
 
         @SuppressLint("LongLogTag")
         @Override
-        public void onActivityPaused(Activity activity) {
+        public void onActivityPaused(@NonNull Activity activity) {
             PeriodicWorkRequest syncWorkRequest = new PeriodicWorkRequest.Builder(
                 SyncWorker.class,
                 PeriodicWorkRequest.MIN_PERIODIC_INTERVAL_MILLIS,
@@ -258,15 +259,15 @@ public class Simplenote extends Application {
         }
 
         @Override
-        public void onActivityStopped(Activity activity) {
+        public void onActivityStopped(@NonNull Activity activity) {
         }
 
         @Override
-        public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+        public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {
         }
 
         @Override
-        public void onActivityDestroyed(Activity activity) {
+        public void onActivityDestroyed(@NonNull Activity activity) {
         }
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -32,22 +32,23 @@ import org.wordpress.passcodelock.AppLockManager;
 import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
 
 public class Simplenote extends Application {
-
-    private static final int TEN_SECONDS_MILLIS = 10000;
-
-    // log tag
-    public static final String TAG = "Simplenote";
-
-    // intent IDs
-    public static final int INTENT_PREFERENCES = 1;
-    public static final int INTENT_EDIT_NOTE = 2;
     public static final String DELETED_NOTE_ID = "deletedNoteId";
     public static final String SELECTED_NOTE_ID = "selectedNoteId";
+    public static final String TAG = "Simplenote";
+    public static final int INTENT_EDIT_NOTE = 2;
+    public static final int INTENT_PREFERENCES = 1;
+    public static final int ONE_MINUTE_MILLIS = 60 * 1000;  // 60 seconds
+    public static final int TEN_SECONDS_MILLIS = 10 * 1000;  // 10 seconds
+
     private static final String AUTH_PROVIDER = "simplenote.com";
-    private Simperium mSimperium;
+    private static final String TAG_SYNC = "sync";
+
+    private static Bucket<Preferences> mPreferencesBucket;
+
     private Bucket<Note> mNotesBucket;
     private Bucket<Tag> mTagsBucket;
-    private static Bucket<Preferences> mPreferencesBucket;
+    private Simperium mSimperium;
+    private boolean mIsInBackground = true;
 
     public void onCreate() {
         super.onCreate();
@@ -141,10 +142,11 @@ public class Simplenote extends Application {
         return mPreferencesBucket;
     }
 
-    private class ApplicationLifecycleMonitor implements Application.ActivityLifecycleCallbacks,
-            ComponentCallbacks2 {
-        private boolean mIsInBackground = true;
+    public boolean isInBackground() {
+        return mIsInBackground;
+    }
 
+    private class ApplicationLifecycleMonitor implements Application.ActivityLifecycleCallbacks, ComponentCallbacks2 {
         // ComponentCallbacks
         @Override
         public void onTrimMemory(int level) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -1,5 +1,6 @@
 package com.automattic.simplenote;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
 import android.content.ComponentCallbacks2;
@@ -7,6 +8,7 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.Log;
 
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.work.BackoffPolicy;
@@ -209,6 +211,7 @@ public class Simplenote extends Application {
         }
 
         // ActivityLifeCycle callbacks
+        @SuppressLint("LongLogTag")
         @Override
         public void onActivityResumed(Activity activity) {
             if (mIsInBackground) {
@@ -221,6 +224,7 @@ public class Simplenote extends Application {
                 mIsInBackground = false;
                 AppLog.add(Type.ACTION, "App opened");
                 WorkManager.getInstance(getApplicationContext()).cancelUniqueWork(TAG_SYNC);
+                Log.d("Simplenote.onActivityResumed", "Stopped worker");
             }
         }
 
@@ -232,6 +236,7 @@ public class Simplenote extends Application {
         public void onActivityStarted(Activity activity) {
         }
 
+        @SuppressLint("LongLogTag")
         @Override
         public void onActivityPaused(Activity activity) {
             PeriodicWorkRequest syncWorkRequest = new PeriodicWorkRequest.Builder(
@@ -249,6 +254,7 @@ public class Simplenote extends Application {
                 ExistingPeriodicWorkPolicy.REPLACE,
                 syncWorkRequest
             );
+            Log.d("Simplenote.onActivityPaused", "Started worker");
         }
 
         @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SyncWorker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SyncWorker.java
@@ -1,0 +1,69 @@
+package com.automattic.simplenote.utils;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+
+import androidx.annotation.NonNull;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import com.automattic.simplenote.Simplenote;
+import com.automattic.simplenote.models.Note;
+import com.automattic.simplenote.models.Preferences;
+import com.automattic.simplenote.models.Tag;
+import com.simperium.client.Bucket;
+
+import static com.automattic.simplenote.Simplenote.TEN_SECONDS_MILLIS;
+
+public class SyncWorker extends Worker {
+    private Bucket<Note> mBucketNote;
+    private Bucket<Preferences> mBucketPreference;
+    private Bucket<Tag> mBucketTag;
+
+    public SyncWorker(@NonNull Context context, @NonNull WorkerParameters params) {
+        super(context, params);
+        Simplenote application = (Simplenote) context.getApplicationContext();
+        mBucketNote = application.getNotesBucket();
+        mBucketTag = application.getTagsBucket();
+        mBucketPreference  = application.getPreferencesBucket();
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        mBucketNote.start();
+        mBucketTag.start();
+        mBucketPreference.start();
+
+        new Handler(Looper.getMainLooper()).postDelayed(
+            new Runnable() {
+                @Override
+                public void run() {
+                    if (mBucketNote != null) {
+                        mBucketNote.stop();
+                    }
+
+                    if (mBucketTag != null) {
+                        mBucketTag.stop();
+                    }
+
+                    if (mBucketPreference != null) {
+                        mBucketPreference.stop();
+                    }
+                }
+            },
+            TEN_SECONDS_MILLIS
+        );
+
+        return Result.retry();
+    }
+
+    @Override
+    public void onStopped() {
+        super.onStopped();
+        mBucketNote.stop();
+        mBucketTag.stop();
+        mBucketPreference.stop();
+    }
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SyncWorker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SyncWorker.java
@@ -13,6 +13,7 @@ import com.automattic.simplenote.Simplenote;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Preferences;
 import com.automattic.simplenote.models.Tag;
+import com.automattic.simplenote.utils.AppLog.Type;
 import com.simperium.client.Bucket;
 
 import static com.automattic.simplenote.Simplenote.TEN_SECONDS_MILLIS;
@@ -33,9 +34,23 @@ public class SyncWorker extends Worker {
     @NonNull
     @Override
     public Result doWork() {
-        mBucketNote.start();
-        mBucketTag.start();
-        mBucketPreference.start();
+        AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(getApplicationContext()));
+
+        if (mBucketNote != null) {
+            mBucketNote.start();
+            AppLog.add(Type.SYNC, "Started note bucket (SyncWorker)");
+        }
+
+        if (mBucketTag != null) {
+            mBucketTag.start();
+            AppLog.add(Type.SYNC, "Started tag bucket (SyncWorker)");
+        }
+
+        if (mBucketPreference != null) {
+            mBucketPreference.start();
+            AppLog.add(Type.SYNC, "Started preference bucket (SyncWorker)");
+        }
+
         Log.d("SyncWorker.doWork", "Started buckets");
 
         new Handler(Looper.getMainLooper()).postDelayed(
@@ -45,14 +60,17 @@ public class SyncWorker extends Worker {
                     if (((Simplenote) getApplicationContext()).isInBackground()) {
                         if (mBucketNote != null) {
                             mBucketNote.stop();
+                            AppLog.add(Type.SYNC, "Stopped note bucket (SyncWorker)");
                         }
 
                         if (mBucketTag != null) {
                             mBucketTag.stop();
+                            AppLog.add(Type.SYNC, "Stopped tag bucket (SyncWorker)");
                         }
 
                         if (mBucketPreference != null) {
                             mBucketPreference.stop();
+                            AppLog.add(Type.SYNC, "Stopped preference bucket (SyncWorker)");
                         }
 
                         Log.d("SyncWorker.doWork", "Stopped buckets");
@@ -68,9 +86,22 @@ public class SyncWorker extends Worker {
     @Override
     public void onStopped() {
         super.onStopped();
-        mBucketNote.stop();
-        mBucketTag.stop();
-        mBucketPreference.stop();
+
+        if (mBucketNote != null) {
+            mBucketNote.stop();
+            AppLog.add(Type.SYNC, "Stopped note bucket (SyncWorker)");
+        }
+
+        if (mBucketTag != null) {
+            mBucketTag.stop();
+            AppLog.add(Type.SYNC, "Stopped tag bucket (SyncWorker)");
+        }
+
+        if (mBucketPreference != null) {
+            mBucketPreference.stop();
+            AppLog.add(Type.SYNC, "Stopped preference bucket (SyncWorker)");
+        }
+
         Log.d("SyncWorker.onStopped", "Stopped buckets");
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SyncWorker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SyncWorker.java
@@ -40,16 +40,18 @@ public class SyncWorker extends Worker {
             new Runnable() {
                 @Override
                 public void run() {
-                    if (mBucketNote != null) {
-                        mBucketNote.stop();
-                    }
+                    if (((Simplenote) getApplicationContext()).isInBackground()) {
+                        if (mBucketNote != null) {
+                            mBucketNote.stop();
+                        }
 
-                    if (mBucketTag != null) {
-                        mBucketTag.stop();
-                    }
+                        if (mBucketTag != null) {
+                            mBucketTag.stop();
+                        }
 
-                    if (mBucketPreference != null) {
-                        mBucketPreference.stop();
+                        if (mBucketPreference != null) {
+                            mBucketPreference.stop();
+                        }
                     }
                 }
             },

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SyncWorker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SyncWorker.java
@@ -3,6 +3,7 @@ package com.automattic.simplenote.utils;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.work.Worker;
@@ -35,6 +36,7 @@ public class SyncWorker extends Worker {
         mBucketNote.start();
         mBucketTag.start();
         mBucketPreference.start();
+        Log.d("SyncWorker.doWork", "Started buckets");
 
         new Handler(Looper.getMainLooper()).postDelayed(
             new Runnable() {
@@ -52,6 +54,8 @@ public class SyncWorker extends Worker {
                         if (mBucketPreference != null) {
                             mBucketPreference.stop();
                         }
+
+                        Log.d("SyncWorker.doWork", "Stopped buckets");
                     }
                 }
             },
@@ -67,5 +71,6 @@ public class SyncWorker extends Worker {
         mBucketNote.stop();
         mBucketTag.stop();
         mBucketPreference.stop();
+        Log.d("SyncWorker.onStopped", "Stopped buckets");
     }
 }


### PR DESCRIPTION
### Fix
Add a worker to run syncing tasks in the background to avoid data loss as described in #992 among other issues.  The background tasks are starting and stopping the note, tag, and preference buckets, which effectively triggers syncing.  Currently, the buckets are stopped after the app has been closed for ten seconds.  The worker added in these changes starts after the app has been closed for ten seconds.  It also has a backoff criteria of one minute and a constraint which requires an active network connection.  The worker starts the buckets and stops them after ten seconds.  The flow is as follows:
- After the app is closed for ten seconds, start the worker
- If there is an active network connection...
    - Start the buckets
    - Start timer for one minute to start the buckets again
    - Stop the buckets after ten seconds
- When the app is resumed, stop the worker

Effectively, the buckets are started for ten seconds every minute when there is a network connection.

### Test
There aren't any user-facing changes to this pull request.  The best way to see what's happening is to watch the logcat with the logs filtered to show "Debug" only and the "(Started)|(Stopped)" regular expression is used.  See the logs below for example.

```
2020-08-25 11:07:01.796 17642-17642/com.automattic.simplenote.debug D/Simplenote.onActivityPaused: Started worker
2020-08-25 11:07:11.866 17642-17883/com.automattic.simplenote.debug D/SyncWorker.doWork: Started buckets
2020-08-25 11:07:21.908 17642-17642/com.automattic.simplenote.debug D/SyncWorker.doWork: Stopped buckets
2020-08-25 11:08:11.912 17642-17991/com.automattic.simplenote.debug D/SyncWorker.doWork: Started buckets
2020-08-25 11:08:21.954 17642-17642/com.automattic.simplenote.debug D/SyncWorker.doWork: Stopped buckets
2020-08-25 11:08:24.860 17642-17642/com.automattic.simplenote.debug D/Simplenote.onActivityResumed: Stopped worker
```

While watching the logcat, launch the app then send it to the background by going to the home screen or opening another app.  Verify the buckets are started and stopped according to the flow mentioned above.

### Review
Only one developer is required to review these changes, but anyone can perform the review.  @malinajirka and @maxme, I requested you as reviewers too since you commented on the background service idea and seem to have experience with this type of implementation.

### Release
`RELEASE-NOTES.txt` was updated in 2f92028 with:
> Added syncing in the background to avoid data loss when exiting the app