### PR TITLE
Issue/1199 update untagged empty

### DIFF
--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -237,7 +237,7 @@
     <string name="empty_notes_search_button_default">Create a new note</string>
     <string name="empty_notes_tag">No notes tagged \"%1$s\"</string>
     <string name="empty_notes_trash">Your trash is empty</string>
-    <string name="empty_notes_untagged">Create an untagged note</string>
+    <string name="empty_notes_untagged">No untagged notes</string>
     <string name="empty_notes_widget">No notes</string>
     <string name="empty_tags">No tags</string>
     <string name="empty_tags_search">No tags found</string>


### PR DESCRIPTION
### Fix
Update empty view the message for untagged notes from "Create an untagged note" to "No untagged notes" to close #1199.  See the screenshots below for illustration.

![1199_update_untagged_empty](https://user-images.githubusercontent.com/3827611/99399016-4e653280-28a2-11eb-8539-f619c605f5bf.png)

### Test
In order for **_Untagged Notes_** item to be shown in the navigation drawer and the empty view shown when selected, the account must have at least one note and all notes must have at least one tag.
1. Open navigation drawer.
2. Tap ***Untagged Notes*** item in drawer.
3. Notice empty view is shown.
4. Notice "No untagged notes" message is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

#### Note
Contact me for an installable build.

### Release
These changes do not require release notes.