### PR TITLE
Crash No Webview

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,9 +1,9 @@
 2.13
 -----
+* Fixed crashing on devices with no web view installed [https://github.com/Automattic/simplenote-android/pull/1182]
 
 2.12
 -----
-
 * Added autocomplete to the editor when adding a link between notes [https://github.com/Automattic/simplenote-android/pull/1161]
 * Added a link to help in settings [https://github.com/Automattic/simplenote-android/pull/1155]
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -918,20 +918,13 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     public void setNote(String noteID, String matchOffsets) {
-        if (mAutoSaveHandler != null)
+        if (mAutoSaveHandler != null) {
             mAutoSaveHandler.removeCallbacks(mAutoSaveRunnable);
-
-        mPlaceholderView.setVisibility(View.GONE);
-
-        if (matchOffsets != null) {
-            mMatchOffsets = matchOffsets;
-        } else {
-            mMatchOffsets = null;
         }
 
-
+        mPlaceholderView.setVisibility(View.GONE);
+        mMatchOffsets = matchOffsets;
         saveNote();
-
         new LoadNoteTask(this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, noteID);
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -551,6 +551,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onResume() {
         super.onResume();
+        checkWebView();
         mIsPaused = false;
         mNotesBucket.start();
         AppLog.add(Type.SYNC, "Started note bucket (NoteEditorFragment)");
@@ -563,6 +564,16 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             if (mContentEditText.hasFocus()) {
                 showSoftKeyboard();
             }
+        }
+    }
+
+    private void checkWebView() {
+        // When a WebView is installed and mMarkdown is null on a large landscape device, a WebView
+        // was not installed when the fragment was created.  So, recreate the activity to refresh
+        // the editor view.
+        if (BrowserUtils.isWebViewInstalled(requireContext()) && mMarkdown == null &&
+            DisplayUtils.isLargeScreenLandscape(requireContext())) {
+            requireActivity().recreate();
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -793,12 +793,21 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     protected void hideMarkdown() {
-        mMarkdown.setVisibility(View.INVISIBLE);
+        if (BrowserUtils.isWebViewInstalled(requireContext()) && mMarkdown != null) {
+            mMarkdown.setVisibility(View.INVISIBLE);
+        } else {
+            mError.setVisibility(View.INVISIBLE);
+        }
     }
 
     protected void showMarkdown() {
         loadMarkdownData();
-        mMarkdown.setVisibility(View.VISIBLE);
+
+        if (BrowserUtils.isWebViewInstalled(requireContext()) && mMarkdown != null) {
+            mMarkdown.setVisibility(View.VISIBLE);
+        } else {
+            mError.setVisibility(View.VISIBLE);
+        }
 
         new Handler().postDelayed(
             new Runnable() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -787,7 +787,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     protected void clearMarkdown() {
-        mMarkdown.loadDataWithBaseURL("file:///android_asset/", mCss + "", "text/html", "utf-8", null);
+        if (mMarkdown != null) {
+            mMarkdown.loadDataWithBaseURL("file:///android_asset/", mCss + "", "text/html", "utf-8", null);
+        }
     }
 
     protected void hideMarkdown() {
@@ -886,11 +888,13 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     private void loadMarkdownData() {
         String formattedContent = NoteMarkdownFragment.getMarkdownFormattedContent(
-                mCss,
-                mContentEditText.getPreviewTextContent()
+            mCss,
+            mContentEditText.getPreviewTextContent()
         );
 
-        mMarkdown.loadDataWithBaseURL(null, formattedContent, "text/html", "utf-8", null);
+        if (mMarkdown != null) {
+            mMarkdown.loadDataWithBaseURL(null, formattedContent, "text/html", "utf-8", null);
+        }
     }
 
     public void setNote(String noteID, String matchOffsets) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -249,7 +249,9 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
     }
 
     public void updateMarkdown(String text) {
-        mMarkdown.loadDataWithBaseURL(null, getMarkdownFormattedContent(mCss, text), "text/html", "utf-8", null);
+        if (mMarkdown != null) {
+            mMarkdown.loadDataWithBaseURL(null, getMarkdownFormattedContent(mCss, text), "text/html", "utf-8", null);
+        }
     }
 
     public static String getMarkdownFormattedContent(String cssContent, String sourceContent) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -173,12 +173,8 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
 
     @Override
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
-        // Disable share and delete actions until note is loaded.
-        if (mIsLoadingNote) {
-            menu.findItem(R.id.menu_trash).setEnabled(false);
-        } else {
-            menu.findItem(R.id.menu_trash).setEnabled(true);
-        }
+        // Disable trash action until note is loaded.
+        menu.findItem(R.id.menu_trash).setEnabled(!mIsLoadingNote);
 
         MenuItem pinItem = menu.findItem(R.id.menu_pin);
         MenuItem publishItem = menu.findItem(R.id.menu_publish);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -213,6 +213,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
     @Override
     public void onResume() {
         super.onResume();
+        checkWebView();
         mNotesBucket.start();
         AppLog.add(Type.SYNC, "Started note bucket (NoteMarkdownFragment)");
         mNotesBucket.addListener(this);
@@ -246,6 +247,14 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
                 " / Characters: " + NoteUtils.getCharactersCount(note.getContent()) +
                 " / Words: " + NoteUtils.getWordCount(note.getContent()) + ")"
         );
+    }
+
+    private void checkWebView() {
+        // When a WebView is installed and mMarkdown is null, a WebView was not installed when the
+        // fragment was created.  So, open the note again to show the markdown preview.
+        if (BrowserUtils.isWebViewInstalled(requireContext()) && mMarkdown == null) {
+            SimplenoteLinkify.openNote(requireActivity(), mNote.getSimperiumKey());
+        }
     }
 
     public void updateMarkdown(String text) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -92,27 +92,43 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
         }
 
         setHasOptionsMenu(true);
-        View layout = inflater.inflate(R.layout.fragment_note_markdown, container, false);
-        mMarkdown = layout.findViewById(R.id.markdown);
-        mMarkdown.setWebViewClient(
-            new WebViewClient() {
-                @Override
-                public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request){
-                    String url = request.getUrl().toString();
+        View layout;
 
-                    if (url.startsWith(SimplenoteLinkify.SIMPLENOTE_LINK_PREFIX)){
-                        SimplenoteLinkify.openNote(requireActivity(), url.replace(SIMPLENOTE_LINK_PREFIX, ""));
-                    } else {
-                        BrowserUtils.launchBrowserOrShowError(requireContext(), url);
+        if (BrowserUtils.isWebViewInstalled(requireContext())) {
+            layout = inflater.inflate(R.layout.fragment_note_markdown, container, false);
+            mMarkdown = layout.findViewById(R.id.markdown);
+            mMarkdown.setWebViewClient(
+                new WebViewClient() {
+                    @Override
+                    public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request){
+                        String url = request.getUrl().toString();
+
+                        if (url.startsWith(SimplenoteLinkify.SIMPLENOTE_LINK_PREFIX)){
+                            SimplenoteLinkify.openNote(requireActivity(), url.replace(SIMPLENOTE_LINK_PREFIX, ""));
+                        } else {
+                            BrowserUtils.launchBrowserOrShowError(requireContext(), url);
+                        }
+
+                        return true;
                     }
-
-                    return true;
                 }
-            }
-        );
-        mCss = ThemeUtils.isLightTheme(requireContext())
-            ? ContextUtils.readCssFile(requireContext(), "light.css")
-            : ContextUtils.readCssFile(requireContext(), "dark.css");
+            );
+            mCss = ThemeUtils.isLightTheme(requireContext())
+                ? ContextUtils.readCssFile(requireContext(), "light.css")
+                : ContextUtils.readCssFile(requireContext(), "dark.css");
+        } else {
+            layout = inflater.inflate(R.layout.fragment_note_error, container, false);
+            layout.findViewById(R.id.error).setVisibility(View.VISIBLE);
+            layout.findViewById(R.id.button).setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        BrowserUtils.launchBrowserOrShowError(requireContext(), BrowserUtils.URL_WEB_VIEW);
+                    }
+                }
+            );
+        }
+
         return layout;
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -325,10 +325,6 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
             mShouldSelectNewNote = false;
         }
 
-        if (mIsShowingMarkdown) {
-            setMarkdownShowing(false);
-        }
-
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         if(DisplayUtils.isLargeScreenLandscape(this)) {
             if (mIsTabletFullscreen) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/BrowserUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/BrowserUtils.java
@@ -7,6 +7,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.view.ContextThemeWrapper;
+import android.webkit.WebView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -18,6 +19,15 @@ public class BrowserUtils {
     public static boolean isBrowserInstalled(Context context) {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.simperium_url)));
         return (intent.resolveActivity(context.getPackageManager()) != null);
+    }
+
+    public static boolean isWebViewInstalled(Context context) {
+        try {
+            new WebView(context);
+            return true;
+        } catch (Exception exception) {
+            return false;
+        }
     }
 
     public static boolean copyToClipboard(Context base, String url) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/BrowserUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/BrowserUtils.java
@@ -16,6 +16,8 @@ import androidx.appcompat.app.AlertDialog;
 import com.automattic.simplenote.R;
 
 public class BrowserUtils {
+    public static final String URL_WEB_VIEW = "https://play.google.com/store/apps/details?id=com.google.android.webview";
+
     public static boolean isBrowserInstalled(Context context) {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.simperium_url)));
         return (intent.resolveActivity(context.getPackageManager()) != null);

