### PR TITLE
Add Analytics Tracking

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java
@@ -16,6 +16,7 @@ import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Reference;
 import com.automattic.simplenote.utils.DateTimeUtils;
@@ -132,6 +133,11 @@ public class InfoBottomSheetDialog extends BottomSheetDialogBase {
                 new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
+                        AnalyticsTracker.track(
+                            AnalyticsTracker.Stat.INTERNOTE_LINK_TAPPED,
+                            AnalyticsTracker.CATEGORY_LINK,
+                            "internote_link_tapped_info"
+                        );
                         SimplenoteLinkify.openNote(mFragment.requireActivity(), reference.getKey());
                     }
                 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -222,6 +222,11 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 case R.id.menu_view_link:
                     if (mLinkText != null) {
                         if (mLinkText.startsWith(SIMPLENOTE_LINK_PREFIX)) {
+                            AnalyticsTracker.track(
+                                AnalyticsTracker.Stat.INTERNOTE_LINK_TAPPED,
+                                AnalyticsTracker.CATEGORY_LINK,
+                                "internote_link_tapped_editor"
+                            );
                             SimplenoteLinkify.openNote(requireActivity(), mLinkText.replace(SIMPLENOTE_LINK_PREFIX, ""));
                         } else {
                             try {
@@ -455,6 +460,11 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                             String url = request.getUrl().toString();
 
                             if (url.startsWith(SimplenoteLinkify.SIMPLENOTE_LINK_PREFIX)){
+                                AnalyticsTracker.track(
+                                    AnalyticsTracker.Stat.INTERNOTE_LINK_TAPPED,
+                                    AnalyticsTracker.CATEGORY_LINK,
+                                    "internote_link_tapped_editor"
+                                );
                                 SimplenoteLinkify.openNote(requireActivity(), url.replace(SIMPLENOTE_LINK_PREFIX, ""));
                             } else {
                                 BrowserUtils.launchBrowserOrShowError(requireContext(), url);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -463,7 +463,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                                 AnalyticsTracker.track(
                                     AnalyticsTracker.Stat.INTERNOTE_LINK_TAPPED,
                                     AnalyticsTracker.CATEGORY_LINK,
-                                    "internote_link_tapped_editor"
+                                    "internote_link_tapped_markdown"
                                 );
                                 SimplenoteLinkify.openNote(requireActivity(), url.replace(SIMPLENOTE_LINK_PREFIX, ""));
                             } else {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -665,6 +665,11 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
                 return true;
             case R.id.menu_copy_internal:
+                AnalyticsTracker.track(
+                    AnalyticsTracker.Stat.INTERNOTE_LINK_COPIED,
+                    AnalyticsTracker.CATEGORY_LINK,
+                    "internote_link_copied_editor"
+                );
                 if (BrowserUtils.copyToClipboard(requireContext(), SimplenoteLinkify.getNoteLinkWithTitle(mNote.getTitle(), mNote.getSimperiumKey()))) {
                     Snackbar.make(mRootView, R.string.link_copied, Snackbar.LENGTH_SHORT).show();
                 } else {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -219,6 +219,11 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         if (getListView().getCheckedItemIds().length > 0) {
             switch (item.getItemId()) {
                 case R.id.menu_link:
+                    AnalyticsTracker.track(
+                        AnalyticsTracker.Stat.INTERNOTE_LINK_COPIED,
+                        AnalyticsTracker.CATEGORY_LINK,
+                        "internote_link_copied_list"
+                    );
                     BrowserUtils.copyToClipboard(requireContext(), getSelectedNoteLinks());
                     mode.finish();
                     break;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -259,11 +259,6 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
         // When a WebView is installed and mMarkdown is null, a WebView was not installed when the
         // fragment was created.  So, open the note again to show the markdown preview.
         if (BrowserUtils.isWebViewInstalled(requireContext()) && mMarkdown == null) {
-            AnalyticsTracker.track(
-                AnalyticsTracker.Stat.INTERNOTE_LINK_TAPPED,
-                AnalyticsTracker.CATEGORY_LINK,
-                "internote_link_tapped_markdown"
-            );
             SimplenoteLinkify.openNote(requireActivity(), mNote.getSimperiumKey());
         }
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -105,6 +105,11 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
                         String url = request.getUrl().toString();
 
                         if (url.startsWith(SimplenoteLinkify.SIMPLENOTE_LINK_PREFIX)){
+                            AnalyticsTracker.track(
+                                AnalyticsTracker.Stat.INTERNOTE_LINK_TAPPED,
+                                AnalyticsTracker.CATEGORY_LINK,
+                                "internote_link_tapped_markdown"
+                            );
                             SimplenoteLinkify.openNote(requireActivity(), url.replace(SIMPLENOTE_LINK_PREFIX, ""));
                         } else {
                             BrowserUtils.launchBrowserOrShowError(requireContext(), url);
@@ -254,6 +259,11 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
         // When a WebView is installed and mMarkdown is null, a WebView was not installed when the
         // fragment was created.  So, open the note again to show the markdown preview.
         if (BrowserUtils.isWebViewInstalled(requireContext()) && mMarkdown == null) {
+            AnalyticsTracker.track(
+                AnalyticsTracker.Stat.INTERNOTE_LINK_TAPPED,
+                AnalyticsTracker.CATEGORY_LINK,
+                "internote_link_tapped_markdown"
+            );
             SimplenoteLinkify.openNote(requireActivity(), mNote.getSimperiumKey());
         }
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -17,6 +17,7 @@ import androidx.core.view.MenuCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
+import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.utils.AppLog;
 import com.automattic.simplenote.utils.AppLog.Type;
@@ -150,6 +151,12 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
                 deleteNote();
                 return true;
             case R.id.menu_copy_internal:
+                AnalyticsTracker.track(
+                    AnalyticsTracker.Stat.INTERNOTE_LINK_COPIED,
+                    AnalyticsTracker.CATEGORY_LINK,
+                    "internote_link_copied_markdown"
+                );
+
                 if (!isAdded()) {
                     return false;
                 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
@@ -9,6 +9,7 @@ import java.util.Map;
 public final class AnalyticsTracker {
     private static final List<Tracker> TRACKERS = new ArrayList<>();
     public static String CATEGORY_NOTE = "note";
+    public static String CATEGORY_LINK = "link";
     public static String CATEGORY_SEARCH = "search";
     public static String CATEGORY_TAG = "tag";
     public static String CATEGORY_USER = "user";
@@ -156,7 +157,10 @@ public final class AnalyticsTracker {
         NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED,
         NOTE_WIDGET_NOTE_TAPPED,
         NOTE_WIDGET_SIGN_IN_TAPPED,
-        RECENT_SEARCH_TAPPED
+        RECENT_SEARCH_TAPPED,
+        INTERNOTE_LINK_COPIED,
+        INTERNOTE_LINK_CREATED,
+        INTERNOTE_LINK_TAPPED
     }
 
     public interface Tracker {

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -18,6 +18,7 @@ import androidx.annotation.DrawableRes;
 import androidx.appcompat.widget.AppCompatMultiAutoCompleteTextView;
 
 import com.automattic.simplenote.R;
+import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.utils.ChecklistUtils;
 import com.automattic.simplenote.utils.DisplayUtils;
@@ -108,6 +109,11 @@ public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView imple
 
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        AnalyticsTracker.track(
+            AnalyticsTracker.Stat.INTERNOTE_LINK_CREATED,
+            AnalyticsTracker.CATEGORY_LINK,
+            "internote_link_created"
+        );
         @SuppressWarnings("unchecked")
         Bucket.ObjectCursor<Note> cursor = (Bucket.ObjectCursor<Note>) parent.getAdapter().getItem(position);
         String key = cursor.getString(cursor.getColumnIndex(Note.KEY_PROPERTY)).replace("note", "");


### PR DESCRIPTION
### Fix
Add analytics events to track internote link usage.  The events tracked are:
- Internote link copied with app bar actions
- Internote link tapped in editor and preview
- Internote link created with autocomplete

### Test
Adding a breakpoint in the code can verify the event is triggered at the right time.  Each test scenario below has a link to the line of code to add a breakpoint.
#### [Copied (List)](https://github.com/Automattic/simplenote-android/blob/d5707495e57f0bbdd9e8dbc87a8bbedd2b1b5a98/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java#L222)
1. Long-press any note in list.
2. Tap ***Copy Internal Link*** action in app bar.
3. Notice breakpoint is hit.

#### [Copied (Editor)](https://github.com/Automattic/simplenote-android/blob/d5707495e57f0bbdd9e8dbc87a8bbedd2b1b5a98/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java#L678)
1. Tap any note in list.
2. Tap overflow/ellipsis action in app bar.
3. Tap ***Copy Internal Link*** item in menu.
4. Notice breakpoint is hit.

#### [Copied (Markdown)](https://github.com/Automattic/simplenote-android/blob/d5707495e57f0bbdd9e8dbc87a8bbedd2b1b5a98/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java#L159)
1. Tap any note in list with markdown enabled.
2. Tap ***Preview*** tab.
3. Tap overflow/ellipsis action in app bar.
4. Tap ***Copy Internal Link*** item in menu.
5. Notice breakpoint is hit.

#### [Created](https://github.com/Automattic/simplenote-android/blob/d5707495e57f0bbdd9e8dbc87a8bbedd2b1b5a98/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java#L112)
1. Tap any note in list.
2. Enter `[` followed by a character matching the title of at least one existing note.
3. Notice autocomplete popup menu is shown.
4. Tap any item in autocomplete popup menu.
5. Notice breakpiont is hit.

#### [Tapped (Information)](https://github.com/Automattic/simplenote-android/blob/d5707495e57f0bbdd9e8dbc87a8bbedd2b1b5a98/Simplenote/src/main/java/com/automattic/simplenote/InfoBottomSheetDialog.java#L136)
1. Tap any note in list which is referenced with an internote link in another note.
2. Tap ***Information*** action in app bar.
3. Notice ***Referenced In*** section at bottom of sheet.
4. Tap any item in ***Referenced In*** section.
5. Notice breakpoint is hit.

#### [Tapped (Editor - Action)](https://github.com/Automattic/simplenote-android/blob/d5707495e57f0bbdd9e8dbc87a8bbedd2b1b5a98/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java#L225)
1. Tap any note in list with internote link in content.
2. Tap `simplenote://note/d34db3ef` part of internote link.
3. Notice ***Link*** action menu is shown.
4. Tap ***Open Note*** action in app bar.
5. Notice breakpoint is hit.

#### [Tapped (Markdown - Phone)](https://github.com/Automattic/simplenote-android/blob/d5707495e57f0bbdd9e8dbc87a8bbedd2b1b5a98/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java#L108)
1. Tap any note in list with markdown enabled.
2. Tap ***Preview*** tab.
3. Tap internote link in content.
4. Notice breakpoint is hit.

#### [Tapped (Markdown - Tablet)](https://github.com/Automattic/simplenote-android/blob/d5707495e57f0bbdd9e8dbc87a8bbedd2b1b5a98/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java#L463)
1. Tap any note in list with markdown enabled.
2. Tap ***Show Preview*** action in app bar.
3. Tap internote link in content.
4. Notice breakpoint is hit.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.