### PR TITLE
Rename the installDeps gradle task to configureApply

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,9 +98,9 @@ task applyCredentials(type:Exec, dependsOn:checkBundle) {
     }
 }
 
-tasks.register("installDeps") {
+tasks.register("configureApply") {
     group = 'Onboarding'
-    description = 'Install dependencies for production builds'
+    description = 'Install dependencies for debug and production builds'
     dependsOn applyCredentials
     doLast {
         println("Done")


### PR DESCRIPTION
### Fix
This PR renames the installDeps gradle task to configureApply to make it match the setup in our other repos.

### Test
Run `./gradlew configureApply` and verify it succeeds.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

These changes do not require release notes.
