### PR TITLE
Update Bucket Lifecycle

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1535,8 +1535,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         if (changeType == Bucket.ChangeType.MODIFY) {
             if (getNote() != null && getNote().getSimperiumKey().equals(key)) {
                 try {
-                    mNotesBucket = noteBucket;
-                    final Note updatedNote = mNotesBucket.get(key);
+                    final Note updatedNote = noteBucket.get(key);
+
                     if (getActivity() != null) {
                         getActivity().runOnUiThread(new Runnable() {
                             @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -553,8 +553,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         super.onResume();
         checkWebView();
         mIsPaused = false;
-        mNotesBucket.start();
-        AppLog.add(Type.SYNC, "Started note bucket (NoteEditorFragment)");
         mNotesBucket.addListener(this);
         mTagInput.setOnTagAddedListener(this);
 
@@ -625,8 +623,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     public void onDestroy() {
         super.onDestroy();
         mNotesBucket.removeListener(this);
-        mNotesBucket.stop();
-        AppLog.add(Type.SYNC, "Stopped note bucket (NoteEditorFragment)");
         AppLog.add(Type.SCREEN, "Destroyed (NoteEditorFragment)");
     }
 
@@ -1563,8 +1559,6 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     public void onSaveObject(Bucket<Note> noteBucket, Note note) {
         if (mIsPaused) {
             mNotesBucket.removeListener(this);
-            mNotesBucket.stop();
-            AppLog.add(Type.SYNC, "Stopped note bucket (NoteEditorFragment)");
         }
 
         AppLog.add(

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -554,6 +554,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         checkWebView();
         mIsPaused = false;
         mNotesBucket.addListener(this);
+        AppLog.add(Type.SYNC, "Added note bucket listener (NoteEditorFragment)");
         mTagInput.setOnTagAddedListener(this);
 
         if (mContentEditText != null) {
@@ -623,6 +624,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     public void onDestroy() {
         super.onDestroy();
         mNotesBucket.removeListener(this);
+        AppLog.add(Type.SYNC, "Removed note bucket listener (NoteEditorFragment)");
         AppLog.add(Type.SCREEN, "Destroyed (NoteEditorFragment)");
     }
 
@@ -1559,6 +1561,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     public void onSaveObject(Bucket<Note> noteBucket, Note note) {
         if (mIsPaused) {
             mNotesBucket.removeListener(this);
+            AppLog.add(Type.SYNC, "Removed note bucket listener (NoteEditorFragment)");
         }
 
         AppLog.add(

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -600,7 +600,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mBucketPreferences.removeOnDeleteObjectListener(this);
         mBucketPreferences.removeOnNetworkChangeListener(this);
         mBucketPreferences.removeOnSaveObjectListener(this);
-        mBucketPreferences.stop();
         AppLog.add(Type.SCREEN, "Paused (NoteListFragment)");
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -592,6 +592,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mBucketPreferences.addOnDeleteObjectListener(this);
         mBucketPreferences.addOnNetworkChangeListener(this);
         mBucketPreferences.addOnSaveObjectListener(this);
+        AppLog.add(Type.SYNC, "Added preference bucket listener (NoteListFragment)");
     }
 
     @Override
@@ -600,6 +601,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         mBucketPreferences.removeOnDeleteObjectListener(this);
         mBucketPreferences.removeOnNetworkChangeListener(this);
         mBucketPreferences.removeOnSaveObjectListener(this);
+        AppLog.add(Type.SYNC, "Removed preference bucket listener (NoteListFragment)");
         AppLog.add(Type.SCREEN, "Paused (NoteListFragment)");
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -201,6 +201,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
     public void onDestroy() {
         super.onDestroy();
         mNotesBucket.removeListener(this);
+        AppLog.add(Type.SYNC, "Removed note bucket listener (NoteMarkdownFragment)");
         AppLog.add(Type.SCREEN, "Destroyed (NoteMarkdownFragment)");
     }
 
@@ -209,6 +210,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
         super.onResume();
         checkWebView();
         mNotesBucket.addListener(this);
+        AppLog.add(Type.SYNC, "Added note bucket listener (NoteMarkdownFragment)");
         AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(requireContext()));
         AppLog.add(Type.SCREEN, "Resumed (NoteMarkdownFragment)");
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -201,8 +201,6 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
     public void onDestroy() {
         super.onDestroy();
         mNotesBucket.removeListener(this);
-        mNotesBucket.stop();
-        AppLog.add(Type.SYNC, "Stopped note bucket (NoteMarkdownFragment)");
         AppLog.add(Type.SCREEN, "Destroyed (NoteMarkdownFragment)");
     }
 
@@ -210,8 +208,6 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
     public void onResume() {
         super.onResume();
         checkWebView();
-        mNotesBucket.start();
-        AppLog.add(Type.SYNC, "Started note bucket (NoteMarkdownFragment)");
         mNotesBucket.addListener(this);
         AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(requireContext()));
         AppLog.add(Type.SCREEN, "Resumed (NoteMarkdownFragment)");

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -296,11 +296,6 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
         disableScreenshotsIfLocked(this);
 
-        mNotesBucket.start();
-        AppLog.add(Type.SYNC, "Started note bucket (NotesActivity)");
-        mTagsBucket.start();
-        AppLog.add(Type.SYNC, "Started tag bucket (NotesActivity)");
-
         mNotesBucket.addOnNetworkChangeListener(this);
         mNotesBucket.addOnSaveObjectListener(this);
         mNotesBucket.addOnDeleteObjectListener(this);
@@ -342,14 +337,10 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
     protected void onPause() {
         super.onPause();  // Always call the superclass method first
         mTagsBucket.removeListener(mTagsMenuUpdater);
-        mTagsBucket.stop();
-        AppLog.add(Type.SYNC, "Stopped tag bucket (NotesActivity)");
 
         mNotesBucket.removeOnNetworkChangeListener(this);
         mNotesBucket.removeOnSaveObjectListener(this);
         mNotesBucket.removeOnDeleteObjectListener(this);
-        mNotesBucket.stop();
-        AppLog.add(Type.SYNC, "Stopped note bucket (NotesActivity)");
         AppLog.add(Type.SCREEN, "Paused (NotesActivity)");
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -299,7 +299,9 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         mNotesBucket.addOnNetworkChangeListener(this);
         mNotesBucket.addOnSaveObjectListener(this);
         mNotesBucket.addOnDeleteObjectListener(this);
+        AppLog.add(Type.SYNC, "Added note bucket listener (NotesActivity)");
         mTagsBucket.addListener(mTagsMenuUpdater);
+        AppLog.add(Type.SYNC, "Added tag bucket listener (NotesActivity)");
 
         updateNavigationDrawerItems();
 
@@ -337,10 +339,12 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
     protected void onPause() {
         super.onPause();  // Always call the superclass method first
         mTagsBucket.removeListener(mTagsMenuUpdater);
+        AppLog.add(Type.SYNC, "Removed tag bucket listener (NotesActivity)");
 
         mNotesBucket.removeOnNetworkChangeListener(this);
         mNotesBucket.removeOnSaveObjectListener(this);
         mNotesBucket.removeOnDeleteObjectListener(this);
+        AppLog.add(Type.SYNC, "Removed note bucket listener (NotesActivity)");
         AppLog.add(Type.SCREEN, "Paused (NotesActivity)");
     }
 
@@ -1614,6 +1618,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         mNotesBucket.removeOnNetworkChangeListener(this);
         mNotesBucket.removeOnSaveObjectListener(this);
         mNotesBucket.removeOnDeleteObjectListener(this);
+        AppLog.add(Type.SYNC, "Removed note bucket listener (NotesActivity)");
     }
 
     // Returns the appropriate view to show the undo bar within

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -79,7 +79,6 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
         simperium.setUserStatusChangeListener(this);
         simperium.setOnUserCreatedListener(this);
         mPreferencesBucket = currentApp.getPreferencesBucket();
-        mPreferencesBucket.start();
 
         authenticatePreference.setSummary(currentApp.getSimperium().getUser().getEmail());
         if (simperium.needsAuthorization()) {
@@ -262,12 +261,6 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
                 exportData(resultData.getData(), true);
                 break;
         }
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        mPreferencesBucket.stop();
     }
 
     private boolean hasUnsyncedNotes() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -290,6 +290,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
         application.getTagsBucket().stop();
         AppLog.add(Type.SYNC, "Stopped tag bucket (PreferencesFragment)");
         application.getPreferencesBucket().stop();
+        AppLog.add(Type.SYNC, "Stopped preference bucket (PreferencesFragment)");
 
         AnalyticsTracker.track(
                 AnalyticsTracker.Stat.USER_SIGNED_OUT,

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -8,6 +8,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatDelegate;
 
 import com.automattic.simplenote.analytics.AnalyticsTracker;
@@ -140,8 +141,7 @@ public class Simplenote extends Application {
         return mPreferencesBucket;
     }
 
-    private class ApplicationLifecycleMonitor implements Application.ActivityLifecycleCallbacks,
-            ComponentCallbacks2 {
+    private class ApplicationLifecycleMonitor implements Application.ActivityLifecycleCallbacks, ComponentCallbacks2 {
         private boolean mIsInBackground = true;
 
         // ComponentCallbacks
@@ -189,7 +189,7 @@ public class Simplenote extends Application {
         }
 
         @Override
-        public void onConfigurationChanged(Configuration newConfig) {
+        public void onConfigurationChanged(@NonNull Configuration newConfig) {
             AppLog.add(Type.LAYOUT, DisplayUtils.getDisplaySizeAndOrientation(Simplenote.this));
         }
 
@@ -197,9 +197,9 @@ public class Simplenote extends Application {
         public void onLowMemory() {
         }
 
-        // ActivityLifeCycle callbacks
+        // ActivityLifecycleCallbacks
         @Override
-        public void onActivityResumed(Activity activity) {
+        public void onActivityResumed(@NonNull Activity activity) {
             if (mIsInBackground) {
                 AnalyticsTracker.track(
                         AnalyticsTracker.Stat.APPLICATION_OPENED,
@@ -222,27 +222,27 @@ public class Simplenote extends Application {
         }
 
         @Override
-        public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+        public void onActivityCreated(@NonNull Activity activity, Bundle savedInstanceState) {
         }
 
         @Override
-        public void onActivityStarted(Activity activity) {
+        public void onActivityStarted(@NonNull Activity activity) {
         }
 
         @Override
-        public void onActivityPaused(Activity activity) {
+        public void onActivityPaused(@NonNull Activity activity) {
         }
 
         @Override
-        public void onActivityStopped(Activity activity) {
+        public void onActivityStopped(@NonNull Activity activity) {
         }
 
         @Override
-        public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+        public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {
         }
 
         @Override
-        public void onActivityDestroyed(Activity activity) {
+        public void onActivityDestroyed(@NonNull Activity activity) {
         }
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -170,6 +170,7 @@ public class Simplenote extends Application {
 
                         if (mPreferencesBucket != null) {
                             mPreferencesBucket.stop();
+                            AppLog.add(Type.SYNC, "Stopped preference bucket (Simplenote)");
                         }
                     }
                 }, TEN_SECONDS_MILLIS);

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -69,7 +69,6 @@ public class Simplenote extends Application {
             tagSchema.addIndex(new NoteCountIndexer(mNotesBucket));
             mTagsBucket = mSimperium.bucket(tagSchema);
             mPreferencesBucket = mSimperium.bucket(new Preferences.Schema());
-            mPreferencesBucket.start();
             // Every time a note changes or is deleted we need to reindex the tag counts
             mNotesBucket.addListener(new NoteTagger(mTagsBucket));
         } catch (BucketNameInvalid e) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -209,6 +209,15 @@ public class Simplenote extends Application {
                 mIsInBackground = false;
                 AppLog.add(Type.ACTION, "App opened");
             }
+
+            String activitySimpleName = activity.getClass().getSimpleName();
+
+            mPreferencesBucket.start();
+            AppLog.add(Type.SYNC, "Started preference bucket (" + activitySimpleName + ")");
+            mNotesBucket.start();
+            AppLog.add(Type.SYNC, "Started note bucket (" + activitySimpleName + ")");
+            mTagsBucket.start();
+            AppLog.add(Type.SYNC, "Started tag bucket (" + activitySimpleName + ")");
         }
 
         @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -31,6 +31,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
+import com.automattic.simplenote.utils.AppLog;
 import com.automattic.simplenote.utils.BaseCursorAdapter;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
@@ -177,6 +178,7 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
         mTagsBucket.addOnNetworkChangeListener(this);
         mTagsBucket.addOnSaveObjectListener(this);
         mTagsBucket.addOnDeleteObjectListener(this);
+        AppLog.add(AppLog.Type.SYNC, "Added tag bucket listener (TagsActivity)");
     }
 
     @Override
@@ -186,6 +188,7 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
         mTagsBucket.removeOnNetworkChangeListener(this);
         mTagsBucket.removeOnSaveObjectListener(this);
         mTagsBucket.removeOnDeleteObjectListener(this);
+        AppLog.add(AppLog.Type.SYNC, "Removed tag bucket listener (TagsActivity)");
     }
 
     public void checkEmptyList() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -174,9 +174,6 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
         super.onResume();
         disableScreenshotsIfLocked(this);
 
-        mNotesBucket.start();
-        mTagsBucket.start();
-
         mTagsBucket.addOnNetworkChangeListener(this);
         mTagsBucket.addOnSaveObjectListener(this);
         mTagsBucket.addOnDeleteObjectListener(this);
@@ -189,9 +186,6 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
         mTagsBucket.removeOnNetworkChangeListener(this);
         mTagsBucket.removeOnSaveObjectListener(this);
         mTagsBucket.removeOnDeleteObjectListener(this);
-
-        mNotesBucket.stop();
-        mTagsBucket.stop();
     }
 
     public void checkEmptyList() {


### PR DESCRIPTION
### Fix
Update the bucket lifecycle by moving the `start()` and `stop()` statements from `Activity` and `Fragment` classes to the `Application` class.  These updates are meant to avoid sync issues caused by starting and stopping the buckets on screen changes.  By starting the buckets in the `onActivityResumed` method, the buckets are started when any screen is shown whether the app is started from the launcher, widget, or elsewhere.  Starting the buckets when they are already started does not affect syncing as shown in the [`Channel.start` method within Simperium](https://github.com/Simperium/simperium-android/blob/098bece0f6fe0f41bd13359b08f28482faf5a76d/Simperium/src/main/java/com/simperium/client/Channel.java#L610-L613).

These changes also remove the `mNotesBucket = noteBucket;` statement from the `onNetworkChange` method in the `NoteEditorFragment` class.  That statement was added in https://github.com/Automattic/simplenote-android/pull/1060 to fix tags being reverted when added/removed remotely.  Since the `mNotesBucket` variable was being used to retrieve the `Note` object of the updated note, assigning the `mNotesBucket` variable to the `noteBucket` parameter was required.  Removing that assigning statement and using the `noteBucket` parameter to retrieve the `Note` object maintains the fix from https://github.com/Automattic/simplenote-android/pull/1060 in my testing.  Also, it removes the only assignment of a `Bucket<Note>` variable that is not from the `Application` class.  Now, all instances of `Bucket<Note>` are from the `Simplenote` class.

### Test
Since these changes have no user-facing aspect, smoke testing is all that is required.  The changes affect the bucket starting and stopping so it's best to test creating and editing notes and tags to ensure syncing is working as expected across devices. Using multiple emulators or platforms side-by-side is a good way to see if syncing is working.

Since these changes also modify the changes from https://github.com/Automattic/simplenote-android/pull/1060, I'm including testing steps for that fix to make sure there isn't a regression.
1. ***Android***: Tap any note in list.
2. ***Other***: Select note from Step 1 in list.
3. ***Android***: Add `android` tag to note.
4. ***Other***: Notice `android` tag in note.
5. ***Other***: Add `other` tag to note.
6. ***Android***: Notice `other` tag in note.
7. ***Android***: Remove `other` tag from note.
8. ***Other***: Notice `other` tag removed from note.
9. ***Other***: Remove `android` tag from note.
10. ***Android***: Notice `android` tag removed from note.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

#### Note
Contact me for an installable build.

### Release
These changes do not require release notes.