### PR TITLE
Issue/1197 update dialog background

### DIFF
--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -73,7 +73,7 @@
     </style>
 
     <style name="Dialog.Sepia" parent="Dialog">
-        <item name="android:colorBackground">@color/background_dark_sepia_8</item>
+        <item name="android:colorBackground">@color/background_dark_sepia_24</item>
     </style>
 
     <style name="DrawerArrowStyle" parent="Widget.AppCompat.DrawerArrowToggle">

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -60,6 +60,14 @@
         <item name="tint">@color/item_default_dark</item>
     </style>
 
+    <style name="Dialog" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">
+        <item name="android:colorBackground">@color/background_dark_24</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Dialog.Button</item>
+        <item name="buttonBarNeutralButtonStyle">@style/Dialog.Button</item>
+        <item name="buttonBarPositiveButtonStyle">@style/Dialog.Button</item>
+        <item name="colorPrimary">?attr/colorAccent</item>
+    </style>
+
     <style name="Dialog.Black" parent="Dialog">
         <item name="android:colorBackground">@color/background_dark_black_8</item>
     </style>

--- a/Simplenote/src/main/res/values-night/styles.xml
+++ b/Simplenote/src/main/res/values-night/styles.xml
@@ -69,7 +69,7 @@
     </style>
 
     <style name="Dialog.Black" parent="Dialog">
-        <item name="android:colorBackground">@color/background_dark_black_8</item>
+        <item name="android:colorBackground">@color/background_dark_black_24</item>
     </style>
 
     <style name="Dialog.Sepia" parent="Dialog">


### PR DESCRIPTION
### Fix
Update the dialog background color to use the 24dp elevation value to close #1197.  Now, all dialog backgrounds are the same color for all styles except **_Sepia_**.  See the screenshots below for illustration.

![1197_update_dialog_background](https://user-images.githubusercontent.com/3827611/98857757-bb994380-241c-11eb-80ae-eb1eacded602.png)

See the table below for references to the dialog background color for each style.

Style|Resource|Color
-|-|-
Default|`background_dark_24`|`#3d3f41`
Classic|`background_dark_24`|`#3d3f41`
Black|`background_dark_black_24`|`#3d3f41`
Matrix|`background_dark_black_24`|`#3d3f41`
Mono|`background_dark_24`|`#3d3f41`
Publication|`background_dark_24`|`#3d3f41`
Sepia|`background_dark_sepia_24`|`#42403e`

### Test
Follow the steps below for each style by choosing a different style in Step 5 each time.
1. Open navigation drawer.
2. Tap ***Settings*** item in drawer.
3. Tap ***Style*** item under ***Appearance*** section.
4. Notice ***Style*** screen with ***Default***, ***Matrix***, ***Publication***, ***Mono***, ***Sepia***, ***Black***, and ***Classic*** styles.
5. Tap ***Default***, ***Matrix***, ***Publication***, ***Mono***, ***Sepia***, ***Black***, or ***Classic*** style.
6. Tap back arrow in app bar.
7. Tap ***Theme*** setting under ***Appearance*** section on ***Settings*** screen.
8. Notice dialog background color as shown in screenshots above.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

#### Note
Contact me for an installable build.

### Release
These changes do not require release notes.  `RELEASE-NOTES.txt` will be updated once the styles feature is complete.