### PR TITLE
Crash Encode Charset

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 2.11
 -----
-* Added linking between notes [#1145]
-* Fixed a bug with toggling tab-indented checkboxes [#1148]
+* Added linking between notes [https://github.com/Automattic/simplenote-android/pull/1145]
+* Fixed toggling tab-indented checkboxes [https://github.com/Automattic/simplenote-android/pull/1148]
 * Fixed adding or editing a tag on Android 6 [https://github.com/Automattic/simplenote-android/pull/1157]
 
 2.10

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,8 @@
 2.11
 -----
+* Added linking between notes [#1145]
+* Fixed a bug with toggling tab-indented checkboxes [#1148]
+* Fixed adding or editing a tag on Android 6 [https://github.com/Automattic/simplenote-android/pull/1157]
 
 2.10
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 2.11
 -----
-* Added linking between notes [https://github.com/Automattic/simplenote-android/pull/1145]
-* Fixed toggling tab-indented checkboxes [https://github.com/Automattic/simplenote-android/pull/1148]
+* Added linking between notes [#1145]
+* Fixed a bug with toggling tab-indented checkboxes [#1148]
 * Fixed adding or editing a tag on Android 6 [https://github.com/Automattic/simplenote-android/pull/1157]
 
 2.10

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,9 @@
 -----
 * Added linking between notes [#1145]
 * Fixed a bug with toggling tab-indented checkboxes [#1148]
+
+2.10.1
+-----
 * Fixed adding or editing a tag on Android 6 [https://github.com/Automattic/simplenote-android/pull/1157]
 
 2.10

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -32,7 +32,7 @@ android {
         } else {
             versionName "2.10.1"
         }
-        versionCode 2.10.1
+        versionCode 117
         minSdkVersion 23
         targetSdkVersion 29
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagUtils.java
@@ -62,7 +62,7 @@ public class TagUtils {
         try {
             String normalized = Normalizer.normalize(name, Normalizer.Form.NFC);
             String lowercased = normalized.toLowerCase(Locale.US);
-            String encoded = URLEncoder.encode(lowercased, StandardCharsets.UTF_8.toString());
+            String encoded = URLEncoder.encode(lowercased, StandardCharsets.UTF_8.name());
             return encoded.replace("*", "%2A").replace("+", "%20");
         } catch (UnsupportedEncodingException e) {
             // TODO: Handle encoding exception with a custom UTF-8 encoder.
@@ -81,7 +81,7 @@ public class TagUtils {
         try {
             String normalized = Normalizer.normalize(name, Normalizer.Form.NFC);
             String lowercased = normalized.toLowerCase(Locale.US);
-            String encoded = URLEncoder.encode(lowercased, StandardCharsets.UTF_8.toString()).replace("*", "%2A").replace("+", "%20");
+            String encoded = URLEncoder.encode(lowercased, StandardCharsets.UTF_8.name()).replace("*", "%2A").replace("+", "%20");
             return encoded.length() <= MAXIMUM_LENGTH_ENCODED_HASH;
         } catch (UnsupportedEncodingException e) {
             // TODO: Handle encoding exception with a custom UTF-8 encoder.


### PR DESCRIPTION
### Fix
Update the URL encoder character encoding parameter is the `TagUtils.hashTagValid` and `TagUtils.hashTagValid` methods to avoid an `IllegalCharsetNameException` crash on Android 6.0.x.  The static constant `StandardCharsets.UTF_8`'s `toString()` method throws the exception since `java.nio.charset.CharsetICU[UTF-8]` is returned, which is not a proper character encoding value.  `StandardCharsets.UTF_8.toString()` returns `UTF-8` for all other Android versions supported.  Replacing `toStrong()` with `name()` returns the canonical name, which is `UTF-8` for all versions including Android 6.0.x.

### Test
Since the `IllegalCharsetNameException` crash occurs only on Android 6.0.x (API 23) devices, it's best to test on at least one Android 6.0.x (API 23) device and one Android 7.0 (API 24) or higher device.
1. Tap any note in list.
2. Enter any text in ***Add tag...*** field at bottom of note.
3. Tap ***Spacev or ***Enter***/***Return*** key.
4. Notice text from Step 2 is added as tag to note.
5. Notice app does not crash.
6. Tap back arrow in app bar.
7. Open navigation drawer.
8. Tap ***Edit*** button in ***Tags*** header.
9. Tap tag from Step 4.
10. Notice ***Rename Tag*** dialog is shown.
11. Notice app does not crash.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 19909313 with:
> Fixed adding or editing a tag on Android 6 [https://github.com/Automattic/simplenote-android/pull/1157]

#### Note
@mokagio, these changes will require a hotfix and new release candidate build once they are merged.