### PR TITLE
Remove Information Title

### DIFF
--- a/Simplenote/src/main/res/layout/bottom_sheet_info.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_info.xml
@@ -14,6 +14,7 @@
 
         <LinearLayout
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/padding_small"
             android:layout_width="match_parent"
             android:orientation="horizontal">
 
@@ -83,6 +84,7 @@
 
         <LinearLayout
             android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/padding_small"
             android:layout_width="match_parent"
             android:orientation="horizontal">
 
@@ -119,6 +121,7 @@
 
             <com.automattic.simplenote.widgets.RobotoMediumTextView
                 android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/padding_small"
                 android:layout_width="match_parent"
                 android:padding="@dimen/padding_large"
                 android:text="@string/references"
@@ -129,6 +132,7 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/references"
                 android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/padding_small"
                 android:layout_width="match_parent"
                 tools:listitem="@layout/reference_list_row">
             </androidx.recyclerview.widget.RecyclerView>

--- a/Simplenote/src/main/res/layout/bottom_sheet_info.xml
+++ b/Simplenote/src/main/res/layout/bottom_sheet_info.xml
@@ -12,15 +12,6 @@
         android:orientation="vertical"
         android:theme="@style/Theme.Simplestyle.BottomSheetDialog">
 
-        <com.automattic.simplenote.widgets.RobotoRegularTextView
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"
-            android:padding="@dimen/padding_large"
-            android:text="@string/information"
-            android:textColor="?attr/notePreviewColor"
-            style="@style/Theme.Simplestyle.BottomSheetDialog.Label">
-        </com.automattic.simplenote.widgets.RobotoRegularTextView>
-
         <LinearLayout
             android:layout_height="wrap_content"
             android:layout_width="match_parent"


### PR DESCRIPTION
### Fix
Remove the title "Information" from the **_Information_** sheet.  The "Information" title conflicted stylistically with the "Referenced In" title added recently with internote links.  See the screenshots below for illustration.

![remove_information_title](https://user-images.githubusercontent.com/3827611/96015647-0c5d5280-0e05-11eb-94c5-717385804e11.png)

### Test
1. Tap any note in list.
2. Tap ***Information*** action in top app bar.
3. Notice "Information" title is not shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

#### Note
Contact me for an installable build.

### Release
These changes do not require release notes.