### PR TITLE
Add Styled Widgets (Part 1)

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDark.java
@@ -51,7 +51,7 @@ public class NoteWidgetDark extends AppWidgetProvider {
 
     @Override
     public void onAppWidgetOptionsChanged(Context context, AppWidgetManager appWidgetManager, int appWidgetId, Bundle newOptions) {
-        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.note_widget_dark);
+        RemoteViews views = new RemoteViews(context.getPackageName(), PrefUtils.getLayoutWidget(context, false));
         resizeWidget(newOptions, views);
         appWidgetManager.updateAppWidget(appWidgetId, views);
     }
@@ -98,7 +98,7 @@ public class NoteWidgetDark extends AppWidgetProvider {
 
     private void updateWidget(Context context, AppWidgetManager appWidgetManager, int appWidgetId, Bundle appWidgetOptions) {
         // Get widget views
-        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.note_widget_dark);
+        RemoteViews views = new RemoteViews(context.getPackageName(), PrefUtils.getLayoutWidget(context, false));
         resizeWidget(appWidgetOptions, views);
 
         // Verify user authentication

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
@@ -72,7 +72,7 @@ public class NoteWidgetDarkConfigureActivity extends AppCompatActivity {
 
         // Get widget information
         mWidgetManager = AppWidgetManager.getInstance(NoteWidgetDarkConfigureActivity.this);
-        mRemoteViews = new RemoteViews(getPackageName(), R.layout.note_widget_dark);
+        mRemoteViews = new RemoteViews(getPackageName(), PrefUtils.getLayoutWidget(NoteWidgetDarkConfigureActivity.this, false));
         Intent intent = getIntent();
         Bundle extras = intent.getExtras();
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLight.java
@@ -51,7 +51,7 @@ public class NoteWidgetLight extends AppWidgetProvider {
 
     @Override
     public void onAppWidgetOptionsChanged(Context context, AppWidgetManager appWidgetManager, int appWidgetId, Bundle newOptions) {
-        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.note_widget_light);
+        RemoteViews views = new RemoteViews(context.getPackageName(), PrefUtils.getLayoutWidget(context, true));
         resizeWidget(newOptions, views);
         appWidgetManager.updateAppWidget(appWidgetId, views);
     }
@@ -98,7 +98,7 @@ public class NoteWidgetLight extends AppWidgetProvider {
 
     private void updateWidget(Context context, AppWidgetManager appWidgetManager, int appWidgetId, Bundle appWidgetOptions) {
         // Get widget views
-        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.note_widget_light);
+        RemoteViews views = new RemoteViews(context.getPackageName(), PrefUtils.getLayoutWidget(context, true));
         resizeWidget(appWidgetOptions, views);
 
         // Verify user authentication

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLightConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLightConfigureActivity.java
@@ -72,7 +72,7 @@ public class NoteWidgetLightConfigureActivity extends AppCompatActivity {
 
         // Get widget information
         mWidgetManager = AppWidgetManager.getInstance(NoteWidgetLightConfigureActivity.this);
-        mRemoteViews = new RemoteViews(getPackageName(), R.layout.note_widget_light);
+        mRemoteViews = new RemoteViews(getPackageName(), PrefUtils.getLayoutWidget(NoteWidgetLightConfigureActivity.this, true));
         Intent intent = getIntent();
         Bundle extras = intent.getExtras();
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -169,6 +169,29 @@ public class PrefUtils {
         getPrefs(context).edit().putBoolean(PREF_PREMIUM, isPremium).apply();
     }
 
+    public static int getLayoutWidget(Context context, boolean isLight) {
+        if (isPremium(context)) {
+            switch (getStyleIndexSelected(context)) {
+                case STYLE_BLACK:
+                    return isLight ? R.layout.note_widget_light : R.layout.note_widget_dark_black;
+                case STYLE_MATRIX:
+                    return isLight ? R.layout.note_widget_light_mono : R.layout.note_widget_dark_matrix;
+                case STYLE_MONO:
+                    return isLight ? R.layout.note_widget_light_mono : R.layout.note_widget_dark_mono;
+                case STYLE_PUBLICATION:
+                    return isLight ? R.layout.note_widget_light_publication : R.layout.note_widget_dark_publication;
+                case STYLE_SEPIA:
+                    return isLight ? R.layout.note_widget_light_sepia : R.layout.note_widget_dark_sepia;
+                case STYLE_CLASSIC:
+                case STYLE_DEFAULT:
+                default:
+                    return isLight ? R.layout.note_widget_light : R.layout.note_widget_dark;
+            }
+        } else {
+            return isLight ? R.layout.note_widget_light : R.layout.note_widget_dark;
+        }
+    }
+
     public static int getStyleIndexSelected(Context context) {
         return getPrefs(context).getInt(PREF_STYLE_INDEX, STYLE_DEFAULT);
     }

--- a/Simplenote/src/main/res/drawable/note_widget_background_dark_black.xml
+++ b/Simplenote/src/main/res/drawable/note_widget_background_dark_black.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <solid
+        android:color="@android:color/black">
+    </solid>
+
+    <corners
+        android:radius="@dimen/corner_radius">
+    </corners>
+
+</shape>

--- a/Simplenote/src/main/res/drawable/note_widget_background_dark_sepia.xml
+++ b/Simplenote/src/main/res/drawable/note_widget_background_dark_sepia.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <solid
+        android:color="@color/background_dark_sepia">
+    </solid>
+
+    <corners
+        android:radius="@dimen/corner_radius">
+    </corners>
+
+</shape>

--- a/Simplenote/src/main/res/drawable/note_widget_background_light_sepia.xml
+++ b/Simplenote/src/main/res/drawable/note_widget_background_light_sepia.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <solid
+        android:color="@color/background_light_sepia">
+    </solid>
+
+    <corners
+        android:radius="@dimen/corner_radius">
+    </corners>
+
+</shape>

--- a/Simplenote/src/main/res/layout/note_widget_dark_black.xml
+++ b/Simplenote/src/main/res/layout/note_widget_dark_black.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_layout"
+    android:background="@drawable/note_widget_background_dark_black"
+    android:foreground="?android:attr/selectableItemBackgroundBorderless"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:paddingEnd="@dimen/widget_margin"
+    android:paddingStart="@dimen/widget_margin"
+    android:paddingTop="@dimen/widget_margin">
+
+    <TextView
+        android:id="@+id/widget_text"
+        android:ellipsize="end"
+        android:layout_centerInParent="true"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:maxLines="4"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_dark"
+        android:textSize="@dimen/text_widget"
+        android:visibility="visible"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_dark"
+        tools:visibility="gone">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_title"
+        android:ellipsize="end"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_dark"
+        android:textSize="@dimen/text_content_title"
+        android:visibility="gone"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_dark"
+        tools:visibility="visible">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_content"
+        android:ellipsize="end"
+        android:layout_below="@id/widget_text_title"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:textColor="@color/text_body_dark"
+        android:textSize="@dimen/text_content"
+        android:visibility="gone"
+        tools:text="- Create note widget\n- Update layout design\n- Add resizable attributes\n- Add note content"
+        tools:visibility="visible">
+    </TextView>
+
+</RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_widget_dark_matrix.xml
+++ b/Simplenote/src/main/res/layout/note_widget_dark_matrix.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_layout"
+    android:background="@drawable/note_widget_background_dark_black"
+    android:foreground="?android:attr/selectableItemBackgroundBorderless"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:paddingEnd="@dimen/widget_margin"
+    android:paddingStart="@dimen/widget_margin"
+    android:paddingTop="@dimen/widget_margin">
+
+    <TextView
+        android:id="@+id/widget_text"
+        android:ellipsize="end"
+        android:fontFamily="monospace"
+        android:layout_centerInParent="true"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:maxLines="4"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_dark"
+        android:textSize="@dimen/text_widget"
+        android:visibility="visible"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_dark"
+        tools:visibility="gone">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_title"
+        android:ellipsize="end"
+        android:fontFamily="monospace"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_dark"
+        android:textSize="@dimen/text_content_title"
+        android:visibility="gone"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_dark"
+        tools:visibility="visible">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_content"
+        android:ellipsize="end"
+        android:fontFamily="monospace"
+        android:layout_below="@id/widget_text_title"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:textColor="@color/text_body_dark"
+        android:textSize="@dimen/text_content"
+        android:visibility="gone"
+        tools:text="- Create note widget\n- Update layout design\n- Add resizable attributes\n- Add note content"
+        tools:visibility="visible">
+    </TextView>
+
+</RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_widget_dark_mono.xml
+++ b/Simplenote/src/main/res/layout/note_widget_dark_mono.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_layout"
+    android:background="@drawable/note_widget_background_dark"
+    android:foreground="?android:attr/selectableItemBackgroundBorderless"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:paddingEnd="@dimen/widget_margin"
+    android:paddingStart="@dimen/widget_margin"
+    android:paddingTop="@dimen/widget_margin">
+
+    <TextView
+        android:id="@+id/widget_text"
+        android:ellipsize="end"
+        android:fontFamily="monospace"
+        android:layout_centerInParent="true"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:maxLines="4"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_dark"
+        android:textSize="@dimen/text_widget"
+        android:visibility="visible"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_dark"
+        tools:visibility="gone">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_title"
+        android:ellipsize="end"
+        android:fontFamily="monospace"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_dark"
+        android:textSize="@dimen/text_content_title"
+        android:visibility="gone"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_dark"
+        tools:visibility="visible">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_content"
+        android:ellipsize="end"
+        android:fontFamily="monospace"
+        android:layout_below="@id/widget_text_title"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:textColor="@color/text_body_dark"
+        android:textSize="@dimen/text_content"
+        android:visibility="gone"
+        tools:text="- Create note widget\n- Update layout design\n- Add resizable attributes\n- Add note content"
+        tools:visibility="visible">
+    </TextView>
+
+</RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_widget_dark_publication.xml
+++ b/Simplenote/src/main/res/layout/note_widget_dark_publication.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_layout"
+    android:background="@drawable/note_widget_background_dark"
+    android:foreground="?android:attr/selectableItemBackgroundBorderless"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:paddingEnd="@dimen/widget_margin"
+    android:paddingStart="@dimen/widget_margin"
+    android:paddingTop="@dimen/widget_margin">
+
+    <TextView
+        android:id="@+id/widget_text"
+        android:ellipsize="end"
+        android:fontFamily="serif"
+        android:layout_centerInParent="true"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:maxLines="4"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_dark"
+        android:textSize="@dimen/text_widget"
+        android:visibility="visible"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_dark"
+        tools:visibility="gone">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_title"
+        android:ellipsize="end"
+        android:fontFamily="serif"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_dark"
+        android:textSize="@dimen/text_content_title"
+        android:visibility="gone"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_dark"
+        tools:visibility="visible">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_content"
+        android:ellipsize="end"
+        android:fontFamily="serif"
+        android:layout_below="@id/widget_text_title"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:textColor="@color/text_body_dark"
+        android:textSize="@dimen/text_content"
+        android:visibility="gone"
+        tools:text="- Create note widget\n- Update layout design\n- Add resizable attributes\n- Add note content"
+        tools:visibility="visible">
+    </TextView>
+
+</RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_widget_dark_sepia.xml
+++ b/Simplenote/src/main/res/layout/note_widget_dark_sepia.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_layout"
+    android:background="@drawable/note_widget_background_dark_sepia"
+    android:foreground="?android:attr/selectableItemBackgroundBorderless"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:paddingEnd="@dimen/widget_margin"
+    android:paddingStart="@dimen/widget_margin"
+    android:paddingTop="@dimen/widget_margin">
+
+    <TextView
+        android:id="@+id/widget_text"
+        android:ellipsize="end"
+        android:layout_centerInParent="true"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:maxLines="4"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_dark"
+        android:textSize="@dimen/text_widget"
+        android:visibility="visible"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_dark"
+        tools:visibility="gone">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_title"
+        android:ellipsize="end"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_dark"
+        android:textSize="@dimen/text_content_title"
+        android:visibility="gone"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_dark"
+        tools:visibility="visible">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_content"
+        android:ellipsize="end"
+        android:layout_below="@id/widget_text_title"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:textColor="@color/text_body_dark"
+        android:textSize="@dimen/text_content"
+        android:visibility="gone"
+        tools:text="- Create note widget\n- Update layout design\n- Add resizable attributes\n- Add note content"
+        tools:visibility="visible">
+    </TextView>
+
+</RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_widget_light_mono.xml
+++ b/Simplenote/src/main/res/layout/note_widget_light_mono.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_layout"
+    android:background="@drawable/note_widget_background_light"
+    android:foreground="?android:attr/selectableItemBackgroundBorderless"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:paddingEnd="@dimen/widget_margin"
+    android:paddingStart="@dimen/widget_margin"
+    android:paddingTop="@dimen/widget_margin">
+
+    <TextView
+        android:id="@+id/widget_text"
+        android:ellipsize="end"
+        android:fontFamily="monospace"
+        android:layout_centerInParent="true"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:maxLines="4"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_light"
+        android:textSize="@dimen/text_widget"
+        android:visibility="visible"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_light"
+        tools:visibility="gone">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_title"
+        android:ellipsize="end"
+        android:fontFamily="monospace"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_light"
+        android:textSize="@dimen/text_content_title"
+        android:visibility="gone"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_light"
+        tools:visibility="visible">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_content"
+        android:ellipsize="end"
+        android:fontFamily="monospace"
+        android:layout_below="@id/widget_text_title"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:textColor="@color/text_body_light"
+        android:textSize="@dimen/text_content"
+        android:visibility="gone"
+        tools:text="- Create note widget\n- Update layout design\n- Add resizable attributes\n- Add note content"
+        tools:visibility="visible">
+    </TextView>
+
+</RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_widget_light_publication.xml
+++ b/Simplenote/src/main/res/layout/note_widget_light_publication.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_layout"
+    android:background="@drawable/note_widget_background_light"
+    android:foreground="?android:attr/selectableItemBackgroundBorderless"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:paddingEnd="@dimen/widget_margin"
+    android:paddingStart="@dimen/widget_margin"
+    android:paddingTop="@dimen/widget_margin">
+
+    <TextView
+        android:id="@+id/widget_text"
+        android:ellipsize="end"
+        android:fontFamily="serif"
+        android:layout_centerInParent="true"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:maxLines="4"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_light"
+        android:textSize="@dimen/text_widget"
+        android:visibility="visible"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_light"
+        tools:visibility="gone">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_title"
+        android:ellipsize="end"
+        android:fontFamily="serif"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_light"
+        android:textSize="@dimen/text_content_title"
+        android:visibility="gone"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_light"
+        tools:visibility="visible">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_content"
+        android:ellipsize="end"
+        android:fontFamily="serif"
+        android:layout_below="@id/widget_text_title"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:textColor="@color/text_body_light"
+        android:textSize="@dimen/text_content"
+        android:visibility="gone"
+        tools:text="- Create note widget\n- Update layout design\n- Add resizable attributes\n- Add note content"
+        tools:visibility="visible">
+    </TextView>
+
+</RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_widget_light_sepia.xml
+++ b/Simplenote/src/main/res/layout/note_widget_light_sepia.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_layout"
+    android:background="@drawable/note_widget_background_light_sepia"
+    android:foreground="?android:attr/selectableItemBackgroundBorderless"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:paddingEnd="@dimen/widget_margin"
+    android:paddingStart="@dimen/widget_margin"
+    android:paddingTop="@dimen/widget_margin">
+
+    <TextView
+        android:id="@+id/widget_text"
+        android:ellipsize="end"
+        android:layout_centerInParent="true"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:maxLines="4"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_light"
+        android:textSize="@dimen/text_widget"
+        android:visibility="visible"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_light"
+        tools:visibility="gone">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_title"
+        android:ellipsize="end"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text="@string/loading_note"
+        android:textColor="@color/text_title_light"
+        android:textSize="@dimen/text_content_title"
+        android:visibility="gone"
+        tools:text="To-Do List"
+        tools:textColor="@color/text_title_light"
+        tools:visibility="visible">
+    </TextView>
+
+    <TextView
+        android:id="@+id/widget_text_content"
+        android:ellipsize="end"
+        android:layout_below="@id/widget_text_title"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:textColor="@color/text_body_light"
+        android:textSize="@dimen/text_content"
+        android:visibility="gone"
+        tools:text="- Create note widget\n- Update layout design\n- Add resizable attributes\n- Add note content"
+        tools:visibility="visible">
+    </TextView>
+
+</RelativeLayout>


### PR DESCRIPTION
### Fix
This is the first part in a series of pull requests to add styled widgets to the app.  The pull requests are split into parts in an attempt to make the changes smaller.  This part adds the selected app style to the note widget.  See the screenshots below for illustration.

![add_styled_widgets_1](https://user-images.githubusercontent.com/3827611/96634908-657f2780-12d8-11eb-94b2-ad28126c77de.png)

### Test
The first steps add the **_Note (Light)_** and **_Note (Dark)_** widgets to the home screen.  These steps assume the AOSP launcher (i.e. Nexus/Pixel launcher).  The steps to add the widget to the home screen may be slightly different based on the launcher used.  Other steps should be the same regardless of launcher.
1. Long-press home screen.
2. Tap ***Widgets*** option.
3. Scroll to ***Simplenote*** widget.
4. Notice ***Note (Light)*** widget with ***To-Do List*** preview image.
5. Long-press ***Note (Light)*** widget.
6. Place ***Note (Light)*** widget on home screen.
7. Notice ***Select Note*** dialog with note list.
8. Tap any note in list.
9. Notice note title shown in widget with light theme.
10. Long-press home screen.
11. Tap ***Widgets*** option.
12. Scroll to ***Simplenote*** widget.
13. Notice ***Note (Dark)*** widget with ***To-Do List*** preview image.
14. Long-press ***Note (Dark)*** widget.
15. Place ***Note (Dark)*** widget on home screen.
16. Notice ***Select Note*** dialog with note list.
17. Tap any note in list.
18. Notice note title shown in widget with dark theme.

After adding the note widgets to the home screen, follow the steps below for each style by choosing a different style in Step 5 each time.
1. Open navigation drawer.
2. Tap ***Settings*** item in drawer.
3. Tap ***Style*** item under ***Appearance*** section.
4. Notice ***Style*** screen with ***Default***, ***Matrix***, ***Publication***, ***Mono***, ***Sepia***, ***Black***, and ***Classic*** styles.
5. Tap ***Default***, ***Matrix***, ***Publication***, ***Mono***, ***Sepia***, ***Black***, or ***Classic*** style.
6. Notice selected style is shown in ***Styles***.
7. Tap back arrow in navigation bar.
8. Notice selected style is shown in ***Settings***.
9. Tap back arrow in navigation bar.
10. Notice selected style is shown in ***All Notes***.
11. Tap back arrow in navigation bar.
12. Notice selected style is shown in note widgets.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

#### Note
Contact me for an installable build.

### Release
These changes do not require release notes.  `RELEASE-NOTES.txt` will be updated once the styles feature is complete.