### PR TITLE
Keyboard Shortcuts Translations

### DIFF
--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -272,14 +272,14 @@
     <string name="item_action_toggle_preview">Toggle Preview</string>
     <string name="item_action_toggle_preview_enable_error">Enable markdown to toggle preview</string>
     <string name="item_action_toggle_preview_error">Select a note to toggle preview</string>
-    <string name="key_multiple_ctrl">Ctrl</string>
-    <string name="key_multiple_shift">Shift</string>
-    <string name="key_single_c">C</string>
-    <string name="key_single_h">H</string>
-    <string name="key_single_i">I</string>
-    <string name="key_single_l">L</string>
-    <string name="key_single_p">P</string>
-    <string name="key_single_s">S</string>
+    <string name="key_multiple_ctrl" translatable="false">Ctrl</string>
+    <string name="key_multiple_shift" translatable="false">Shift</string>
+    <string name="key_single_c" translatable="false">C</string>
+    <string name="key_single_h" translatable="false">H</string>
+    <string name="key_single_i" translatable="false">I</string>
+    <string name="key_single_l" translatable="false">L</string>
+    <string name="key_single_p" translatable="false">P</string>
+    <string name="key_single_s" translatable="false">S</string>
 
     <!-- SIMPERIUM -->
     <string name="simperium_button_login">Log In</string>


### PR DESCRIPTION
### Fix
Add the `translatable="false"` attribute to string resources for keyboard shortcuts keys so that they will not be translated.  The keyboard shortcuts should remain as listed below.

#### Large Device in Landscape
Shortcut|Keys
-|-
New Note|`CTRL` `SHIFT` `I`
Open Search|`CTRL` `SHIFT` `S`
Toggle Checklist|`CTRL` `SHIFT` `C`
Toggle Preview|`CTRL` `SHIFT` `P`
Toggle List|`CTRL` `SHIFT` `L`
Show Information|`CTRL` `I`
Show History|`CTRL` `H`
Show Share|`CTRL` `S`

#### Small Device in Landscape and Portrait or Large Device in Portrait
##### Note List
Shortcut|Keys
-|-
New Note|`CTRL` `SHIFT` `I`
Open Search|`CTRL` `SHIFT` `S`

##### Editor with Edit Tab
Shortcut|Keys
-|-
Toggle Checklist|`CTRL` `SHIFT` `C`
Toggle Preview|`CTRL` `SHIFT` `P`
Show Information|`CTRL` `I`
Show History|`CTRL` `H`
Show Share|`CTRL` `S`

##### Editor with Preview Tab
Shortcut|Keys
-|-
Toggle Preview|`CTRL` `SHIFT` `P`

See the screenshots below for illustration.

![add_keyboard_shortcuts_small](https://user-images.githubusercontent.com/3827611/83545352-511ec780-a4bc-11ea-85a5-8c1d2fba0873.png)

![add_keyboard_shortcuts_large](https://user-images.githubusercontent.com/3827611/83545366-55e37b80-a4bc-11ea-91b6-500765c8cd81.png)

### Test
1. Press `CTRL` `,` keys.
2. Notice keyboard shortcuts dialog is shown as above.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.