### PR TITLE
Update Tag Canonical

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -431,6 +431,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         mContentEditText.setDropDownBackgroundResource(R.drawable.bg_list_popup);
         mContentEditText.setAdapter(mLinkAutocompleteAdapter);
         mTagInput = mRootView.findViewById(R.id.tag_input);
+        mTagInput.setBucketTag(((Simplenote) requireActivity().getApplication()).getTagsBucket());
         mTagInput.setDropDownBackgroundResource(R.drawable.bg_list_popup);
         mTagInput.setTokenizer(new SpaceTokenizer());
         mTagInput.setAdapter(mTagAutocompleteAdapter);

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagUtils.java
@@ -52,6 +52,27 @@ public class TagUtils {
     }
 
     /**
+     * Get the canonical representation of a tag from the hashed value of the lexical variation.
+     *
+     * @param bucket    {@link Bucket<Tag>} in which to get tag.
+     * @param lexical   {@link String} lexical variation of tag.
+     *
+     * @return          {@link String} canonical of tag if exists; lexical variation otherwise.
+     */
+    public static String getCanonicalFromLexical(Bucket<Tag> bucket, String lexical) {
+        String hashed = hashTag(lexical);
+
+        try {
+            Tag tag = bucket.getObject(hashed);
+            Log.d("getCanonicalFromLexical", "Tag " + "\"" + hashed + "\"" + " does exist");
+            return tag.getName();
+        } catch (BucketObjectMissingException e) {
+            Log.d("getCanonicalFromLexical", "Tag " + "\"" + hashed + "\"" + " does not exist");
+            return lexical;
+        }
+    }
+
+    /**
      * Hash the tag @param name with normalizing, lowercasing, and encoding.
      *
      * @param name      {@link String} to hash as the tag kay.

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
@@ -17,12 +17,15 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.AppCompatMultiAutoCompleteTextView;
 
 import com.automattic.simplenote.R;
+import com.automattic.simplenote.models.Tag;
+import com.simperium.client.Bucket;
 
 import java.util.Objects;
 
 import static com.automattic.simplenote.utils.SearchTokenizer.SPACE;
 
 public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTextView implements OnItemClickListener {
+    private Bucket<Tag> mBucketTag;
     private OnTagAddedListener mTagAddedListener;
     private TextWatcher mTextWatcher = new TextWatcher() {
         @Override
@@ -86,7 +89,9 @@ public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTex
     }
 
     public void notifyTagsChanged() {
-        notifyTagsChanged(getText().toString());
+        String lexical = getText().toString().trim();
+        String canonical = TagUtils.getCanonicalFromLexical(mBucketTag, lexical);
+        notifyTagsChanged(canonical);
     }
 
     public void notifyTagsChanged(String tag) {
@@ -105,6 +110,10 @@ public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTex
             addTextChangedListener(mTextWatcher);
             showDialogErrorLength();
         }
+    }
+
+    public void setBucketTag(Bucket<Tag> bucket) {
+        mBucketTag = bucket;
     }
 
     public void setOnTagAddedListener(OnTagAddedListener listener) {


### PR DESCRIPTION
### Fix
Update adding a tag to a note to use the canonical representation if the tag already exists.  If the canonical tag doesn't exist, a new tag is created.  Canonical refers to the hashed value of a tag added in https://github.com/Automattic/simplenote-android/pull/1092.  Lexical refers to variations of a tag that resolve to the same hashed value (e.g. tag, Tag, TAG, etc.).  When a lexical variation of an existing tag is entered into the **_Add tag..._** field at the bottom of a note, the tag is autocorrected to the canonical representation.

### Test
1. Tap any note in list.
2. Enter any value in **_Add tag..._** field not matching an existing tag.
3. Tap **_Space_** key to submit tag.
4. Notice tag is added to note as entered.
5. Enter any variation of value from Step 4 with different lowercase or uppercase characters.
6. Tap **_Space_** key to submit tag.
7. Notice tag is not added to note as entered.
8. Tap tag chip from Step 4.
9. Tap _**x**_ in tag chip.
10. Notice tag is removed from note.
11. Enter any variation of value from Step 2 with different lowercase or uppercase characters.
12. Tap **_Space_** key to submit tag.
13. Notice tag from Step 4 is added to note

### Review
Only one developer is required to review these changes, but anyone can perform the review.  @dmsnell, feel free to verify these changes are using the correct terminology and/or code, but don't feel obligated.

### Release
These changes do not require release notes.