### PR TITLE
Update Search Empty

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -68,6 +68,7 @@ import com.automattic.simplenote.utils.StrUtils;
 import com.automattic.simplenote.utils.TextHighlighter;
 import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.utils.WidgetUtils;
+import com.automattic.simplenote.widgets.RobotoRegularTextView;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
 import com.simperium.client.Bucket;
@@ -138,6 +139,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     private Bucket<Tag> mBucketTag;
     private ActionMode mActionMode;
     private View mRootView;
+    private RobotoRegularTextView mEmptyViewButton;
     private ImageView mEmptyViewImage;
     private TextView mEmptyViewText;
     private View mDividerLine;
@@ -289,6 +291,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
         LinearLayout emptyView = view.findViewById(android.R.id.empty);
         emptyView.setVisibility(View.GONE);
+        mEmptyViewButton = emptyView.findViewById(R.id.button);
         mEmptyViewImage = emptyView.findViewById(R.id.image);
         mEmptyViewText = emptyView.findViewById(R.id.text);
         setEmptyListImage(R.drawable.ic_notes_24dp);
@@ -577,6 +580,17 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER, String.valueOf(mPreferenceSortOrder)).apply();
         // Reset the active callbacks interface to the dummy implementation.
         mCallbacks = sCallbacks;
+    }
+
+    public void setEmptyListButton(String message) {
+        if (mEmptyViewButton != null) {
+            if (!message.isEmpty()) {
+                mEmptyViewButton.setVisibility(View.VISIBLE);
+                mEmptyViewButton.setText(message);
+            } else {
+                mEmptyViewButton.setVisibility(View.GONE);
+            }
+        }
     }
 
     public void setEmptyListImage(@DrawableRes int image) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -283,7 +283,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         if (ACTION_NEW_NOTE.equals(notesActivity.getIntent().getAction()) &&
                 !notesActivity.userIsUnauthorized()){
             //if user tap on "app shortcut", create a new note
-            createNewNote("new_note_shortcut");
+            createNewNote("", "new_note_shortcut");
         }
 
         mPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
@@ -307,7 +307,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mFloatingActionButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                createNewNote("action_bar_button");
+                createNewNote("", "action_bar_button");
             }
         });
         mFloatingActionButton.setOnLongClickListener(new View.OnLongClickListener() {
@@ -523,14 +523,16 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         }
     }
 
-    public void createNewNote(String label){
-        if (!isAdded()) return;
+    public void createNewNote(String title, String label){
+        if (!isAdded()) {
+            return;
+        }
 
-        addNote();
+        addNote(title);
         AnalyticsTracker.track(
-                AnalyticsTracker.Stat.LIST_NOTE_CREATED,
-                AnalyticsTracker.CATEGORY_NOTE,
-                label
+            AnalyticsTracker.Stat.LIST_NOTE_CREATED,
+            AnalyticsTracker.CATEGORY_NOTE,
+            label
         );
     }
 
@@ -774,25 +776,29 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         return matcher.replaceAll("");
     }
 
