### PR TITLE
Crash Recent Searches

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
@@ -37,23 +37,29 @@ public class Preferences extends BucketObject {
     }
 
     public ArrayList<String> getRecentSearches() {
-        JSONArray recents = (JSONArray) getProperty(RECENT_SEARCHES_KEY);
+        Object object = getProperty(RECENT_SEARCHES_KEY);
 
-        if (recents == null) {
-            recents = new JSONArray();
-        }
+        if (object instanceof JSONArray) {
+            JSONArray recents = (JSONArray) object;
 
-        ArrayList<String> recentsList = new ArrayList<>(recents.length());
-
-        for (int i = 0; i < recents.length(); i++) {
-            String recent = recents.optString(i);
-
-            if (!recent.isEmpty()) {
-                recentsList.add(recent);
+            if (recents == null) {
+                recents = new JSONArray();
             }
-        }
 
-        return recentsList;
+            ArrayList<String> recentsList = new ArrayList<>(recents.length());
+
+            for (int i = 0; i < recents.length(); i++) {
+                String recent = recents.optString(i);
+
+                if (!recent.isEmpty()) {
+                    recentsList.add(recent);
+                }
+            }
+
+            return recentsList;
+        } else {
+            return new ArrayList<>();
+        }
     }
 
     public void setAnalyticsEnabled(boolean enabled) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
@@ -41,11 +41,6 @@ public class Preferences extends BucketObject {
 
         if (object instanceof JSONArray) {
             JSONArray recents = (JSONArray) object;
-
-            if (recents == null) {
-                recents = new JSONArray();
-            }
-
             ArrayList<String> recentsList = new ArrayList<>(recents.length());
 
             for (int i = 0; i < recents.length(); i++) {


### PR DESCRIPTION
### Fix
Update the `Preferences.getRecentSearches` method to check the returned `Object` is an instance of `JSONArray` before making the cast to avoid a `ClassCastException` crash.  See the stack trace below for details.

<details>
<summary>
Stack Trace
</summary>
<pre>
java.lang.ClassCastException: java.lang.String cannot be cast to org.json.JSONArray
    at com.automattic.simplenote.models.Preferences.getRecentSearches
    at com.automattic.simplenote.NoteListFragment.getSearchItems
    at com.automattic.simplenote.NoteListFragment.access$2900
    at com.automattic.simplenote.NoteListFragment$10.run
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loop(Looper.java:237)
    at android.app.ActivityThread.main(ActivityThread.java:8019)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1100)
</pre>
</details>

The crash is due to the recent searches value being invalid in the database.  I'm not sure what users are doing to get the invalid value in the database and I'm unable to reproduce the crash consequently.  These changes allow the app to not crash and recover from the invalid database state.  With these changes, users will not see recent searches when the database is in an invalid state.  Once a valid state is restored, they will see recent searches.

Since a new `if`/`else` was added, the diff of these changes looks larger than necessary unless you use the "Hide whitespace changes" setting in GitHub.  That makes the changes go from (+17/-11) to (+7/-1).

#### Note
Even though this is a crash, I do not think this warrants a hotfix since the crash appears to affect about a dozen users.

### Test
Since I'm not sure how the invalid value as saved to the database to recreate the crash, I'm not sure how to test the fix without editing the code to save an invalid value then reverting the edit.  The [`setProperty` statement in the `Preferences.setRecentSearches` method](https://github.com/Automattic/simplenote-android/blob/893a8ec887ae121991c3e0361c5dd4cad07f1d6c/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java#L78) can be edited to force the invalid value to be saved in the database.
#### From
```java
setProperty(RECENT_SEARCHES_KEY, new JSONArray(recents));
```
#### To
``` java
setProperty(RECENT_SEARCHES_KEY, "");
```
After the edit, follow the steps below to save the invalid value.
1. Tap ***Search*** action in app bar.
2. Enter any text in ***Search notes or tags*** field.
3. Submit search with **_Enter_**/**_Return_** key.
4. Notice search results matching query are shown.
5. Notice app does not crash.

Then, revert the edit and test the fix with the steps below.
1. Tap ***Search*** action in app bar.
2. Notice app does not crash.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.