### PR TITLE
Update Paused Flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 2.11.1
 -----
+* Fixed switching between apps causing data loss [https://github.com/Automattic/simplenote-android/pull/1170]
 
 2.11
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -483,6 +483,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onResume() {
         super.onResume();
+        mIsPaused = false;
         mNotesBucket.start();
         AppLog.add(Type.SYNC, "Started note bucket (NoteEditorFragment)");
         mNotesBucket.addListener(this);


### PR DESCRIPTION
### Fix
Update the `mIsPaused` boolean flag to be reset (i.e. set to `false`) when the app is no longer paused (i.e. `onResume` is called).  The flag was introduced in #880 in order to move the note bucket listener removal and note bucket stopping from `onPause` to `onSaveObject`, which fixed #879.  If the `mIsPaused` flag is never reset, the note bucket listener will be removed and note bucket will be stopped after the app is paused, resumed, and an edit is made.  Any edits made after the listener is removed and the bucket is stopped may not be synced causing data loss.

### Test
Even though I'm still unable to reproduce the issue, @dmsnell and I walked through the Simplenote and Simperium lifecycle to verify this change _could_ be the root cause of data loss when switching between apps and the change should not cause any other bug.  The testing steps below are what produced the same application logs that were shared with us by users.  Therefore, these are what we believe would reproduce the data loss issue.
1. Open any note in list.
2. Tap the recents/overview button in navigation bar.
3. Tap Simplenote app in recents list.
4. Edit text in note.
5. Switch to another app.
6. Switch back to Simplenote app.
7. Notice edits from Step 4 are shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 10f8ced1 with:
> Fixed switching between apps causing data loss [https://github.com/Automattic/simplenote-android/pull/1170]

#### Note
@mokagio, these changes will require a hotfix and new release candidate build once they are merged.