### PR TITLE
Add Style Setting (Part 7)

### DIFF
--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -60,6 +60,14 @@
         <item name="tint">@color/item_default_dark</item>
     </style>
 
+    <style name="Dialog.Black" parent="Dialog">
+        <item name="android:colorBackground">@color/background_dark_black_8</item>
+    </style>
+
+    <style name="Dialog.Sepia" parent="Dialog">
+        <item name="android:colorBackground">@color/background_dark_sepia_8</item>
+    </style>
+
     <style name="DrawerArrowStyle" parent="Widget.AppCompat.DrawerArrowToggle">
         <item name="color">?attr/toolbarIconColor</item>
         <item name="spinBars">true</item>
@@ -118,11 +126,13 @@
     </style>
 
     <style name="Style.Black" parent="Theme.Simplestyle">
+        <item name="android:alertDialogTheme">@style/Dialog.Black</item>
         <item name="android:navigationBarColor">@android:color/black</item>
         <item name="android:windowBackground">@android:color/black</item>
         <item name="actionModeBackgroundColor">@color/background_dark_0</item>
         <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.White</item>
         <item name="actionModeTextColor">@color/item_black_dark</item>
+        <item name="alertDialogTheme">@style/Dialog.Black</item>
         <item name="chipCheckedOnBackgroundColor">@color/background_dark_24</item>
         <item name="chipCheckedOffBackgroundColor">@color/background_dark_8</item>
         <item name="colorAccent">@color/item_black_dark</item>
@@ -164,10 +174,12 @@
     </style>
 
     <style name="Style.Matrix" parent="Theme.Simplestyle">
+        <item name="android:alertDialogTheme">@style/Dialog.Black</item>
         <item name="android:windowBackground">@color/background_dark_matrix</item>
         <item name="actionModeBackgroundColor">@color/background_dark_matrix</item>
         <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
         <item name="actionModeTextColor">@color/item_matrix_dark</item>
+        <item name="alertDialogTheme">@style/Dialog.Black</item>
         <item name="colorAccent">@color/item_matrix_dark</item>
         <item name="colorPrimary">@color/green</item>
         <item name="colorPrimaryDark">@color/background_dark_matrix</item>
@@ -223,11 +235,13 @@
     </style>
 
     <style name="Style.Sepia" parent="Theme.Simplestyle">
+        <item name="android:alertDialogTheme">@style/Dialog.Sepia</item>
         <item name="android:navigationBarColor">?attr/mainBackgroundColor</item>
         <item name="android:windowBackground">@color/background_dark_sepia</item>
         <item name="actionModeBackgroundColor">@color/background_dark_sepia_4</item>
         <item name="actionModeCloseButtonStyle">@style/CloseButtonStyle.Accent</item>
         <item name="actionModeTextColor">@color/item_sepia_dark</item>
+        <item name="alertDialogTheme">@style/Dialog.Sepia</item>
         <item name="chipCheckedOnBackgroundColor">@color/background_dark_sepia_24</item>
         <item name="chipCheckedOffBackgroundColor">@color/background_dark_sepia_8</item>
         <item name="colorAccent">@color/item_sepia_dark</item>


### PR DESCRIPTION
### Fix
This is the seventh part in a series of pull requests to add a style setting to the app.  The pull requests are split into parts in an attempt to make the changes smaller.  This part updates the dialog background color for the ***Black***, ***Matrix***, and ***Sepia*** styles with ***Dark*** theme.  See the screenshots below for illustration.

![add_style_setting_dialog](https://user-images.githubusercontent.com/3827611/91361095-dc0a1800-e7b4-11ea-8edb-6ac94ed2fcde.png)

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in drawer.
3. Tap ***Style*** item under ***Appearance*** section.
4. Tap ***Black***, ***Matrix***, or ***Sepia*** style.
5. Tap back arrow in app bar.
6. Tap back arrow in app bar.
7. Open navigation drawer.
8. Tap ***Edit*** button in ***Tags*** header.
9. Tap any tag in list.
10. Notice dialog background color as shown in screenshots above.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.  `RELEASE-NOTES.txt` will be updated once the styles feature is complete.