### PR TITLE
Update Snackbar Messages

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1386,40 +1386,11 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 }
             } else {
                 if (mHideActionOnSuccess) {
-                    Snackbar.make(mRootView, R.string.unpublish_successful, Snackbar.LENGTH_LONG)
-                            .show();
+                    Snackbar.make(mRootView, R.string.unpublish_successful, Snackbar.LENGTH_LONG).show();
                 } else {
                     Snackbar.make(mRootView, R.string.unpublish_successful, Snackbar.LENGTH_LONG)
-                            .setAction(
-                                R.string.undo,
-                                new View.OnClickListener() {
-                                    @Override
-                                    public void onClick(View v) {
-                                        mHideActionOnSuccess = true;
-                                        publishNote();
-                                    }
-                                }
-                            )
-                            .show();
-                }
-            }
-        } else {
-            if (mNote.isPublished()) {
-                Snackbar.make(mRootView, R.string.unpublish_error, Snackbar.LENGTH_LONG)
                         .setAction(
-                            R.string.retry,
-                            new View.OnClickListener() {
-                                @Override
-                                public void onClick(View v) {
-                                    mHideActionOnSuccess = true;
-                                    unpublishNote();
-                                }
-                            }
-                        ).show();
-            } else {
-                Snackbar.make(mRootView, R.string.publish_error, Snackbar.LENGTH_LONG)
-                        .setAction(
-                            R.string.retry,
+                            R.string.undo,
                             new View.OnClickListener() {
                                 @Override
                                 public void onClick(View v) {
@@ -1427,7 +1398,35 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                                     publishNote();
                                 }
                             }
-                        ).show();
+                        )
+                        .show();
+                }
+            }
+        } else {
+            if (mNote.isPublished()) {
+                Snackbar.make(mRootView, R.string.unpublish_error, Snackbar.LENGTH_LONG)
+                    .setAction(
+                        R.string.retry,
+                        new View.OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                mHideActionOnSuccess = true;
+                                unpublishNote();
+                            }
+                        }
+                    ).show();
+            } else {
+                Snackbar.make(mRootView, R.string.publish_error, Snackbar.LENGTH_LONG)
+                    .setAction(
+                        R.string.retry,
+                        new View.OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                mHideActionOnSuccess = true;
+                                publishNote();
+                            }
+                        }
+                    ).show();
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1414,7 +1414,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                                 unpublishNote();
                             }
                         }
-                    ).show();
+                    )
+                    .show();
             } else {
                 Snackbar.make(mRootView, R.string.publish_error, Snackbar.LENGTH_LONG)
                     .setAction(
@@ -1426,7 +1427,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                                 publishNote();
                             }
                         }
-                    ).show();
+                    )
+                    .show();
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -39,7 +39,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.view.ActionMode;
 import androidx.core.app.ShareCompat;
