### PR TITLE
Crash Device Language Change

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -50,6 +50,8 @@ import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
 import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
 
 public class NoteEditorActivity extends ThemedAppCompatActivity {
+    private static final String STATE_TAB_EDIT = "TAB_EDIT";
+    private static final String STATE_TAB_PREVIEW = "TAB_PREVIEW";
     private static final String STATE_MATCHES_INDEX = "MATCHES_INDEX";
     private static final String STATE_MATCHES_LOCATIONS = "MATCHES_LOCATIONS";
     private static final int INDEX_TAB_EDIT = 0;
@@ -170,11 +172,11 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
             isPreviewEnabled = intent.getBooleanExtra(NoteEditorFragment.ARG_PREVIEW_ENABLED, false);
         } else {
             mNoteEditorFragmentPagerAdapter.addFragment(
-                    getSupportFragmentManager().getFragment(savedInstanceState, getString(R.string.tab_edit)),
+                    getSupportFragmentManager().getFragment(savedInstanceState, STATE_TAB_EDIT),
                     getString(R.string.tab_edit)
             );
             mNoteEditorFragmentPagerAdapter.addFragment(
-                    getSupportFragmentManager().getFragment(savedInstanceState, getString(R.string.tab_preview)),
+                    getSupportFragmentManager().getFragment(savedInstanceState, STATE_TAB_PREVIEW),
                     getString(R.string.tab_preview)
             );
 
@@ -248,11 +250,11 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
     @Override
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         if (mNoteEditorFragmentPagerAdapter.getCount() > 0 && mNoteEditorFragmentPagerAdapter.getItem(INDEX_TAB_EDIT).isAdded()) {
-            getSupportFragmentManager().putFragment(outState, getString(R.string.tab_edit), mNoteEditorFragmentPagerAdapter.getItem(INDEX_TAB_EDIT));
+            getSupportFragmentManager().putFragment(outState, STATE_TAB_EDIT, mNoteEditorFragmentPagerAdapter.getItem(INDEX_TAB_EDIT));
         }
 
         if (mNoteEditorFragmentPagerAdapter.getCount() > 1 && mNoteEditorFragmentPagerAdapter.getItem(INDEX_TAB_PREVIEW).isAdded()) {
-            getSupportFragmentManager().putFragment(outState, getString(R.string.tab_preview), mNoteEditorFragmentPagerAdapter.getItem(INDEX_TAB_PREVIEW));
+            getSupportFragmentManager().putFragment(outState, STATE_TAB_PREVIEW, mNoteEditorFragmentPagerAdapter.getItem(INDEX_TAB_PREVIEW));
         }
 
         outState.putBoolean(NoteEditorFragment.ARG_MARKDOWN_ENABLED, isMarkdownEnabled);


### PR DESCRIPTION
Fixes #959 

### Fix
This PR fixes a crash on changing device language with a note open.

The crash was caused due to the fact that, when saving a tab during 'onSaveInstanceState(...)' a key of a specific language was used (ie. 'Edit' if the device was on English at that point), but when restoring a tab during 'onCreate(...)' a key of another language was used (ie. 'Editar' if the device was switched to Spanish). Thus, no restore actually occurred on the tab layer, causing the crash.

Using a constant as a key for saving/restoring state fixes this issue.

### Test
1) Open the app and select a markdown note in the notes list to open the editor.
1) Change your device language (e.g. from UK English to Spanish).
1) Return to the app. Result: App **NOT** crashing and language change is visible on tabs.
1) Open the app again and select a non-markdown note.
1) Change your device language (e.g. from Spanish back to UK English).
1) Return to the app. Result: App **NOT** crashing and language change is visible in app.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.