### PR TITLE
Enforce use of bundle exec in Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,10 @@
 default_platform(:android)
 fastlane_require 'dotenv'
 
+unless FastlaneCore::Helper.bundler?
+  UI.user_error!('Please run fastlane via `bundle exec`')
+end
+
 USER_ENV_FILE_PATH = File.join(Dir.home, '.simplenoteandroid-env.default')
 
 before_all do


### PR DESCRIPTION
### Fix

This adds checks in the `Fastfile` so that it stops you from accidentally run `fastlane` without prefixing them with `bundle exec`.

If you forget to prepend `bundle exec` when invoking `fastlane`, this will now error and stop, telling you to use `bundle exec` – so you run the versions of fastlane specified in the repo's `Gemfile.lock` – instead of continuing to run with the system-wide version – which might not be the same and behave differently than when ran under bundle exec.

### Test:


1️⃣  Run `fastlane lanes`, and check it fails with the following output

<details><summary>Expected fastlane failure when running without <tt>bundle exec</tt></summary>

```
[✔] 🚀 
[19:25:18]: fastlane detected a Gemfile in the current directory
[19:25:18]: However, it seems like you didn't use `bundle exec`
[19:25:18]: To launch fastlane faster, please use
[19:25:18]: 
[19:25:18]: $ bundle exec fastlane lanes
[19:25:18]: 
[19:25:18]: Get started using a Gemfile for fastlane https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile
[19:25:19]: Installing Ruby gem 'fastlane-plugin-wpmreleasetoolkit'...
[19:25:36]: Found gem "fastlane-plugin-release_helper" instead of the required name "fastlane-plugin-wpmreleasetoolkit"
[19:25:37]: Successfully installed 'fastlane-plugin-wpmreleasetoolkit'
[19:25:37]: Error loading plugin 'fastlane-plugin-wpmreleasetoolkit': cannot load such file -- fastlane/plugin/wpmreleasetoolkit
[19:25:37]: It seems like you wanted to load some plugins, however they couldn't be loaded
[19:25:37]: Please follow the troubleshooting guide: https://docs.fastlane.tools/plugins/plugins-troubleshooting/
+-----------------------------------+-----------+------------------+
|                           Used plugins                           |
+-----------------------------------+-----------+------------------+
| Plugin                            | Version   | Action           |
+-----------------------------------+-----------+------------------+
| fastlane-plugin-wpmreleasetoolkit | undefined | No actions found |
+-----------------------------------+-----------+------------------+

[!] No actions were found while loading one or more plugins
    Please use `bundle exec fastlane` with plugins
    More info - https://docs.fastlane.tools/plugins/using-plugins/#run-with-plugins

[19:25:38]: ------------------------------
[19:25:38]: --- Step: default_platform ---
[19:25:38]: ------------------------------

[!] Please run fastlane via `bundle exec`
```
</details>

2️⃣  Run `bundle exec fastlane lanes` (or `be fastlane lanes` if you created an alias for `bundle exec` in your `.zshrc`, which I recommend) and check that it runs without issues and lists the available lanes

### Review

Only one developer is required to review these changes, but anyone can perform the review.

### Release

These changes do not require release notes.
