### PR TITLE
Add Delete Action

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.15
 -----
+* Added permanently deleting notes from trash individually [https://github.com/Automattic/simplenote-android/pull/1224]
  
 2.14
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -711,6 +711,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             case R.id.menu_share:
                 shareNote();
                 return true;
+            case R.id.menu_delete:
+                NoteUtils.showDialogDeletePermanently(requireActivity(), mNote);
+                return true;
             case R.id.menu_trash:
                 if (!isAdded()) {
                     return false;
@@ -740,6 +743,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             MenuItem publishItem = menu.findItem(R.id.menu_publish);
             MenuItem copyLinkItem = menu.findItem(R.id.menu_copy);
             MenuItem markdownItem = menu.findItem(R.id.menu_markdown);
+            MenuItem deleteItem = menu.findItem(R.id.menu_delete);
             MenuItem trashItem = menu.findItem(R.id.menu_trash);
             mChecklistMenuItem = menu.findItem(R.id.menu_checklist);
             mInformationMenuItem = menu.findItem(R.id.menu_info).setVisible(true);
@@ -769,9 +773,13 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 DrawableUtils.setMenuItemAlpha(mChecklistMenuItem, 1.0);  // 1.0 is 100% opacity.
             }
 
+            // Show delete action only when note is in Trash.
+            // Change trash action to restore when note is in Trash.
             if (mNote.isDeleted()) {
+                deleteItem.setVisible(true);
                 trashItem.setTitle(R.string.restore);
             } else {
+                deleteItem.setVisible(false);
                 trashItem.setTitle(R.string.trash);
             }
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -148,6 +148,9 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
 
                 requireActivity().finish();
                 return true;
+            case R.id.menu_delete:
+                NoteUtils.showDialogDeletePermanently(requireActivity(), mNote);
+                return true;
             case R.id.menu_trash:
                 if (!isAdded()) {
                     return false;
@@ -185,6 +188,8 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
 
     @Override
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
+        // Show delete action only when note is in Trash.
+        menu.findItem(R.id.menu_delete).setVisible(mNote != null && mNote.isDeleted());
         // Disable trash action until note is loaded.
         menu.findItem(R.id.menu_trash).setEnabled(!mIsLoadingNote);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -850,11 +850,16 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
             }
         });
 
+        MenuItem deleteItem = menu.findItem(R.id.menu_delete);
         MenuItem trashItem = menu.findItem(R.id.menu_trash);
 
+        // Show delete action only when note is in Trash.
+        // Change trash action to restore when note is in Trash.
         if (mCurrentNote != null && mCurrentNote.isDeleted()) {
+            deleteItem.setVisible(true);
             trashItem.setTitle(R.string.restore);
         } else {
+            deleteItem.setVisible(false);
             trashItem.setTitle(R.string.trash);
         }
 
@@ -914,6 +919,9 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 return true;
             case R.id.menu_markdown_preview:
                 togglePreview(item);
+                return true;
+            case R.id.menu_delete:
+                NoteUtils.showDialogDeletePermanently(NotesActivity.this, mCurrentNote);
                 return true;
             case R.id.menu_trash:
                 if (mNoteEditorFragment != null && mCurrentNote != null) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -937,7 +937,8 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
                 alert.setTitle(R.string.empty_trash);
                 alert.setMessage(R.string.confirm_empty_trash);
-                alert.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                alert.setNegativeButton(R.string.cancel, null);
+                alert.setPositiveButton(R.string.empty, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int whichButton) {
                         new EmptyTrashTask(NotesActivity.this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
                         setIconAfterAnimation(item, R.drawable.ic_trash_disabled_24dp, R.string.empty_trash);
@@ -946,11 +947,6 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                             CATEGORY_NOTE,
                             "overflow_menu"
                         );
-                    }
-                });
-                alert.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int whichButton) {
-                        // Do nothing, just closing the dialog
                     }
                 });
                 alert.show();

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
@@ -1,14 +1,25 @@
 package com.automattic.simplenote.utils;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.text.method.LinkMovementMethod;
+import android.widget.TextView;
 
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.view.ContextThemeWrapper;
+
+import com.automattic.simplenote.NoteEditorActivity;
+import com.automattic.simplenote.NotesActivity;
+import com.automattic.simplenote.R;
 import com.automattic.simplenote.Simplenote;
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 
 import java.text.NumberFormat;
 import java.util.Calendar;