--- a/Simplenote/src/main/res/drawable/ic_warning_24dp.xml
+++ b/Simplenote/src/main/res/drawable/ic_warning_24dp.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,22C6.5,22,2,17.5,2,12S6.5,2,12,2s10,4.5,10,10S17.5,22,12,22z M12,4c-4.4,0-8,3.6-8,8s3.6,8,8,8s8-3.6,8-8 S16.4,4,12,4z">
+    </path>
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,15c0.6,0,1,0.4,1,1c0,0.6-0.4,1-1,1s-1-0.4-1-1C11,15.4,11.4,15,12,15z">
+    </path>
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,7h2v6h-2V7z">
+    </path>
+
+</vector>

--- a/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
+++ b/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml
@@ -128,20 +128,19 @@
 
         </LinearLayout>
 
-        <FrameLayout
+        <ViewStub
+            android:id="@+id/stub_error"
+            android:layout="@layout/fragment_note_error"
             android:layout_height="match_parent"
-            android:layout_width="match_parent"
-            android:paddingEnd="8dp"
-            android:paddingStart="8dp">
+            android:layout_width="match_parent">
+        </ViewStub>
 
-            <WebView
-                android:id="@+id/markdown"
-                android:layout_height="match_parent"
-                android:layout_width="match_parent"
-                android:visibility="invisible">
-            </WebView>
-
-        </FrameLayout>
+        <ViewStub
+            android:id="@+id/stub_webview"
+            android:layout="@layout/fragment_note_webview"
+            android:layout_height="match_parent"
+            android:layout_width="match_parent">
+        </ViewStub>
 
     </FrameLayout>
 

