### PR TITLE
Issue/1149 remove empty checklist

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/AutoBullet.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/AutoBullet.java
@@ -1,7 +1,6 @@
 package com.automattic.simplenote.utils;
 
 import android.text.Editable;
-import android.text.TextUtils;
 
 import com.automattic.simplenote.widgets.CheckableSpan;
 
@@ -30,12 +29,11 @@ public class AutoBullet {
             prevParagraphStart++; // ++ because we don't actually include the previous linebreak
             String prevParagraph = noteContent.substring(prevParagraphStart, prevParagraphEnd);
             BulletMetadata metadata = extractBulletMetadata(prevParagraph);
-
             // See if there's a CheckableSpan in the previous line
             CheckableSpan[] checkableSpans = editable.getSpans(prevParagraphStart, prevParagraphEnd, CheckableSpan.class);
 
             if (checkableSpans.length > 0) {
-                if (TextUtils.isEmpty(prevParagraph.trim())) {
+                if (prevParagraph.trim().equalsIgnoreCase(String.valueOf(CHAR_NO_BREAK_SPACE))) {
                     // Empty checklist item, remove and place cursor at start of line
                     editable.replace(prevParagraphStart, newCursorPosition, "");
                 } else {


### PR DESCRIPTION
### Fix
Update the check for an empty checklist item from empty text to a no-break space character to close #1149.  The checklist item text (i.e. `- [ ]` or `- [x]`) is replaced with a no-break space character before applying the checkable image space.  The check for an empty checklist item was looking for empty text rather than the replacement no-break space character.  An empty checklist item is checked so that tapping **_Enter_**/**_Return_** on an empty checklist item removes the checklist item from the line similar to the other list items (e.g. `-`, `+`, `*`, `•`).

### Test
1. Tap ***New Note*** floating action button.
2. Tap ***Toggle Checklist*** action in app bar.
3. Tap **_Enter_**/**_Return_** key.
4. Notice checklist item is removed.
5. Notice new checklist item is not inserted.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.