### PR TITLE
Add Tracking Recent

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -83,6 +83,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_SEARCH;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.RECENT_SEARCH_TAPPED;
 import static com.automattic.simplenote.models.Note.TAGS_PROPERTY;
 import static com.automattic.simplenote.models.Preferences.MAX_RECENT_SEARCHES;
 import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
@@ -1265,6 +1267,14 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                 @Override
                 public void onClick(View view) {
                     ((NotesActivity) requireActivity()).submitSearch(holder.mSuggestionText.getText().toString());
+
+                    if (holder.mViewType == HISTORY) {
+                        AnalyticsTracker.track(
+                            RECENT_SEARCH_TAPPED,
+                            CATEGORY_SEARCH,
+                            "recent_search_tapped"
+                        );
+                    }
                 }
             });
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
@@ -9,6 +9,7 @@ import java.util.Map;
 public final class AnalyticsTracker {
     private static final List<Tracker> TRACKERS = new ArrayList<>();
     public static String CATEGORY_NOTE = "note";
+    public static String CATEGORY_SEARCH = "search";
     public static String CATEGORY_TAG = "tag";
     public static String CATEGORY_USER = "user";
     public static String CATEGORY_WIDGET = "widget";
@@ -154,7 +155,8 @@ public final class AnalyticsTracker {
         NOTE_WIDGET_LAST_DELETED,
         NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED,
         NOTE_WIDGET_NOTE_TAPPED,
-        NOTE_WIDGET_SIGN_IN_TAPPED
+        NOTE_WIDGET_SIGN_IN_TAPPED,
+        RECENT_SEARCH_TAPPED
     }
 
     public interface Tracker {


### PR DESCRIPTION
### Fix
Add analytics to track when recent searches is used.

### Test
There are no user-facing changes in this pull request.  In order to check if the analytics tracking is triggered in the right spot, set a breakpoint [here](https://github.com/Automattic/simplenote-android/compare/add-tracking-recent?expand=1#diff-291124c3836fdaed5786d9e1f5aab559R1272) and follow the steps below.
1. Tap ***Search*** action in top app bar.
2. Tap any recent search item.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.