### PR TITLE
Update Sheet Styles

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/BottomSheetDialogBase.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/BottomSheetDialogBase.java
@@ -9,13 +9,14 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
+import com.automattic.simplenote.utils.ThemeUtils;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 public class BottomSheetDialogBase extends BottomSheetDialogFragment {
     @Override
     public int getTheme() {
-        return R.style.Theme_Simplestyle_BottomSheetDialog;
+        return ThemeUtils.getThemeFromStyle(requireContext());
     }
 
     @NonNull

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -9,6 +9,7 @@ import android.net.Uri;
 
 import androidx.annotation.AttrRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.StyleRes;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.preference.PreferenceManager;
 
@@ -136,6 +137,26 @@ public class ThemeUtils {
             case STYLE_PUBLICATION:
             default:
                 return isLight ? "light.css" : "dark.css";
+        }
+    }
+
+    public static @StyleRes int getThemeFromStyle(Context context) {
+        switch (PrefUtils.getStyleIndexSelected(context)) {
+            case STYLE_BLACK:
+                return R.style.Theme_Simplestyle_BottomSheetDialog_Black;
+            case STYLE_CLASSIC:
+                return R.style.Theme_Simplestyle_BottomSheetDialog_Classic;
+            case STYLE_MATRIX:
+                return R.style.Theme_Simplestyle_BottomSheetDialog_Matrix;
+            case STYLE_MONO:
+                return R.style.Theme_Simplestyle_BottomSheetDialog_Mono;
+            case STYLE_PUBLICATION:
+                return R.style.Theme_Simplestyle_BottomSheetDialog_Publication;
+            case STYLE_SEPIA:
+                return R.style.Theme_Simplestyle_BottomSheetDialog_Sepia;
+            case STYLE_DEFAULT:
+            default:
+                return R.style.Theme_Simplestyle_BottomSheetDialog;
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/ThemeUtils.java
@@ -156,7 +156,7 @@ public class ThemeUtils {
                 return R.style.Theme_Simplestyle_BottomSheetDialog_Sepia;
             case STYLE_DEFAULT:
             default:
-                return R.style.Theme_Simplestyle_BottomSheetDialog;
+                return R.style.Theme_Simplestyle_BottomSheetDialog_Default;
         }
     }
 

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -116,6 +116,9 @@
         <item name="colorPrimaryDark">@color/blue_50</item>
     </style>
 
+    <style name="Theme.Simplestyle.BottomSheetDialog.Default" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+    </style>
+
     <style name="Theme.Simplestyle.BottomSheetDialog.Matrix" parent="@style/Theme.Simplestyle.BottomSheetDialog">
         <item name="colorAccent">@color/item_matrix_dark</item>
         <item name="colorPrimary">@color/green</item>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -104,6 +104,42 @@
         <item name="colorPrimaryDark">@color/blue_dark</item>
     </style>
 
+    <style name="Theme.Simplestyle.BottomSheetDialog.Black" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+        <item name="colorAccent">@color/item_black_dark</item>
+        <item name="colorPrimary">@android:color/black</item>
+        <item name="colorPrimaryDark">@android:color/black</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog.Classic" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+        <item name="colorAccent">@color/item_classic_dark</item>
+        <item name="colorPrimary">@color/blue_50</item>
+        <item name="colorPrimaryDark">@color/blue_50</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog.Matrix" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+        <item name="colorAccent">@color/item_matrix_dark</item>
+        <item name="colorPrimary">@color/green</item>
+        <item name="colorPrimaryDark">@color/background_dark_matrix</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog.Mono" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+        <item name="colorAccent">@color/item_mono_dark</item>
+        <item name="colorPrimary">@color/gray</item>
+        <item name="colorPrimaryDark">@color/gray</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog.Publication" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+        <item name="colorAccent">@color/item_publication_dark</item>
+        <item name="colorPrimary">@color/red</item>
+        <item name="colorPrimaryDark">@color/red</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog.Sepia" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+        <item name="colorAccent">@color/item_sepia_dark</item>
+        <item name="colorPrimary">@color/orange</item>
+        <item name="colorPrimaryDark">@color/background_dark_sepia_1</item>
+    </style>
+
     <style name="Theme.Simplestyle.BottomSheetDialog.Label" parent="Theme.Simplestyle.BottomSheetDialog">
         <item name="android:ellipsize">end</item>
         <item name="android:gravity">center_vertical|start</item>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -116,7 +116,7 @@
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLightStatusBar">true</item>
     </style>
-    
+
     <style name="Theme.Simplestyle.Splash">
         <item name="android:navigationBarColor">@color/blue</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
@@ -132,6 +132,42 @@
         <item name="colorAccent">@color/item_default_light</item>
         <item name="colorPrimary">@color/blue</item>
         <item name="colorPrimaryDark">@color/blue_dark</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog.Black" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+        <item name="colorAccent">@color/item_black_light</item>
+        <item name="colorPrimary">@android:color/black</item>
+        <item name="colorPrimaryDark">@android:color/black</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog.Classic" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+        <item name="colorAccent">@color/item_classic_light</item>
+        <item name="colorPrimary">@color/blue_50</item>
+        <item name="colorPrimaryDark">@color/blue_50</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog.Matrix" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+        <item name="colorAccent">@color/item_matrix_light</item>
+        <item name="colorPrimary">@color/green</item>
+        <item name="colorPrimaryDark">@color/background_light</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog.Mono" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+        <item name="colorAccent">@color/item_mono_light</item>
+        <item name="colorPrimary">@color/gray</item>
+        <item name="colorPrimaryDark">@color/gray</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog.Publication" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+        <item name="colorAccent">@color/item_publication_light</item>
+        <item name="colorPrimary">@color/red</item>
+        <item name="colorPrimaryDark">@color/red</item>
+    </style>
+
+    <style name="Theme.Simplestyle.BottomSheetDialog.Sepia" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+        <item name="colorAccent">@color/item_sepia_light</item>
+        <item name="colorPrimary">@color/orange</item>
+        <item name="colorPrimaryDark">@color/background_light_sepia</item>
     </style>
 
     <style name="Theme.Simplestyle.BottomSheetDialog.Label" parent="Theme.MaterialComponents.Light.BottomSheetDialog">

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -146,6 +146,9 @@
         <item name="colorPrimaryDark">@color/blue_50</item>
     </style>
 
+    <style name="Theme.Simplestyle.BottomSheetDialog.Default" parent="@style/Theme.Simplestyle.BottomSheetDialog">
+    </style>
+
     <style name="Theme.Simplestyle.BottomSheetDialog.Matrix" parent="@style/Theme.Simplestyle.BottomSheetDialog">
         <item name="colorAccent">@color/item_matrix_light</item>
         <item name="colorPrimary">@color/green</item>


### PR DESCRIPTION
### Fix
Update the bottom sheet styles to follow the selected app style.  See the screenshots below for illustration.

![update_sheet_styles](https://user-images.githubusercontent.com/3827611/94224972-01bc3700-feb1-11ea-84e5-63254ecf1304.png)

### Test
The best way I found to test both **_Light_** and **_Dark_** for all styles is to set the **_Theme_** setting to **_System default_**.  Then, toggle the **_Dark theme_** option from Android's **_Quick Settings_**.  Unfortunately, there isn't a quick way to switch Simplenote app styles.  The only way to do it is through the **_Style_** setting via **_Settings_**.

#### Default
1. Tap any note in list referenced in another note with an internote link.
2. Tap ***Information*** action in app bar.
3. Notice **_Referenced In_** section is shown in **_Information_** sheet.
4. Notice **_Referenced In_** text is `simplenote_blue_50` (`#3361cc`) for **_Light_** and `simplenote_blue_20` (`#84a4f0`) for **_Dark_**.
5. Swipe up to fully expand Information sheet.
6. Swipe up on **_Referenced In_** list.
7. Notice overscroll color is `simplenote_blue_50` (`#3361cc`) for **_Light_** and `simplenote_blue_20` (`#84a4f0`) for **_Dark_**.

#### Classic
1. Tap any note in list referenced in another note with an internote link.
2. Tap ***Information*** action in app bar.
3. Notice **_Referenced In_** section is shown in **_Information_** sheet.
4. Notice **_Referenced In_** text is `blue_50` (`#2271b1`) for **_Light_** and `blue_20` (`#72aee6`) for **_Dark_**.
5. Swipe up to fully expand Information sheet.
6. Swipe up on **_Referenced In_** list.
7. Notice overscroll color is `blue_50` (`#2271b1`)for **_Light_** and `blue_20` (`#72aee6`) for **_Dark_**.

#### Black
1. Tap any note in list referenced in another note with an internote link.
2. Tap ***Information*** action in app bar.
3. Notice **_Referenced In_** section is shown in **_Information_** sheet.
4. Notice **_Referenced In_** text is `black` (`#000000`) for **_Light_** and `white` (`#ffffff`) for **_Dark_**.
5. Swipe up to fully expand Information sheet.
6. Swipe up on **_Referenced In_** list.
7. Notice overscroll color is `black` (`#000000`)for **_Light_** and `black` (`#000000`) for **_Dark_**.

#### Mono
1. Tap any note in list referenced in another note with an internote link.
2. Tap ***Information*** action in app bar.
3. Notice **_Referenced In_** section is shown in **_Information_** sheet.
4. Notice **_Referenced In_** text is `gray_50` (`#646970`) for **_Light_** and `gray_20` (`#a7aaad`) for **_Dark_**.
5. Swipe up to fully expand Information sheet.
6. Swipe up on **_Referenced In_** list.
7. Notice overscroll color is `gray_50` (`#646970`)for **_Light_** and `gray_20` (`#a7aaad`) for **_Dark_**.

#### Matrix
1. Tap any note in list referenced in another note with an internote link.
2. Tap ***Information*** action in app bar.
3. Notice **_Referenced In_** section is shown in **_Information_** sheet.
4. Notice **_Referenced In_** text is `green_50` (`#008a20`) for **_Light_** and `green_20` (`#1ed15a`) for **_Dark_**.
5. Swipe up to fully expand Information sheet.
6. Swipe up on **_Referenced In_** list.
7. Notice overscroll color is `green_50` (`#008a20`)for **_Light_** and `green_20` (`#1ed15a`) for **_Dark_**.

#### Publication
1. Tap any note in list referenced in another note with an internote link.
2. Tap ***Information*** action in app bar.
3. Notice **_Referenced In_** section is shown in **_Information_** sheet.
4. Notice **_Referenced In_** text is `red_50` (`#d63638`) for **_Light_** and `red_20` (`#ff8085`) for **_Dark_**.
5. Swipe up to fully expand Information sheet.
6. Swipe up on **_Referenced In_** list.
7. Notice overscroll color is `red_50` (`#d63638`)for **_Light_** and `red_20` (`#ff8085`) for **_Dark_**.

#### Sepia
1. Tap any note in list referenced in another note with an internote link.
2. Tap ***Information*** action in app bar.
3. Notice **_Referenced In_** section is shown in **_Information_** sheet.
4. Notice **_Referenced In_** text is `orange_50` (`#b26200`) for **_Light_** and `orange_20` (`#faa754`) for **_Dark_**.
5. Swipe up to fully expand Information sheet.
6. Swipe up on **_Referenced In_** list.
7. Notice overscroll color is `orange_50` (`#b26200`)for **_Light_** and `orange_20` (`#faa754`) for **_Dark_**.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

#### Note
Contact me for an installable build.

### Release
These changes do not require release notes.  `RELEASE-NOTES.txt` will be updated once the styles feature is complete.