### PR TITLE
Add Internote Autocomplete

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.12
 -----
- 
+* Added autocomplete to the editor when adding a link between notes [https://github.com/Automattic/simplenote-android/pull/1161]
+
 2.11
 -----
 * Added linking between notes [#1145]

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -107,6 +107,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     public static final String ARG_MATCH_OFFSETS = "match_offsets";
     public static final String ARG_MARKDOWN_ENABLED = "markdown_enabled";
     public static final String ARG_PREVIEW_ENABLED = "preview_enabled";
+
     private static final String STATE_NOTE_ID = "state_note_id";
     private static final int AUTOSAVE_DELAY_MILLIS = 2000;
     private static final int MAX_REVISIONS = 30;
@@ -129,7 +130,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private Handler mPublishTimeoutHandler;
     private Handler mHistoryTimeoutHandler;
     private LinearLayout mPlaceholderView;
-    private CursorAdapter mAutocompleteAdapter;
+    private CursorAdapter mLinkAutocompleteAdapter;
+    private CursorAdapter mTagAutocompleteAdapter;
     private boolean mIsLoadingNote;
     private boolean mIsMarkdownEnabled;
     private boolean mIsPreviewEnabled;
@@ -329,12 +331,12 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         mMatchHighlighter = new TextHighlighter(requireActivity(),
                 R.attr.editorSearchHighlightForegroundColor, R.attr.editorSearchHighlightBackgroundColor);
-        mAutocompleteAdapter = new CursorAdapter(getActivity(), null, 0x0) {
+        mTagAutocompleteAdapter = new CursorAdapter(getActivity(), null, 0x0) {
             @Override
             public View newView(Context context, Cursor cursor, ViewGroup parent) {
                 Activity activity = (Activity) context;
                 if (activity == null) return null;
-                return activity.getLayoutInflater().inflate(R.layout.tag_autocomplete_list_item, null);
+                return activity.getLayoutInflater().inflate(R.layout.autocomplete_list_item, null);
             }
 
             @Override
@@ -365,6 +367,54 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             }
         };
 
+        mLinkAutocompleteAdapter = new CursorAdapter(getContext(), null, 0x0) {
+            private Activity mActivity = requireActivity();
+
+            @Override
+            public void bindView(View view, Context context, Cursor cursor) {
+                ((TextView) view).setText(convertToString(cursor));
+            }
+
+            @Override
+            public CharSequence convertToString(Cursor cursor) {
+                return cursor.getString(cursor.getColumnIndex(Note.TITLE_INDEX_NAME));
+            }
+
+            @Override
+            public View newView(Context context, Cursor cursor, ViewGroup parent) {
+                return mActivity.getLayoutInflater().inflate(R.layout.autocomplete_list_item, null);
+            }
+
+            @Override
+            public Cursor runQueryOnBackgroundThread(CharSequence filter) {
+                if (filter == null) {
+                    return null;
+                }
+
+                Simplenote application = (Simplenote) mActivity.getApplication();
+                Query<Note> query = application.getNotesBucket().query();
+                query.include(Note.PINNED_INDEX_NAME);
+                query.include(Note.TITLE_INDEX_NAME);
+                query.where(Note.TITLE_INDEX_NAME, Query.ComparisonType.LIKE, String.format("%%%s%%", filter));
+                PrefUtils.sortNoteQuery(query, requireContext(), true);
+                Cursor cursor = query.execute();
+
+                final int heightAutocomplete = DisplayUtils.dpToPx(requireContext(), cursor.getCount() * 48);
+                final int heightDisplay = DisplayUtils.getDisplayPixelSize(requireContext()).y;
+                final int heightDropdown = Math.min(heightDisplay / 4, heightAutocomplete);
+
+                mActivity.runOnUiThread(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            mContentEditText.setDropDownHeight(heightDropdown);
+                        }
+                    }
+                );
+                return cursor;
+            }
+        };
+
         WidgetUtils.updateNoteWidgets(requireActivity().getApplicationContext());
     }
 
@@ -377,9 +427,12 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mContentEditText.setMovementMethod(SimplenoteMovementMethod.getInstance());
         mContentEditText.setOnFocusChangeListener(this);
         mContentEditText.setTextSize(TypedValue.COMPLEX_UNIT_SP, PrefUtils.getFontSize(requireContext()));