-    public void addNote() {
-
+    public void addNote(String title) {
         // Prevents jarring 'New note...' from showing in the list view when creating a new note
         NotesActivity notesActivity = (NotesActivity) requireActivity();
-        if (!DisplayUtils.isLargeScreenLandscape(notesActivity))
+
+        if (!DisplayUtils.isLargeScreenLandscape(notesActivity)) {
             notesActivity.stopListeningToNotesBucket();
+        }
 
         // Create & save new note
         Simplenote simplenote = (Simplenote) requireActivity().getApplication();
         Bucket<Note> notesBucket = simplenote.getNotesBucket();
         final Note note = notesBucket.newObject();
+        note.setContent(title);
         note.setCreationDate(Calendar.getInstance());
         note.setModificationDate(note.getCreationDate());
         note.setMarkdownEnabled(PrefUtils.getBoolPref(getActivity(), PrefUtils.PREF_MARKDOWN_ENABLED, false));
 
         if (notesActivity.getSelectedTag() != null && notesActivity.getSelectedTag().name != null) {
             String tagName = notesActivity.getSelectedTag().name;
-            if (!tagName.equals(getString(R.string.all_notes)) && !tagName.equals(getString(R.string.trash)) && !tagName.equals(getString(R.string.untagged_notes)))
+
+            if (!tagName.equals(getString(R.string.all_notes)) && !tagName.equals(getString(R.string.trash)) && !tagName.equals(getString(R.string.untagged_notes))) {
                 note.setTagString(tagName);
+            }
         }
 
         note.save();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -639,11 +639,12 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
     public void createNewNote(View view) {
         getNoteListFragment().createNewNote(
-            mSearchView != null && mSearchView.getQuery() != null ?
-                mSearchView.getQuery().toString() :
-                "",
-            "new_note_search"
+            isSearchQueryNotNull() ? mSearchView.getQuery().toString() : "", "new_note_search"
         );
+    }
+
+    private boolean isSearchQueryNotNull() {
+        return mSearchView != null && mSearchView.getQuery() != null;
     }
 
     private void setSelectedTagActive() {
@@ -1154,7 +1155,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
             getNoteListFragment().setNoteSelected(noteID);
             setMarkdownShowing(isPreviewEnabled && matchOffsets == null);
 
-            if (mSearchView != null && mSearchView.getQuery() != null) {
+            if (isSearchQueryNotNull()) {
                 mTabletSearchQuery = mSearchView.getQuery().toString();
             }
 
@@ -1541,7 +1542,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
     public void checkEmptyListText(boolean isSearch) {
         if (isSearch) {
             getNoteListFragment().setEmptyListButton(
-                mSearchView != null && mSearchView.getQuery() != null ?
+                isSearchQueryNotNull() ?
                     getString(R.string.empty_notes_search_button, mSearchView.getQuery().toString()) :
                     getString(R.string.empty_notes_search_button_default)
             );

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -637,6 +637,9 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         startActivity(new Intent(NotesActivity.this, TagsActivity.class));
     }
 
+    public void createNewNote(View view) {
+    }
+
     private void setSelectedTagActive() {
         if (mSelectedTag == null) {
             mSelectedTag = mTagsAdapter.getDefaultItem();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1539,13 +1539,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                     getString(R.string.empty_notes_search_button, mSearchView.getQuery().toString()) :
                     getString(R.string.empty_notes_search_button_default)
             );
-
-            if (DisplayUtils.isLandscape(this) && !DisplayUtils.isLargeScreen(this)) {
-                getNoteListFragment().setEmptyListImage(-1);
-            } else {
-                getNoteListFragment().setEmptyListImage(R.drawable.ic_search_24dp);
-            }
-
+            getNoteListFragment().setEmptyListImage(-1);
             getNoteListFragment().setEmptyListMessage(getString(R.string.empty_notes_search));
         } else if (mSelectedTag != null) {
             getNoteListFragment().setEmptyListButton("");

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -289,7 +289,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                     "note_list_widget"
                 );
                 intent.removeExtra(KEY_LIST_WIDGET_CLICK);
-                getNoteListFragment().addNote();
+                getNoteListFragment().addNote("");
             }
         }
 
@@ -638,6 +638,12 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
     }
 
     public void createNewNote(View view) {
+        getNoteListFragment().createNewNote(
+            mSearchView != null && mSearchView.getQuery() != null ?
+                mSearchView.getQuery().toString() :
+                "",
+            "new_note_search"
+        );
     }
 
     private void setSelectedTagActive() {
@@ -1459,7 +1465,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 }
             case KeyEvent.KEYCODE_I:
                 if (event.isShiftPressed() && event.isCtrlPressed()) {
-                    getNoteListFragment().createNewNote("keyboard_shortcut");
+                    getNoteListFragment().createNewNote("", "keyboard_shortcut");
                     return true;
                 } else if (event.isCtrlPressed()) {
                     if (isLargeLandscapeAndNoteSelected()) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1534,6 +1534,12 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
     public void checkEmptyListText(boolean isSearch) {
         if (isSearch) {
+            getNoteListFragment().setEmptyListButton(
+                mSearchView != null && mSearchView.getQuery() != null ?
+                    getString(R.string.empty_notes_search_button, mSearchView.getQuery().toString()) :
+                    getString(R.string.empty_notes_search_button_default)
+            );
+
             if (DisplayUtils.isLandscape(this) && !DisplayUtils.isLargeScreen(this)) {
                 getNoteListFragment().setEmptyListImage(-1);
             } else {
@@ -1542,6 +1548,8 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
             getNoteListFragment().setEmptyListMessage(getString(R.string.empty_notes_search));
         } else if (mSelectedTag != null) {
+            getNoteListFragment().setEmptyListButton("");
+
             if (mSelectedTag.id == ALL_NOTES_ID) {
                 getNoteListFragment().setEmptyListImage(R.drawable.ic_notes_24dp);
                 getNoteListFragment().setEmptyListMessage(getString(R.string.empty_notes_all));
@@ -1561,6 +1569,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 getNoteListFragment().setEmptyListMessage(getString(R.string.empty_notes_tag, mSelectedTag.name));
             }
         } else {
+            getNoteListFragment().setEmptyListButton("");
             getNoteListFragment().setEmptyListImage(R.drawable.ic_notes_24dp);
             getNoteListFragment().setEmptyListMessage(getString(R.string.empty_notes_all));
         }

--- a/Simplenote/src/main/res/layout/empty_view.xml
+++ b/Simplenote/src/main/res/layout/empty_view.xml
@@ -44,7 +44,7 @@
         android:padding="@dimen/padding_small"
         android:text="@string/empty_notes_search_button"
         android:textColor="?attr/colorAccent"
-        android:textSize="@dimen/text_empty"
+        android:textSize="@dimen/text_empty_button"
         android:visibility="gone"
         tools:visibility="visible">
     </com.automattic.simplenote.widgets.RobotoRegularTextView>

--- a/Simplenote/src/main/res/layout/empty_view.xml
+++ b/Simplenote/src/main/res/layout/empty_view.xml
@@ -2,6 +2,7 @@
 
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:gravity="center"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
@@ -26,6 +27,26 @@
         android:textColor="?attr/notePreviewColor"
         android:text="@string/empty_notes_all"
         android:textSize="@dimen/text_empty">
+    </com.automattic.simplenote.widgets.RobotoRegularTextView>
+
+    <com.automattic.simplenote.widgets.RobotoRegularTextView
+        android:id="@+id/button"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:layout_gravity="center_horizontal"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/padding_large"
+        android:layout_marginStart="@dimen/padding_large"
+        android:layout_marginTop="@dimen/padding_small"
+        android:layout_width="wrap_content"
+        android:onClick="createNewNote"
+        android:padding="@dimen/padding_small"
+        android:text="@string/empty_notes_search_button"
+        android:textColor="?attr/colorAccent"
+        android:textSize="@dimen/text_empty"
+        android:visibility="gone"
+        tools:visibility="visible">
     </com.automattic.simplenote.widgets.RobotoRegularTextView>
 
 </LinearLayout>

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -60,7 +60,8 @@
     <dimen name="text_content">14sp</dimen>
     <dimen name="text_content_title">16sp</dimen>
     <dimen name="text_date">14sp</dimen>
-    <dimen name="text_empty">16sp</dimen>
+    <dimen name="text_empty">20sp</dimen>
+    <dimen name="text_empty_button">16sp</dimen>
     <dimen name="text_header">14sp</dimen>
     <dimen name="text_item">16sp</dimen>
     <dimen name="text_key">14sp</dimen>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -224,6 +224,7 @@
     <string name="empty_notes_all">Create your first note</string>
     <string name="empty_notes_search">No notes found</string>
     <string name="empty_notes_search_button">Create a new note titled \"%1$s\"</string>
+    <string name="empty_notes_search_button_default">Create a new note</string>
     <string name="empty_notes_tag">No notes tagged \"%1$s\"</string>
     <string name="empty_notes_trash">Your trash is empty</string>
     <string name="empty_notes_untagged">Create an untagged note</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -223,6 +223,7 @@
 
     <string name="empty_notes_all">Create your first note</string>
     <string name="empty_notes_search">No notes found</string>
+    <string name="empty_notes_search_button">Create a new note titled \"%1$s\"</string>
     <string name="empty_notes_tag">No notes tagged \"%1$s\"</string>
     <string name="empty_notes_trash">Your trash is empty</string>
     <string name="empty_notes_untagged">Create an untagged note</string>


### PR DESCRIPTION
### Fix
Update the empty view when no notes match the text in the search query.  The magnifying glass image was removed, the text was enlarged form 16sp to 20sp, and a button was added to create a new note with the search query text as the title.  See the screenshots below for illustration.

![update_search_empty](https://user-images.githubusercontent.com/3827611/92554969-d3d5c200-f223-11ea-80df-614434b4240c.png)

### Test
1. Tap ***Search*** action in app bar.
2. Enter any text not matching notes in search field.
3. Submit search with entered text.
4. Notice no magnifying glass image.
5. Notice **_No notes found_** text.
6. Notice **_Create a new note titled "TEXT"_** button with **_TEXT_** matching Step 2.
7. Tap **_Create a new note titled "TEXT"_** button.
8. Notice new note created with title matching text from Step 2.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.