--- a/Simplenote/src/main/res/layout/fragment_note_error.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_error.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/error"
+    android:background="?attr/mainBackgroundColor"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/padding_error"
+    android:paddingEnd="@dimen/padding_large"
+    android:paddingStart="@dimen/padding_large"
+    android:paddingTop="@dimen/padding_large"
+    android:visibility="invisible"
+    tools:visibility="visible">
+
+    <ImageView
+        android:id="@+id/image"
+        android:adjustViewBounds="true"
+        android:importantForAccessibility="no"
+        android:layout_height="@dimen/icon_empty"
+        android:layout_marginBottom="@dimen/padding_large"
+        android:layout_marginTop="@dimen/padding_large"
+        android:layout_width="@dimen/icon_empty"
+        android:src="@drawable/ic_warning_24dp"
+        android:tint="?attr/emptyImageColor">
+    </ImageView>
+
+    <com.automattic.simplenote.widgets.RobotoRegularTextView
+        android:id="@+id/text"
+        android:gravity="center_horizontal"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:textColor="?attr/notePreviewColor"
+        android:text="@string/web_view_error"
+        android:textSize="@dimen/text_empty">
+    </com.automattic.simplenote.widgets.RobotoRegularTextView>
+
+    <com.automattic.simplenote.widgets.RobotoRegularTextView
+        android:id="@+id/button"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_horizontal"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/padding_large"
+        android:layout_marginStart="@dimen/padding_large"
+        android:layout_marginTop="@dimen/padding_small"
+        android:layout_width="wrap_content"
+        android:padding="@dimen/padding_small"
+        android:text="@string/web_view_error_button"
+        android:textColor="?attr/colorAccent"
+        android:textSize="@dimen/text_empty_button">
+    </com.automattic.simplenote.widgets.RobotoRegularTextView>
+
+</LinearLayout>

