### PR TITLE
Issue/1118 tab indented checklist

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.11
 -----
+* Fixed a bug with toggling tab-indented checkboxes [#1148]
 
 2.10
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/AutoBullet.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/AutoBullet.java
@@ -40,7 +40,8 @@ public class AutoBullet {
                     editable.replace(prevParagraphStart, newCursorPosition, "");
                 } else {
                     // We can add a new checkbox!
-                    editable.insert(newCursorPosition, metadata.leadingWhitespace + ChecklistUtils.UNCHECKED_MARKDOWN + STR_SPACE);
+                    String leadingWhitespace = metadata.leadingWhitespace != null ? metadata.leadingWhitespace : "";
+                    editable.insert(newCursorPosition, leadingWhitespace + ChecklistUtils.UNCHECKED_MARKDOWN + STR_SPACE);
                 }
 
                 return;

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/AutoBullet.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/AutoBullet.java
@@ -8,9 +8,11 @@ import com.automattic.simplenote.widgets.CheckableSpan;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.automattic.simplenote.utils.ChecklistUtils.CHAR_BULLET;
+import static com.automattic.simplenote.utils.ChecklistUtils.CHAR_NO_BREAK_SPACE;
+
 public class AutoBullet {
-    // \u2022 is the unicode bullet character
-    private static final String PATTERN_BULLET = "^([\\s]*)([-*+\u2022\u00A0])[\\s]+(.*)$";
+    private static final String PATTERN_BULLET = "^([\\s]*)([-*+" + CHAR_BULLET + CHAR_NO_BREAK_SPACE + "])[\\s]+(.*)$";
     private static final String STR_LINE_BREAK = System.getProperty("line.separator");
     private static final String STR_SPACE = " ";
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/AutoBullet.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/AutoBullet.java
@@ -9,9 +9,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class AutoBullet {
-
     // \u2022 is the unicode bullet character
-    private static final String PATTERN_BULLET = "^([\\s]*)([-*+\u2022])[\\s]+(.*)$";
+    private static final String PATTERN_BULLET = "^([\\s]*)([-*+\u2022\u00A0])[\\s]+(.*)$";
     private static final String STR_LINE_BREAK = System.getProperty("line.separator");
     private static final String STR_SPACE = " ";
 
@@ -27,42 +26,29 @@ public class AutoBullet {
             int prevParagraphEnd = newCursorPosition - 1;
             int prevParagraphStart = noteContent.lastIndexOf(STR_LINE_BREAK, prevParagraphEnd - 1);
             prevParagraphStart++; // ++ because we don't actually include the previous linebreak
-
             String prevParagraph = noteContent.substring(prevParagraphStart, prevParagraphEnd);
-
             BulletMetadata metadata = extractBulletMetadata(prevParagraph);
 
             // See if there's a CheckableSpan in the previous line
             CheckableSpan[] checkableSpans = editable.getSpans(prevParagraphStart, prevParagraphEnd, CheckableSpan.class);
+
             if (checkableSpans.length > 0) {
                 if (TextUtils.isEmpty(prevParagraph.trim())) {
                     // Empty checklist item, remove and place cursor at start of line
                     editable.replace(prevParagraphStart, newCursorPosition, "");
                 } else {
                     // We can add a new checkbox!
-                    int spanStart = editable.getSpanStart(checkableSpans[0]);
-                    int spacesBeforeSpan = spanStart - prevParagraphStart;
-                    String spaces = new String(new char[spacesBeforeSpan]).replace('\0', ' ');
-                    editable.insert(newCursorPosition, spaces + ChecklistUtils.UNCHECKED_MARKDOWN + STR_SPACE);
+                    editable.insert(newCursorPosition, metadata.leadingWhitespace + ChecklistUtils.UNCHECKED_MARKDOWN + STR_SPACE);
                 }
+
                 return;
             }
 
             if (metadata.isBullet) {
-                String bullet;
-
                 if (!metadata.isEmptyBullet) {
-                    bullet = buildBullet(metadata);
-                    editable.insert(newCursorPosition, bullet);
+                    editable.insert(newCursorPosition, buildBullet(metadata));
                 } else {
-                    if (metadata.numSpacesPrefixed > 0) {
-                        metadata.numSpacesPrefixed -= 1;
-                        bullet = buildBullet(metadata);
-                    } else {
-                        bullet = "";
-                    }
-
-                    editable.replace(prevParagraphStart, newCursorPosition, bullet);
+                    editable.replace(prevParagraphStart, newCursorPosition, "");
                 }
             }
         }
@@ -73,13 +59,7 @@ public class AutoBullet {
     }
 
     private static String buildBullet(BulletMetadata metadata) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < metadata.numSpacesPrefixed; i++) {
-            sb.append(STR_SPACE);
-        }
-        sb.append(metadata.bulletChar);
-        sb.append(STR_SPACE);
-        return sb.toString();
+        return metadata.leadingWhitespace + metadata.bulletChar + STR_SPACE;
     }
 
     private static BulletMetadata extractBulletMetadata(String input) {
@@ -90,7 +70,7 @@ public class AutoBullet {
 
         if (matcher.find()) {
             metadata.isBullet = true;
-            metadata.numSpacesPrefixed = matcher.group(1).length();
+            metadata.leadingWhitespace = matcher.group(1);
             metadata.bulletChar = matcher.group(2);
             metadata.isEmptyBullet = matcher.group(3).trim().isEmpty();
         }
@@ -99,9 +79,9 @@ public class AutoBullet {
     }
 
     private static class BulletMetadata {
-        boolean isBullet = false;
-        int numSpacesPrefixed;
         String bulletChar;
+        String leadingWhitespace;
+        boolean isBullet = false;
         boolean isEmptyBullet = false;
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ChecklistUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ChecklistUtils.java
@@ -17,12 +17,18 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ChecklistUtils {
+    public static final char CHAR_BALLOT_BOX = '\u2610';
+    public static final char CHAR_BALLOT_BOX_CHECK = '\u2611';
+    public static final char CHAR_BULLET = '\u2022';
+    public static final char CHAR_NO_BREAK_SPACE = '\u00a0';
+    public static final char CHAR_VECTOR_CROSS_PRODUCT = '\u2a2f';
+    public static final int CHECKLIST_OFFSET = 3;
+
     public static String CHECKLIST_REGEX = "(\\s+)?(-[ \\t]+\\[[xX\\s]?\\])";
     public static String CHECKLIST_REGEX_LINES = "^(\\s+)?(-[ \\t]+\\[[xX\\s]?\\])";
-    public static String CHECKED_MARKDOWN_PREVIEW = "- [\u2A2F]";
+    public static String CHECKED_MARKDOWN_PREVIEW = "- [" + CHAR_VECTOR_CROSS_PRODUCT + "]";
     public static String CHECKED_MARKDOWN = "- [x]";
     public static String UNCHECKED_MARKDOWN = "- [ ]";
-    public static final int CHECKLIST_OFFSET = 3;
 
     /***
      * Adds CheckableSpans for matching markdown formatted checklists.
@@ -65,7 +71,7 @@ public class ChecklistUtils {
 
             CheckableSpan checkableSpan = new CheckableSpan();
             checkableSpan.setChecked(match.contains("x") || match.contains("X"));
-            editable.replace(start, end, "\u00A0");
+            editable.replace(start, end, String.valueOf(CHAR_NO_BREAK_SPACE));
 
             Drawable iconDrawable = ContextCompat.getDrawable(context,
                     checkableSpan.isChecked()
@@ -120,7 +126,7 @@ public class ChecklistUtils {
 
             CheckableSpan checkableSpan = new CheckableSpan();
             checkableSpan.setChecked(match.contains("x") || match.contains("X"));
-            editable.replace(start, end, checkableSpan.isChecked() ? "\u2611" : "\u2610");
+            editable.replace(start, end, checkableSpan.isChecked() ? String.valueOf(CHAR_BALLOT_BOX_CHECK) : String.valueOf(CHAR_BALLOT_BOX));
             editable.setSpan(checkableSpan, start, start + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
             positionAdjustment += (end - start) - 1;
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SimplenoteMovementMethod.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SimplenoteMovementMethod.java
@@ -10,12 +10,13 @@ import com.automattic.simplenote.widgets.CheckableSpan;
 
 // Only allows onClick events for CheckableSpans
 public class SimplenoteMovementMethod extends ArrowKeyMovementMethod {
-
     private static SimplenoteMovementMethod mInstance;
 
     public static SimplenoteMovementMethod getInstance() {
-        if (mInstance == null)
+        if (mInstance == null) {
             mInstance = new SimplenoteMovementMethod();
+        }
+
         return mInstance;
     }
 
@@ -40,7 +41,7 @@ public class SimplenoteMovementMethod extends ArrowKeyMovementMethod {
             off = lineStart;
         }
 
-        CheckableSpan[] checkableSpans = buffer.getSpans(off, off + 1, CheckableSpan.class);
+        CheckableSpan[] checkableSpans = buffer.getSpans(off, off, CheckableSpan.class);
 
         if (checkableSpans.length != 0) {
             switch (event.getAction()) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -259,7 +259,7 @@ public class SimplenoteEditText extends AppCompatEditText {
         return content.toString();
     }
 
-    // Replaces any CheckableSpans with their markdown preview counterpart (e.g. '- [\u2A2F]')
+    // Replaces any CheckableSpans with their markdown preview counterpart (e.g. '- [\u2a2f]')
     public String getPreviewTextContent() {
         if (getText() == null) {
             return "";


### PR DESCRIPTION
### Fix
Update the movement method used when tapping checkboxes to allow tab-indented items to be checked/unchecked to close #1118.  These changes also include updating the auto-bullet logic used to continue a list with `-`, `+`, `*`, `•`, or checkboxes by copying the leading whitespace of the previous line rather than using spaces.

### Test
The changes address lists with tab-indented checkboxes specifically, but all lists with any leading whitespace and `-`, `+`, `*`, and `•` characters should remain unchanged.  Since there is not way to directly input a tab character on Android devices, use the items below to copy/paste into the note.  You can also add a tab-indented list item with the macOS or web apps.

```
 - [ ] Space
	- [ ] Tab
```

1. Open any note in list with tab-indented checklist item.
2. Tap checkbox of tab-indented checklist item.
3. Notice checkbox is checked/unchecked.
4. Tap end of line with tab-indented checklist item.
5. Tap **_Enter_**/**_Return_** key.
6. Notice tab-indented checklist item is added to next line.
7. Tap **_Enter_**/**_Return_** key.
8. Notice tab-indented checklist item is removed from current line.

### Review
Only one developer is required to review these changes, but anyone can perform the review.  @jessefriedman, I also requested you as a reviewer since you caught the associated bug.  Your review isn't required, but you may want to ensure the bug is fixed on your device.

#### Note
Contact me for an installable build.

### Release
`RELEASE-NOTES.txt` was updated in f71c727a with:
> Fixed a bug with toggling tab-indented checkboxes [#1148]