+        mContentEditText.setDropDownBackgroundResource(R.drawable.bg_list_popup);
+        mContentEditText.setAdapter(mLinkAutocompleteAdapter);
         mTagInput = mRootView.findViewById(R.id.tag_input);
         mTagInput.setDropDownBackgroundResource(R.drawable.bg_list_popup);
         mTagInput.setTokenizer(new SpaceTokenizer());
+        mTagInput.setAdapter(mTagAutocompleteAdapter);
         mTagInput.setOnFocusChangeListener(this);
         mTagChips = mRootView.findViewById(R.id.tag_chips);
         mTagPadding = mRootView.findViewById(R.id.tag_padding);
@@ -411,7 +464,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 : ContextUtils.readCssFile(requireContext(), "dark.css");
         }
 
-        mTagInput.setAdapter(mAutocompleteAdapter);
         Bundle arguments = getArguments();
 
         if (arguments != null && arguments.containsKey(ARG_ITEM_ID)) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
@@ -38,6 +38,7 @@ public class Note extends BucketObject {
     public static final String PUBLISHED_TAG = "published";
     public static final String NEW_LINE = "\n";
     public static final String CONTENT_PROPERTY = "content";
+    public static final String KEY_PROPERTY = "key";
     public static final String TAGS_PROPERTY = "tags";
     public static final String SYSTEM_TAGS_PROPERTY = "systemTags";
     public static final String CREATION_DATE_PROPERTY = "creationDate";

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/LinkTokenizer.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/LinkTokenizer.java
@@ -1,0 +1,53 @@
+package com.automattic.simplenote.utils;
+
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.TextUtils;
+import android.widget.MultiAutoCompleteTextView;
+
+public class LinkTokenizer implements MultiAutoCompleteTextView.Tokenizer {
+    private static final Character CHARACTER_BRACKET_CLOSE = ']';
+    private static final Character CHARACTER_BRACKET_OPEN = '[';
+
+    @Override
+    public int findTokenEnd(CharSequence text, int cursor) {
+        int i = cursor;
+        int length = text.length();
+
+        while (i < length) {
+            if (text.charAt(i) == CHARACTER_BRACKET_CLOSE) {
+                return i;
+            } else {
+                i++;
+            }
+        }
+
+        return length;
+    }
+
+    @Override
+    public int findTokenStart(CharSequence text, int cursor) {
+        int i = cursor;
+
+        while (i > 0 && text.charAt(i - 1) != CHARACTER_BRACKET_OPEN) {
+            i--;
+        }
+
+        if (i < 1 || text.charAt(i - 1) != CHARACTER_BRACKET_OPEN) {
+            return cursor;
+        }
+
+        return i;
+    }
+
+    @Override
+    public CharSequence terminateToken(CharSequence text) {
+        if (text instanceof Spanned) {
+            SpannableString spannableString = new SpannableString(text + CHARACTER_BRACKET_CLOSE.toString());
+            TextUtils.copySpansFrom((Spanned) text, 0, text.length(), Object.class, spannableString, 0);
+            return spannableString;
+        } else {
+            return text + CHARACTER_BRACKET_CLOSE.toString();
+        }
+    }
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -11,22 +11,63 @@ import android.text.Spanned;
 import android.text.style.ImageSpan;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
+import android.view.View;
+import android.widget.AdapterView;
 
-import androidx.appcompat.widget.AppCompatEditText;
+import androidx.appcompat.widget.AppCompatMultiAutoCompleteTextView;
 import androidx.core.content.ContextCompat;
 
 import com.automattic.simplenote.R;
+import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.utils.ChecklistUtils;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
+import com.automattic.simplenote.utils.LinkTokenizer;
+import com.automattic.simplenote.utils.SimplenoteLinkify;
+import com.simperium.client.Bucket;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-public class SimplenoteEditText extends AppCompatEditText {
+import static com.automattic.simplenote.utils.SimplenoteLinkify.SIMPLENOTE_LINK_ID;
+import static com.automattic.simplenote.utils.SimplenoteLinkify.SIMPLENOTE_LINK_PREFIX;
+
+public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView implements AdapterView.OnItemClickListener {
+    private static final Pattern INTERNOTE_LINK_PATTERN_EDIT = Pattern.compile("([^]]*)(]\\(" + SIMPLENOTE_LINK_PREFIX + SIMPLENOTE_LINK_ID + "\\))");
+    private static final Pattern INTERNOTE_LINK_PATTERN = Pattern.compile("(\\[)([^]]+)(]\\(" + SIMPLENOTE_LINK_PREFIX + SIMPLENOTE_LINK_ID + "\\))");
+    private static final int CHECKBOX_LENGTH = 2; // one ClickableSpan character + one space character
+
+    private LinkTokenizer mTokenizer;
     private List<OnSelectionChangedListener> listeners;
     private OnCheckboxToggledListener mOnCheckboxToggledListener;
-    private final int CHECKBOX_LENGTH = 2; // One CheckableSpan + a space character
+
+    @Override
+    public boolean enoughToFilter() {
+        String substringCursor = getText().toString().substring(getSelectionEnd());
+        Matcher matcherEdit = INTERNOTE_LINK_PATTERN_EDIT.matcher(substringCursor);
+
+        // When an internote link title is being edited, don't show an autocomplete popup.
+        if (matcherEdit.find()) {
+            String substringEdit = substringCursor.substring(0, matcherEdit.end());
+            Matcher matcherFull = INTERNOTE_LINK_PATTERN.matcher(substringEdit);
+
+            if (!matcherFull.find()) {
+                return false;
+            }
+        }
+
+        Editable text = getText();
+        int end = getSelectionEnd();
+
+        if (end < 0) {
+            return false;
+        }
+
+        int start = mTokenizer.findTokenStart(text, end);
+        return start > 0 && end - start >= 1;
+    }
 
     public interface OnCheckboxToggledListener {
         void onCheckboxToggled();
@@ -36,22 +77,43 @@ public class SimplenoteEditText extends AppCompatEditText {
         super(context);
         listeners = new ArrayList<>();
         setTypeface(TypefaceCache.getTypeface(context, TypefaceCache.TYPEFACE_NAME_ROBOTO_REGULAR));
+        setLinkTokenizer();
     }
 
     public SimplenoteEditText(Context context, AttributeSet attrs) {
         super(context, attrs);
         listeners = new ArrayList<>();
         setTypeface(TypefaceCache.getTypeface(context, TypefaceCache.TYPEFACE_NAME_ROBOTO_REGULAR));
+        setLinkTokenizer();
     }
 
     public SimplenoteEditText(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         listeners = new ArrayList<>();
         setTypeface(TypefaceCache.getTypeface(context, TypefaceCache.TYPEFACE_NAME_ROBOTO_REGULAR));
+        setLinkTokenizer();
     }
 
     public void addOnSelectionChangedListener(OnSelectionChangedListener o) {
         listeners.add(o);
+    }
+
+    private void setLinkTokenizer() {
+        mTokenizer = new LinkTokenizer();
+        setOnItemClickListener(this);
+        setTokenizer(mTokenizer);
+        setThreshold(1);
+    }
+
+    @Override
+    public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        @SuppressWarnings("unchecked")
+        Bucket.ObjectCursor<Note> cursor = (Bucket.ObjectCursor<Note>) parent.getAdapter().getItem(position);
+        String key = cursor.getString(cursor.getColumnIndex(Note.KEY_PROPERTY)).replace("note", "");
+        String text = SimplenoteLinkify.getNoteLink(key);
+        int start = Math.max(getSelectionStart(), 0);
+        int end = Math.max(getSelectionEnd(), 0);
+        getEditableText().replace(Math.min(start, end), Math.max(start, end), text, 0, text.length());
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -35,8 +35,8 @@ import static com.automattic.simplenote.utils.SimplenoteLinkify.SIMPLENOTE_LINK_
 import static com.automattic.simplenote.utils.SimplenoteLinkify.SIMPLENOTE_LINK_PREFIX;
 
 public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView implements AdapterView.OnItemClickListener {
-    private static final Pattern INTERNOTE_LINK_PATTERN_EDIT = Pattern.compile("([^]]*)(]\\(" + SIMPLENOTE_LINK_PREFIX + SIMPLENOTE_LINK_ID + "\\))");
     private static final Pattern INTERNOTE_LINK_PATTERN = Pattern.compile("(\\[)([^]]+)(]\\(" + SIMPLENOTE_LINK_PREFIX + SIMPLENOTE_LINK_ID + "\\))");
+    private static final Pattern INTERNOTE_LINK_PATTERN_EDIT = Pattern.compile("([^]]*)(]\\(" + SIMPLENOTE_LINK_PREFIX + SIMPLENOTE_LINK_ID + "\\))");
     private static final int CHECKBOX_LENGTH = 2; // one ClickableSpan character + one space character
 
     private LinkTokenizer mTokenizer;

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -49,11 +49,11 @@ public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView imple
         Matcher matcherEdit = INTERNOTE_LINK_PATTERN_EDIT.matcher(substringCursor);
 
         // When an internote link title is being edited, don't show an autocomplete popup.
-        if (matcherEdit.find()) {
+        if (matcherEdit.lookingAt()) {
             String substringEdit = substringCursor.substring(0, matcherEdit.end());
             Matcher matcherFull = INTERNOTE_LINK_PATTERN.matcher(substringEdit);
 
-            if (!matcherFull.find()) {
+            if (!matcherFull.lookingAt()) {
                 return false;
             }
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -35,8 +35,8 @@ import static com.automattic.simplenote.utils.SimplenoteLinkify.SIMPLENOTE_LINK_
 import static com.automattic.simplenote.utils.SimplenoteLinkify.SIMPLENOTE_LINK_PREFIX;
 
 public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView implements AdapterView.OnItemClickListener {
-    private static final Pattern INTERNOTE_LINK_PATTERN = Pattern.compile("(\\[)([^]]+)(]\\(" + SIMPLENOTE_LINK_PREFIX + SIMPLENOTE_LINK_ID + "\\))");
     private static final Pattern INTERNOTE_LINK_PATTERN_EDIT = Pattern.compile("([^]]*)(]\\(" + SIMPLENOTE_LINK_PREFIX + SIMPLENOTE_LINK_ID + "\\))");
+    private static final Pattern INTERNOTE_LINK_PATTERN_FULL = Pattern.compile("(?s)(.)*(\\[)" + INTERNOTE_LINK_PATTERN_EDIT);
     private static final int CHECKBOX_LENGTH = 2; // one ClickableSpan character + one space character
 
     private LinkTokenizer mTokenizer;
@@ -51,7 +51,7 @@ public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView imple
         // When an internote link title is being edited, don't show an autocomplete popup.
         if (matcherEdit.lookingAt()) {
             String substringEdit = substringCursor.substring(0, matcherEdit.end());
-            Matcher matcherFull = INTERNOTE_LINK_PATTERN.matcher(substringEdit);
+            Matcher matcherFull = INTERNOTE_LINK_PATTERN_FULL.matcher(substringEdit);
 
             if (!matcherFull.lookingAt()) {
                 return false;

--- a/Simplenote/src/main/res/layout/autocomplete_list_item.xml
+++ b/Simplenote/src/main/res/layout/autocomplete_list_item.xml
@@ -7,6 +7,7 @@
     android:layout_height="match_parent"
     android:layout_width="match_parent"
     android:padding="@dimen/padding_medium"
+    android:maxLines="1"
     android:textAppearance="@android:style/TextAppearance.Medium"
     android:textSize="@dimen/text_content_title"
     tools:text="Tag Name">


### PR DESCRIPTION
### Fix
Add autocomplete to the editor when adding an internote link.  The first commit is a revert of the [revert commit in the Add Internote Linking pull request](https://github.com/Automattic/simplenote-android/pull/1145/commits/e85ff49acc26de6023a8e0f6ab257c6bbb8dc318).  The other major commit [updates from the `Matcher.find()` instances to `Matcher.lookingAt()` in the `enoughToFilter()` method](https://github.com/Automattic/simplenote-android/compare/add-internote-autocomplete?expand=1#diff-d7bdc58497d812e17e5ca4af04e93459R51-R59).  The `find()` method caused severe performance issues with large notes and replacing it with `lookingAt()` resolved those issues.  See the animation below for illustration.

<kbd><a href="https://user-images.githubusercontent.com/3827611/94215307-78e5d100-fe99-11ea-90d7-c652d3aa3291.gif"><img src="https://user-images.githubusercontent.com/3827611/94215307-78e5d100-fe99-11ea-90d7-c652d3aa3291.gif" width="300"></a></kbd>

### Test
1. Tap any note in list.
2. Enter `[` in the note.
3. Notice autocomplete is not shown.
4. Enter any character(s) in another note's title.
5. Notice autocomplete is shown.
6. Tap any item in autocomplete list.
7. Notice internote link is inserted into note.
8. Tap anywhere in internote link title (i.e. between `[` and `]`).
9. Enter any character(s).
10. Notice autocomplete is not shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

#### Note
Contact me for an installable build.

### Release
`RELEASE-NOTES.txt` was updated in 6441bd68 with:
> Added autocomplete to the editor when adding a link between notes [https://github.com/Automattic/simplenote-android/pull/1161]