@@ -1369,18 +1368,10 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
         if (isSuccess && isAdded()) {
             if (mNote.isPublished()) {
-                @StringRes int text;
-
-                if (BrowserUtils.copyToClipboard(requireContext(), mNote.getPublishedUrl())) {
-                    text = R.string.publish_successful_link;
-                } else {
-                    text = R.string.publish_successful;
-                }
-
                 if (mHideActionOnSuccess) {
-                    Snackbar.make(mRootView, text, Snackbar.LENGTH_LONG).show();
+                    Snackbar.make(mRootView, R.string.publish_successful, Snackbar.LENGTH_LONG).show();
                 } else {
-                    Snackbar.make(mRootView, text, Snackbar.LENGTH_LONG)
+                    Snackbar.make(mRootView, R.string.publish_successful, Snackbar.LENGTH_LONG)
                         .setAction(
                             R.string.undo,
                             new View.OnClickListener() {

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -164,13 +164,12 @@
     <string name="publish">Publish</string>
     <string name="unpublish">Remove public link</string>
     <string name="published">Published</string>
-    <string name="publish_error">Could not create link.</string>
-    <string name="unpublish_error">Could not remove link.</string>
-    <string name="publish_successful">Published.</string>
-    <string name="publish_successful_link">Published. Link copied!</string>
-    <string name="unpublish_successful">Public link removed.</string>
-    <string name="publishing">Publishing&#8230;</string>
-    <string name="unpublishing">Removing public link&#8230;</string>
+    <string name="publish_error">Could not publish note.</string>
+    <string name="unpublish_error">Could not unpublish note.</string>
+    <string name="publish_successful">Note published.</string>
+    <string name="unpublish_successful">Note unpublished.</string>
+    <string name="publishing">Publishing note&#8230;</string>
+    <string name="unpublishing">Unpublishing note&#8230;</string>
     <string name="error_network_required">A network connection is required. Please, check your connection and try again.</string>
     <string name="retry">Retry</string>
 

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -118,7 +118,7 @@
     <string name="view_map">View Map</string>
     <string name="view_in_browser">View in Browser</string>
     <string name="link">Link</string>
-    <string name="link_copied">Link copied!</string>
+    <string name="link_copied">Link copied.</string>
     <string name="link_copied_failure">Link could not be copied.</string>
     <string name="copy">Copy</string>
 


### PR DESCRIPTION
### Fix
Update the messages shown in snackbars for publishing notes, unpublishing notes, and copying links.  Also, automatically copying the link to the device's clipboard when publishing was removed.  See the screenshots below for illustration.

![update_snackbar_messages](https://user-images.githubusercontent.com/3827611/95783401-fc236700-0c8e-11eb-9947-84694a8b75e5.png)

### Test
Both publishing and unpublishing can take longer than expected if the queue is backed up.  There is a twenty-second timeout if the publishing/unpublishing action isn't completed, which has been common recently.  That part of the app isn't part of these changes.  Feel free to contact me if you're having issues publishing/unpublishing.
#### Publish [Success]
1. Tap unpublished note in list.
2. Tap overflow menu action.
3. Tap ***Publish*** item in menu.
4. Notice snackbar is shown with  ***Publishing note...*** message.
5. Notice snackbar is shown with ***Note published.*** message and ***Undo*** action.
6. Tap ***Undo*** action in snackbar.
7. Notice snackbar is shown with ***Unpublishing note...*** message.
8. Notice snackbar is shown with ***Note unpublished.*** message.

#### Publish [Failure]
1. Tap unpublished note in list.
2. Tap overflow menu action.
3. Tap ***Publish*** item in menu.
4. Notice snackbar is shown with  ***Publishing note...*** message.
5. Notice snackbar is shown with ***Could not publish note.*** message and ***Retry*** action.
6. Tap ***Retry*** action in snackbar.
7. Notice snackbar is shown with ***Publishing note...*** message.

#### Unpublish [Success]
1. Tap published note in list.
2. Tap overflow menu action.
3. Tap ***Publish*** item in menu.
4. Notice snackbar is shown with  ***Unpublishing note...*** message.
5. Notice snackbar is shown with ***Note unpublished.*** message and ***Undo*** action.
6. Tap ***Undo*** action in snackbar.
7. Notice snackbar is shown with ***Publishing note...*** message.
8. Notice snackbar is shown with ***Note published.*** message.

#### Unpublish [Failure]
1. Tap published note in list.
2. Tap overflow menu action.
3. Tap ***Publish*** item in menu.
4. Notice snackbar is shown with  ***Unpublishing note...*** message.
5. Notice snackbar is shown with ***Could not unpublish link.*** message and ***Retry*** action.
6. Tap ***Retry*** action in snackbar.
7. Notice snackbar is shown with ***Unpublishing note...*** message.

#### Copy Link [Internal]
1. Tap published note in list.
2. Tap overflow menu action.
3. Tap ***Copy Internal Link*** item in menu.
4. Notice snackbar is shown with ***Link copied.*** message.
5. Long-press anywhere in note content.
6. Tap **_Paste_** option.
7. Notice internal link is pasted.

#### Copy Link [Public]
1. Tap published note in list.
2. Tap overflow menu action.
3. Tap ***Copy Link*** item in menu.
4. Notice snackbar is shown with ***Link copied.*** message.
5. Long-press anywhere in note content.
6. Tap **_Paste_** option.
7. Notice public link is pasted.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

#### Note
Contact me for an installable build.

### Release
These changes do not require release notes.