### PR TITLE
Add Help Link

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.12
 -----
- 
+* Added a link to help in settings [https://github.com/Automattic/simplenote-android/pull/1155]
+
 2.11
 -----
 * Added linking between notes [#1145]

--- a/Simplenote/src/main/java/com/automattic/simplenote/AboutFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AboutFragment.java
@@ -35,6 +35,7 @@ public class AboutFragment extends Fragment implements SpeedListener {
     private static final String PLAY_STORE_URL = "http://play.google.com/store/apps/details?id=";
     private static final String PLAY_STORE_URI = "market://details?id=";
     private static final String SIMPLENOTE_BLOG_URL = "https://simplenote.com/blog";
+    private static final String SIMPLENOTE_HELP_URL = "https://simplenote.com/help";
     private static final String SIMPLENOTE_HIRING_HANDLE = "https://automattic.com/work-with-us/";
     private static final String SIMPLENOTE_TWITTER_HANDLE = "simplenoteapp";
     private static final String TWITTER_PROFILE_URL = "https://twitter.com/#!/";
@@ -52,6 +53,7 @@ public class AboutFragment extends Fragment implements SpeedListener {
         TextView version = view.findViewById(R.id.about_version);
         View blog = view.findViewById(R.id.about_blog);
         View twitter = view.findViewById(R.id.about_twitter);
+        View help = view.findViewById(R.id.about_help);
         View store = view.findViewById(R.id.about_store);
         View contribute = view.findViewById(R.id.about_contribute);
         View hiring = view.findViewById(R.id.about_careers);
@@ -87,6 +89,16 @@ public class AboutFragment extends Fragment implements SpeedListener {
             }
         });
 
+        help.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                try {
+                    BrowserUtils.launchBrowserOrShowError(requireContext(), SIMPLENOTE_HELP_URL);
+                } catch (Exception e) {
+                    Toast.makeText(getActivity(), R.string.no_browser_available, Toast.LENGTH_LONG).show();
+                }
+            }
+        });
         store.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -106,6 +106,18 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
             }
         });
 
+        findPreference("pref_key_help").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                try {
+                    BrowserUtils.launchBrowserOrShowError(requireContext(), "https://simplenote.com/help");
+                } catch (Exception e) {
+                    Toast.makeText(getActivity(), R.string.no_browser_available, Toast.LENGTH_LONG).show();
+                }
+                return true;
+            }
+        });
+
         findPreference("pref_key_website").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {

--- a/Simplenote/src/main/res/layout/fragment_about.xml
+++ b/Simplenote/src/main/res/layout/fragment_about.xml
@@ -110,6 +110,32 @@
         </RelativeLayout>
 
         <RelativeLayout
+            android:id="@+id/about_help"
+            style="@style/Theme.Simplestyle.About.Row">
+
+            <com.automattic.simplenote.widgets.RobotoRegularTextView
+                android:id="@+id/about_help_title"
+                android:layout_toStartOf="@+id/about_help_arrow"
+                android:text="@string/about_help_title"
+                style="@style/Theme.Simplestyle.About.Title">
+            </com.automattic.simplenote.widgets.RobotoRegularTextView>
+
+            <com.automattic.simplenote.widgets.RobotoRegularTextView
+                android:layout_below="@id/about_help_title"
+                android:layout_toStartOf="@+id/about_help_arrow"
+                android:text="@string/about_help_summary"
+                style="@style/Theme.Simplestyle.About.Subtitle">
+            </com.automattic.simplenote.widgets.RobotoRegularTextView>
+
+            <ImageView
+                android:id="@+id/about_help_arrow"
+                android:importantForAccessibility="no"
+                style="@style/Theme.Simplestyle.About.Arrow">
+            </ImageView>
+
+        </RelativeLayout>
+
+        <RelativeLayout
             android:id="@+id/about_store"
             style="@style/Theme.Simplestyle.About.Row">
 

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="references">Referenced In</string>
     <string name="references_one">%1$d Reference, Last modified %2$s</string>
     <string name="references_other">%1$d References, Last modified %2$s</string>
+    <string name="settings_item_get_help">Get help</string>
 
     <!-- Preferences -->
     <string name="export_file">simplenote.json</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -142,6 +142,8 @@
     <string name="about_hiring">Are you a developer? We\'re hiring.</string>
     <string name="about_play_store">Google Play Store</string>
     <string name="about_twitter_handle" translatable="false">\@simplenoteapp</string>
+    <string name="about_help_summary">FAQ or contact us</string>
+    <string name="about_help_title">Get Help</string>
     <string name="twitter">Twitter</string>
     <string name="rate_us">Rate Us</string>
     <string name="blog">Blog</string>

--- a/Simplenote/src/main/res/xml/preferences.xml
+++ b/Simplenote/src/main/res/xml/preferences.xml
@@ -106,6 +106,12 @@
         </Preference>
 
         <Preference
+            android:key="pref_key_help"
+            android:persistent="false"
+            android:title="@string/settings_item_get_help">
+        </Preference>
+
+        <Preference
             android:key="pref_key_logs"
             android:persistent="false"
             android:title="@string/send_logs">


### PR DESCRIPTION
### Fix
Add a link to help in the app with a "Get Help" item in **_Settings_** and **_About_**, which directs to https://simplenote.com/help on the web.  See the screenshots below for illustration.

![add_help_link](https://user-images.githubusercontent.com/3827611/93795256-5b450d00-fbf6-11ea-8087-20ba9658c561.png)

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Notice **_Get help_** under **_More_** section.
4. Tap **_Get help_** under **_More_** section.
5. Notice [Simplenote Help page](https://simplenote.com/help/) is shown.
6. Tap back arrow in navigation bar.
7. Tap **_About_** under **_More_** section.
8. Notice **_Get Help_** item with **_FAQ or contact us_** summary.
9. Tap **_Get Help_** item.
10. Notice [Simplenote Help page](https://simplenote.com/help/) is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

#### Note
Contact me for an installable build.

### Release
`RELEASE-NOTES.txt` was updated in b5a0ff75 with:
> Added a link to help in settings [https://github.com/Automattic/simplenote-android/pull/1155]