### PR TITLE
Feature Merge Conflict

### DIFF
--- a/Simplenote/src/main/res/layout/bottom_sheet_info.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_info.xml
@@ -9,8 +9,7 @@
     <LinearLayout
         android:layout_height="match_parent"
         android:layout_width="match_parent"
-        android:orientation="vertical"
-        android:theme="@style/Theme.Simplestyle.BottomSheetDialog">
+        android:orientation="vertical">
 
         <com.automattic.simplenote.widgets.RobotoRegularTextView
             android:layout_height="wrap_content"

--- a/Simplenote/src/main/res/values-night-v27/styles.xml
+++ b/Simplenote/src/main/res/values-night-v27/styles.xml
@@ -32,6 +32,9 @@
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowLightNavigationBar">false</item>
         <item name="bottomSheetStyle">@style/Widget.Design.BottomSheet.Modal</item>
+        <item name="colorAccent">@color/item_default_dark</item>
+        <item name="colorPrimary">@color/blue</item>
+        <item name="colorPrimaryDark">@color/blue_dark</item>
     </style>
 
 </resources>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -99,6 +99,9 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowIsFloating">false</item>
         <item name="bottomSheetStyle">@style/Widget.Design.BottomSheet.Modal</item>
+        <item name="colorAccent">@color/item_default_dark</item>
+        <item name="colorPrimary">@color/blue</item>
+        <item name="colorPrimaryDark">@color/blue_dark</item>
     </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialog.Label" parent="Theme.Simplestyle.BottomSheetDialog">

--- a/Simplenote/src/main/res/values-v27/styles.xml
+++ b/Simplenote/src/main/res/values-v27/styles.xml
@@ -66,6 +66,9 @@
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowLightNavigationBar">true</item>
         <item name="bottomSheetStyle">@style/Widget.Design.BottomSheet.Modal</item>
+        <item name="colorAccent">@color/item_default_light</item>
+        <item name="colorPrimary">@color/blue</item>
+        <item name="colorPrimaryDark">@color/blue_dark</item>
     </style>
 
     <style name="Theme.Simplestyle.Passcode" parent="@style/Theme.MaterialComponents.Light.NoActionBar">

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -129,6 +129,9 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowIsFloating">false</item>
         <item name="bottomSheetStyle">@style/Widget.Design.BottomSheet.Modal</item>
+        <item name="colorAccent">@color/item_default_light</item>
+        <item name="colorPrimary">@color/blue</item>
+        <item name="colorPrimaryDark">@color/blue_dark</item>
     </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialog.Label" parent="Theme.MaterialComponents.Light.BottomSheetDialog">


### PR DESCRIPTION
### Fix
Some changes were lost when merging `develop` into `feature/add-app-styles`.  There appears to have been conflicts with the internote linking feature and the `feature/add-app-styles` branch.  This pull request adds the missing changes.  First, the `theme` attribute was removed from the `bottom_sheet_info` layout since [the `Theme_Simplestyle_BottomSheetDialog` style is added programmatically in the `BottomSheetDialogBase` class](https://github.com/Automattic/simplenote-android/blob/feature/add-app-styles/Simplenote/src/main/java/com/automattic/simplenote/BottomSheetDialogBase.java#L18).  Second, the `colorAccent`, `colorPrimary`, and `colorPrimaryDark` attributes were added to the `Theme.Simplestyle.BottomSheetDialog` styles [as they are in the `develop` branch](https://github.com/Automattic/simplenote-android/blob/develop/Simplenote/src/main/res/values/styles.xml#L119-L121).

### Test
1. Tap any note in list referenced in another note with an internote link.
2. Tap ***Information*** action in app bar.
3. Notice **_Referenced In_** section is shown in **_Information_** sheet.
4. Notice **_Referenced In_** text is `blue` (`#3361cc`).
5. Swipe up to fully expand Information sheet.
6. Swipe up on **_Referenced In_** list.
7. Notice overscroll color is `blue` (`#3361cc`).

### Review
Only one developer is required to review these changes, but anyone can perform the review.

#### Note
Contact me for an installable build.

### Release
These changes do not require release notes.