--- a/Simplenote/src/main/res/layout/fragment_note_markdown.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_markdown.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
 <androidx.core.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"

--- a/Simplenote/src/main/res/layout/fragment_note_markdown.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_markdown.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:clipToPadding="false"
-    android:padding="8dp"
+    android:padding="@dimen/padding_small"
     android:scrollbarStyle="outsideOverlay"
     android:scrollbars="vertical">
 

--- a/Simplenote/src/main/res/layout/fragment_note_markdown.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_markdown.xml
@@ -2,17 +2,17 @@
 
 <androidx.core.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     android:clipToPadding="false"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
     android:padding="@dimen/padding_small"
-    android:scrollbarStyle="outsideOverlay"
-    android:scrollbars="vertical">
+    android:scrollbars="vertical"
+    android:scrollbarStyle="outsideOverlay">
 
     <WebView
         android:id="@+id/markdown"
-        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_width="match_parent"
         android:scrollbars="none">
     </WebView>
 

--- a/Simplenote/src/main/res/layout/fragment_note_webview.xml
+++ b/Simplenote/src/main/res/layout/fragment_note_webview.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:paddingEnd="@dimen/padding_small"
+    android:paddingStart="@dimen/padding_small">
+
+    <WebView
+        android:id="@+id/markdown"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:visibility="invisible"
+        tools:visibility="visible">
+    </WebView>
+
+</FrameLayout>

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -10,6 +10,7 @@
     <dimen name="padding_large">16dp</dimen>
     <dimen name="padding_extra_large">20dp</dimen>
     <dimen name="padding_extra_extra_large">24dp</dimen>
+    <dimen name="padding_error">48dp</dimen>
     <dimen name="padding_suggestion">40dp</dimen>
 
     <!-- http://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-keylines-spacing -->

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -75,6 +75,8 @@
     <string name="references_one">%1$d Reference, Last modified %2$s</string>
     <string name="references_other">%1$d References, Last modified %2$s</string>
     <string name="settings_item_get_help">Get help</string>
+    <string name="web_view_error">A web view must be installed on your device to preview markdown.</string>
+    <string name="web_view_error_button">Go to WebView app</string>
 
     <!-- Preferences -->
     <string name="export_file">simplenote.json</string>


### PR DESCRIPTION
### Fix
Update the `NoteEditorFragment` and `NoteMarkdownFragment` classes to handle when a device doesn't not have a `WebView` installed to avoid an `InflateException` crash.  We've been receiving crash reports with the following statement in the stack traces.

```
InflateException: Binary XML file line #10 in com.automattic.simplenote.debug:layout/fragment_note_markdown: Binary XML file line #10 in com.automattic.simplenote.debug:layout/fragment_note_markdown: Error inflating class android.webkit.WebView
```

```
android.view.InflateException: Binary XML file line #137 in com.automattic.simplenote.debug:layout/fragment_note_editor: Binary XML file line #137 in com.automattic.simplenote.debug:layout/fragment_note_editor: Error inflating class android.webkit.WebView
```