+import java.util.Objects;
 
 public class NoteUtils {
     public static void setNotePin(Note note, boolean isPinned) {
@@ -52,5 +63,49 @@ public class NoteUtils {
     public static String getWordCount(String content) {
         int words = (content.trim().length() == 0) ? 0 : content.trim().split("([\\W]+)").length;
         return NumberFormat.getInstance().format(words);
+    }
+
+    public static void showDialogDeletePermanently(final Activity activity, final Note note) {
+        new AlertDialog.Builder(new ContextThemeWrapper(activity, R.style.Dialog))
+            .setTitle(R.string.delete_dialog_title)
+            .setMessage(R.string.delete_dialog_message)
+            .setNegativeButton(R.string.no, null)
+            .setPositiveButton(
+                R.string.yes,
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int whichButton) {
+                        if (note != null) {
+                            note.delete();
+
+                            // Show empty placeholder for large devices in landscape.
+                            if (activity instanceof NotesActivity) {
+                                ((NotesActivity) activity).showDetailPlaceholder();
+                            // Close editor for small devices and large devices in portrait.
+                            } else if (activity instanceof NoteEditorActivity) {
+                                ((NoteEditorActivity) activity).finish();
+                            }
+                        } else {
+                            showDialogErrorDelete(activity);
+                        }
+                    }
+                }
+            )
+            .show();
+    }
+
+    private static void showDialogErrorDelete(Context context) {
+        final AlertDialog dialog = new AlertDialog.Builder(new ContextThemeWrapper(context, R.style.Dialog))
+            .setTitle(R.string.error)
+            .setMessage(HtmlCompat.fromHtml(String.format(
+                context.getString(R.string.delete_dialog_error_message),
+                context.getString(R.string.delete_dialog_error_message_email),
+                "<span style=\"color:#",
+                Integer.toHexString(ThemeUtils.getColorFromAttribute(context, R.attr.colorAccent) & 0xffffff),
+                "\">",
+                "</span>"
+            )))
+            .setPositiveButton(android.R.string.ok, null)
+            .show();
+        ((TextView) Objects.requireNonNull(dialog.findViewById(android.R.id.message))).setMovementMethod(LinkMovementMethod.getInstance());
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
@@ -69,9 +69,9 @@ public class NoteUtils {
         new AlertDialog.Builder(new ContextThemeWrapper(activity, R.style.Dialog))
             .setTitle(R.string.delete_dialog_title)
             .setMessage(R.string.delete_dialog_message)
-            .setNegativeButton(R.string.no, null)
+            .setNegativeButton(R.string.cancel, null)
             .setPositiveButton(
-                R.string.yes,
+                R.string.delete,
                 new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int whichButton) {
                         if (note != null) {

--- a/Simplenote/src/main/res/menu/note_editor.xml
+++ b/Simplenote/src/main/res/menu/note_editor.xml
@@ -54,6 +54,12 @@
         </item>
 
         <item
+            android:id="@+id/menu_delete"
+            android:title="@string/delete"
+            app:showAsAction="never">
+        </item>
+
+        <item
             android:id="@+id/menu_trash"
             android:title="@string/trash"
             app:showAsAction="never">

--- a/Simplenote/src/main/res/menu/note_markdown.xml
+++ b/Simplenote/src/main/res/menu/note_markdown.xml
@@ -60,6 +60,12 @@
         </item>
 
         <item
+            android:id="@+id/menu_delete"
+            android:title="@string/delete"
+            app:showAsAction="never">
+        </item>
+
+        <item
             android:id="@+id/menu_trash"
             android:title="@string/trash"
             app:showAsAction="never">

--- a/Simplenote/src/main/res/menu/notes_list.xml
+++ b/Simplenote/src/main/res/menu/notes_list.xml
@@ -87,6 +87,12 @@
         </item>
 
         <item
+            android:id="@+id/menu_delete"
+            android:title="@string/delete"
+            app:showAsAction="never">
+        </item>
+
+        <item
             android:id="@+id/menu_trash"
             android:title="@string/trash"
             app:showAsAction="never">

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="search_tags">Search Tags</string>
     <string name="search_tags_hint">Search tags</string>
     <string name="notes">Notes</string>
+    <string name="delete">Delete</string>
     <string name="delete_dialog_error_message">An error occurred deleting the note. Please, try again. If the problem continues, contact us at %1$s%2$s%3$s%4$s%5$s for help.</string>
     <string name="delete_dialog_error_message_email" translatable="false">\u003c\u0061\u0020\u0068\u0072\u0065\u0066\u003d\u0022\u006d\u0061\u0069\u006c\u0074\u006f\u003a\u0073\u0075\u0070\u0070\u006f\u0072\u0074\u0040\u0073\u0069\u006d\u0070\u006c\u0065\u006e\u006f\u0074\u0065\u002e\u0063\u006f\u006d\u0022\u003e\u0073\u0075\u0070\u0070\u006f\u0072\u0074\u0040\u0073\u0069\u006d\u0070\u006c\u0065\u006e\u006f\u0074\u0065\u002e\u0063\u006f\u006d\u003c\u002f\u0061\u003e</string>
     <string name="delete_dialog_message">Do you want to permanently delete this note? This action cannot be undone.</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -25,7 +25,7 @@
     <string name="save">Save</string>
     <string name="cancel">Cancel</string>
     <string name="empty_trash">Empty Trash</string>
-    <string name="confirm_empty_trash">Are you sure you want to empty the trash?</string>
+    <string name="confirm_empty_trash">Do you want to empty the trash? All notes in trash will be permanently deleted. This action cannot be undone.</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="word">Word</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="delete_tag">Delete Tag</string>
     <string name="save">Save</string>
     <string name="cancel">Cancel</string>
+    <string name="empty">Empty</string>
     <string name="empty_trash">Empty Trash</string>
     <string name="confirm_empty_trash">Do you want to empty the trash? All notes in trash will be permanently deleted. This action cannot be undone.</string>
     <string name="yes">Yes</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -40,6 +40,10 @@
     <string name="search_tags">Search Tags</string>
     <string name="search_tags_hint">Search tags</string>
     <string name="notes">Notes</string>
+    <string name="delete_dialog_error_message">An error occurred deleting the note. Please, try again. If the problem continues, contact us at %1$s%2$s%3$s%4$s%5$s for help.</string>
+    <string name="delete_dialog_error_message_email" translatable="false">\u003c\u0061\u0020\u0068\u0072\u0065\u0066\u003d\u0022\u006d\u0061\u0069\u006c\u0074\u006f\u003a\u0073\u0075\u0070\u0070\u006f\u0072\u0074\u0040\u0073\u0069\u006d\u0070\u006c\u0065\u006e\u006f\u0074\u0065\u002e\u0063\u006f\u006d\u0022\u003e\u0073\u0075\u0070\u0070\u006f\u0072\u0074\u0040\u0073\u0069\u006d\u0070\u006c\u0065\u006e\u006f\u0074\u0065\u002e\u0063\u006f\u006d\u003c\u002f\u0061\u003e</string>
+    <string name="delete_dialog_message">Do you want to permanently delete this note? This action cannot be undone.</string>
+    <string name="delete_dialog_title">Delete Permanently</string>
     <string name="trash">Trash</string>
     <string name="untagged_notes">Untagged Notes</string>
     <string name="today">Today</string>


### PR DESCRIPTION
### Fix
Add the ***Delete*** action to the overflow/ellipsis menu to permanently delete notes in the ***Trash*** individually.  Currently, notes are only able to be permanently deleted in bulk using the ***Empty Trash*** action.  ***Delete*** will only be shown once the note has been trashed and will be above the ***Restore*** action.  See the screenshots below for illustration.

#### Phone
![add_delete_action_phone](https://user-images.githubusercontent.com/3827611/100946322-53d89480-34c0-11eb-8304-f4bbbda7192f.png)

#### Tablet
![add_delete_action_tablet](https://user-images.githubusercontent.com/3827611/100946329-55a25800-34c0-11eb-8a4a-790ef4f08861.png)

Also included in these changes is an update to the ***Empty Trash*** dialog message.  Since emptying the trash is a destructive action that permanently deletes all notes in ***Trash*** and it cannot be undone like trashing a note, a more verbose message explaining exactly that seems necessary.  See the screenshots below for illustration.

![add_delete_action_empty](https://user-images.githubusercontent.com/3827611/100946419-884c5080-34c0-11eb-928b-1ac08b58b05c.png)

### Test
Since the actions are different on phones and tablets, it's best to test both device form factors to verify the correct actions are visible/invisible as shown in the screenshots above.
1. Tap any note in list.
2. Tap overflow menu action in app bar.
3. Notice ***Trash*** action is shown.
4. Notice ***Delete*** action is hidden.
5. Tap outside overflow menu.
6. Open navigation drawer.
7. Tap ***Trash*** item in navigation drawer.
8. Tap ***Empty Trash*** action in app bar (phone) or overflow menu (tablet).
9. Notice ***Empty Trash*** dialog is shown with messag shown above.
10. Tap ***No*** button in dialog.
11. Notice ***Trash*** is not emptied.
12. Tap any note in list.
13. Tap overflow menu action in app bar.
14. Notice ***Restore*** action is shown.
15. Notice ***Delete*** action is shown.
16. Tap ***Delete*** action in overflow menu.
17. Notice ***Delete Permanently*** dialog is shown.
18. Tap ***No*** button in dialog.
19. Notice ***Delete Permanently*** dialog is hidden.
20. Notice note is not deleted.
21. Tap overflow menu action in app bar.
22. Tap ***Delete*** action in overflow menu.
23. Notice ***Delete Permanently*** dialog is shown.
24. Tap ***Yes*** button in dialog.
25. Notice note is deleted.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

#### Note
Contact me for an installable build.

### Release
`RELEASE-NOTES.txt` was updated in 259e51e with:
> Added permanently deleting notes from trash individually [https://github.com/Automattic/simplenote-android/pull/1224]