The [`layout/fragment_note_markdown.xml` file has `<WebView` on Line 10](https://github.com/Automattic/simplenote-android/blob/33d6f073222f84b537dac4c128bca96cbd16118f/Simplenote/src/main/res/layout/fragment_note_markdown.xml#L10).  The [`layout-large-land/fragment_note_editor` file has `<WebView` on Line 137](https://github.com/Automattic/simplenote-android/blob/33d6f073222f84b537dac4c128bca96cbd16118f/Simplenote/src/main/res/layout-large-land/fragment_note_editor.xml#L137).  The following statement is also in the stack traces.

```
android.webkit.WebViewFactory$MissingWebViewPackageException: Failed to load WebView provider: No WebView installed
```

That implies there is no `WebView` installed on the device, which is why the layouts have trouble inflating the `<WebView` view.  [Starting with Android Lollipop, the system `WebView` was based on Chromium](https://developer.android.com/about/versions/lollipop#WebView) so it would be easier to update the `WebView` separate from operating system updates (i.e. through the [Play Store with Android System WebView](https://play.google.com/store/apps/details?id=com.google.android.webview)).  Consequently, some devices may not have a `WebView` app installed.  These changes are an attempt to fix the crash by catching the exception and showing an informative message with an action button to the user.  This error view mimics our updated empty view with an action button.  See the screenshots below for illustration.

![crash_web_view](https://user-images.githubusercontent.com/3827611/96518873-0c0bef80-1229-11eb-8830-4d654f3ee5fa.png)

This fix feels more like a hack than a fix.  I'm not really happy with it.  I would have liked to detect whether a device has some sort of `WebView` installed rather than relying on checking the exception message, but I couldn't find a dependable way to do that.  I tried using `getPackageManager().hasSystemFeature(PackageManager.FEATURE_WEBVIEW)`, but that didn't work.  If you have any suggestions on how to improve it, please share.

### Test
Even though these changes target devices without `WebView` installed, it's best to test on a device with `WebView` too.  I removed the `WebView` using the following commands.  Installing the Android System WebView app from the Play Store will restore the emulator to the state before removing the `com.google.android.webview` package.

```
$ adb shell pm list packages | grep web
package:com.google.android.webview
$ adb shell pm uninstall --user 0 com.google.android.webview
```

#### With `WebView`
1. Tap any note in list with markdown enabled.
2. Notice app does not crash.
3. Go to ***Preview*** tab.
4. Notice markdown is shown on ***Preview*** tab.

#### Without `WebView`
<ol type="1">
  <li>Tap any note in list with markdown enabled.</li>
  <li>Notice app does not crash.</li>
  <li>Go to <b><i>Preview</i></b> tab.</li>
  <li>Notice <b><i>A web view must be installed on your device to preview markdown</i></b> message is shown on <b><i>Preview</i></b> tab.</li>
  <li>Tap <b><i>Go to WebView app</i></b> button.</li>
    <ol type="a">
      <li>If device has no browser app, notice <b><i>No Browser Detected</i></b> dialog as shown in <b><i>Dialog</i></b> screenshot above.</li>
      <li>If device has browser app...</li>
        <ol type="i">
          <li>and no Play Store app, notice <b><i>Android System WebView</i></b> web page as shown in <b><i>Browser</i></b> screenshot above.</li>
          <li>and Play Store app, notice <b><i>Android System WebView</i></b> store listing as shown in <b><i>Store</i></b> screenshot above.</li>
        </ol>
    </ol>
  <li>Tap <b><i>Install</i></b> button for <b><i>Android System WebView</i></b>.</li>
  <li>Wait for <b><i>Android System WebView</i></b> to be installed.</li>
  <li>Tap back arrow in system navigation bar.</li>
  <li>Notice markdown is shown on <b><i>Preview</i></b> tab.</li>
</ol>

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

#### Note
Contact me for an installable build.

### Release
`RELEASE-NOTES.txt` was updated in 528a5968 with:
> Fixed crashing on devices with no web view installed [https://github.com/Automattic/simplenote-android/pull/1182]