### PR TITLE
Crash Rename Tag

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
@@ -36,14 +36,15 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
     private Bucket<Note> mBucketNote;
     private Bucket<Tag> mBucketTag;
     private Button mButtonNegative;
+    private Button mButtonNeutral;
     private Button mButtonPositive;
     private String mTagOld;
     private Tag mTag;
     private TextInputEditText mEditTextTag;
     private TextInputLayout mEditTextLayout;
     private TextView mMessage;
-    private View.OnClickListener mClickListenerNegativeConflict;
     private View.OnClickListener mClickListenerNegativeRename;
+    private View.OnClickListener mClickListenerNeutralConflict;
     private View.OnClickListener mClickListenerPositiveConflict;
     private View.OnClickListener mClickListenerPositiveRename;
 
@@ -110,7 +111,7 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
             }
         };
 
-        mClickListenerNegativeConflict = new View.OnClickListener() {
+        mClickListenerNeutralConflict = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 showDialogRenameTag();
@@ -132,6 +133,7 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
     @Override
     public void onShow(DialogInterface dialog) {
         mButtonNegative = mDialogEditTag.getButton(DialogInterface.BUTTON_NEGATIVE);
+        mButtonNeutral = mDialogEditTag.getButton(DialogInterface.BUTTON_NEUTRAL);
         mButtonPositive = mDialogEditTag.getButton(DialogInterface.BUTTON_POSITIVE);
         showDialogRenameTag();
         mEditTextTag.setText(mTag.getName());
@@ -184,22 +186,32 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
     }
 
     private void showDialogErrorConflict(String canonical, String tagOld) {
+        mDialogEditTag.setTitle(R.string.dialog_tag_conflict_title);
+
         mMessage.setText(getString(R.string.dialog_tag_conflict_message, canonical, tagOld, canonical));
+        mButtonNeutral.setText(R.string.back);
+        mButtonPositive.setText(R.string.dialog_tag_conflict_button_positive);
+
         mMessage.setVisibility(View.VISIBLE);
         mEditTextLayout.setVisibility(View.GONE);
-        mDialogEditTag.setTitle(R.string.dialog_tag_conflict_title);
-        mButtonNegative.setText(R.string.cancel);
-        mButtonPositive.setText(R.string.dialog_tag_conflict_button_positive);
-        mButtonNegative.setOnClickListener(mClickListenerNegativeConflict);
+        mButtonNegative.setVisibility(View.GONE);
+        mButtonNeutral.setVisibility(View.VISIBLE);
+
+        mButtonNeutral.setOnClickListener(mClickListenerNeutralConflict);
         mButtonPositive.setOnClickListener(mClickListenerPositiveConflict);
     }
 
     private void showDialogRenameTag() {
-        mMessage.setVisibility(View.GONE);
-        mEditTextLayout.setVisibility(View.VISIBLE);
         mDialogEditTag.setTitle(R.string.rename_tag);
+
         mButtonNegative.setText(R.string.cancel);
         mButtonPositive.setText(R.string.save);
+
+        mMessage.setVisibility(View.GONE);
+        mEditTextLayout.setVisibility(View.VISIBLE);
+        mButtonNegative.setVisibility(View.VISIBLE);
+        mButtonNeutral.setVisibility(View.GONE);
+
         mButtonNegative.setOnClickListener(mClickListenerNegativeRename);
         mButtonPositive.setOnClickListener(mClickListenerPositiveRename);
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
@@ -4,6 +4,7 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnShowListener;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -50,6 +51,12 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
         mTag = tag;
         mBucketNote = bucketNote;
         mBucketTag = bucketTag;
+    }
+
+    @Override
+    public void onConfigurationChanged(@NonNull Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        dismiss();
     }
 
     @NonNull
@@ -209,6 +216,8 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
                 context,
                 context.getString(R.string.rename_tag_message)
             );
+        } finally {
+            dismiss();
         }
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
@@ -123,7 +123,6 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
                 String tagNew = getTagNew();
                 int index = mTag.hasIndex() ? mTag.getIndex() : mBucketTag.count();
                 tryToRenameTag(tagNew, index);
-                dismiss();
             }
         };
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
@@ -34,6 +34,7 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
     private AlertDialog mDialogEditTag;
     private Bucket<Note> mBucketNote;
     private Bucket<Tag> mBucketTag;
+    private Button mButtonNegative;
     private Button mButtonPositive;
     private String mTagOld;
     private Tag mTag;
@@ -124,7 +125,9 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
 
     @Override
     public void onShow(DialogInterface dialog) {
+        mButtonNegative = mDialogEditTag.getButton(DialogInterface.BUTTON_NEGATIVE);
         mButtonPositive = mDialogEditTag.getButton(DialogInterface.BUTTON_POSITIVE);
+        showDialogRenameTag();
         mEditTextTag.setText(mTag.getName());
         mTagOld = mEditTextTag.getText() != null ? mEditTextTag.getText().toString() : "";
     }
@@ -170,21 +173,25 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
         return mEditTextTag.getText() != null && mEditTextTag.getText().toString().contains(" ");
     }
 
-    private void showDialogErrorConflict(String canonical, String tagOld, final String tagNew, final int index) {
-        new AlertDialog.Builder(new ContextThemeWrapper(requireContext(), R.style.Dialog))
-            .setTitle(R.string.dialog_tag_conflict_title)
-            .setMessage(getString(R.string.dialog_tag_conflict_message, canonical, tagOld, canonical))
-            .setNegativeButton(R.string.cancel, null)
-            .setPositiveButton(
-                R.string.dialog_tag_conflict_button_positive,
-                new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        tryToRenameTag(tagNew, index);
-                    }
-                }
-            )
-            .show();
+    private void showDialogErrorConflict(String canonical, String tagOld) {
+        mMessage.setText(getString(R.string.dialog_tag_conflict_message, canonical, tagOld, canonical));
+        mMessage.setVisibility(View.VISIBLE);
+        mEditTextLayout.setVisibility(View.GONE);
+        mDialogEditTag.setTitle(R.string.dialog_tag_conflict_title);
+        mButtonNegative.setText(R.string.cancel);
+        mButtonPositive.setText(R.string.dialog_tag_conflict_button_positive);
+        mButtonNegative.setOnClickListener(mClickListenerNegativeConflict);
+        mButtonPositive.setOnClickListener(mClickListenerPositiveConflict);
+    }
+
+    private void showDialogRenameTag() {
+        mMessage.setVisibility(View.GONE);
+        mEditTextLayout.setVisibility(View.VISIBLE);
+        mDialogEditTag.setTitle(R.string.rename_tag);
+        mButtonNegative.setText(R.string.cancel);
+        mButtonPositive.setText(R.string.save);
+        mButtonNegative.setOnClickListener(mClickListenerNegativeRename);
+        mButtonPositive.setOnClickListener(mClickListenerPositiveRename);
     }
 
     private void tryToRenameTag(String tagNew, int index) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
@@ -12,6 +12,7 @@ import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
@@ -38,6 +39,7 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
     private Tag mTag;
     private TextInputEditText mEditTextTag;
     private TextInputLayout mEditTextLayout;
+    private TextView mMessage;
 
     public TagDialogFragment(Tag tag, Bucket<Note> bucketNote, Bucket<Tag> bucketTag) {
         mTag = tag;
@@ -79,6 +81,7 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
         View view = LayoutInflater.from(context).inflate(R.layout.edit_tag, null);
         mEditTextLayout = view.findViewById(R.id.input_tag_name);
         mEditTextTag = (TextInputEditText) mEditTextLayout.getEditText();
+        mMessage = view.findViewById(R.id.message);
 
         if (mEditTextTag != null) {
             mEditTextTag.addTextChangedListener(this);

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
@@ -90,7 +90,7 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
         mClickListenerPositiveRename = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                String tagNew = mEditTextTag.getText() != null ? mEditTextTag.getText().toString().trim() : "";
+                String tagNew = getTagNew();
 
                 if (tagNew.equals(mTagOld)) {
                     dismiss();
@@ -120,7 +120,7 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
         mClickListenerPositiveConflict = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                String tagNew = mEditTextTag.getText() != null ? mEditTextTag.getText().toString().trim() : "";
+                String tagNew = getTagNew();
                 int index = mTag.hasIndex() ? mTag.getIndex() : mBucketTag.count();
                 tryToRenameTag(tagNew, index);
                 dismiss();
@@ -162,6 +162,10 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
 
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count) {
+    }
+
+    private String getTagNew() {
+        return mEditTextTag.getText() != null ? mEditTextTag.getText().toString().trim() : "";
     }
 
     private boolean isTagNameValid() {

--- a/Simplenote/src/main/res/layout/edit_tag.xml
+++ b/Simplenote/src/main/res/layout/edit_tag.xml
@@ -3,6 +3,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
     android:orientation="vertical"
@@ -19,7 +20,9 @@
         android:layout_marginTop="@dimen/margin_default"
         android:layout_width="match_parent"
         android:hint="@string/tag_name"
+        android:visibility="gone"
         app:errorEnabled="true"
+        tools:visibility="visible"
         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
 
         <com.google.android.material.textfield.TextInputEditText
@@ -29,5 +32,16 @@
         </com.google.android.material.textfield.TextInputEditText>
 
     </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:id="@+id/message"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_default_quarter"
+        android:layout_marginStart="@dimen/margin_default_quarter"
+        android:layout_width="match_parent"
+        android:visibility="gone"
+        tools:text="@string/dialog_tag_conflict_message"
+        style="@style/TextAppearance.AppCompat.Subhead">
+    </TextView>
 
 </LinearLayout>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="tag_name">Tag name</string>
     <string name="delete_tag">Delete Tag</string>
     <string name="save">Save</string>
+    <string name="back">Back</string>
     <string name="cancel">Cancel</string>
     <string name="empty">Empty</string>
     <string name="empty_trash">Empty Trash</string>


### PR DESCRIPTION
### Fix
Update the `TagDialogFragment` class to avoid an `IllegalStateException` crash.  While going through the tests in https://github.com/Automattic/simplenote-android/pull/1226, I noticed a crash can occur when renaming a tag encounters an error.  When the **_Tag Conflict_** `AlertDialog` was shown and the `DialogFragment` was dismissed, the fragment is detached from the activity.  Therefore, when the **_Error_** dialog was shown when an error occurred renaming a tag, the context used was no longer valid and an `IllegalStateException` was thrown with the "Fragment TagDialogFragment not attached to a context" message.  This was introduced in https://github.com/Automattic/simplenote-android/pull/1112, which has not been released yet.  To fix the crash, I modified `TagDialogFragment` to show and hide views based on renaming a tag or a tag conflict.  Now, the `DialogFragment` will only be dismissed/detached after determining there is no tag conflict or the user has chosen to merge conflicting tags, which means the context used for the **_Error_** dialog will be valid.

#### Note
Branching off `add-dialog-utils` didn't do what I expected.  It effectively made the changes in the original `crash-rename-tag` branch null.  I had to branch off the latest `develop` and revert the revert, which is not what I wanted.  That's why the commits in this pull request are a little confusing.

### Test
With the changes to the **_Rename Tag_** dialog, an invalid tag should not be able to be entered and the ***Error*** dialog should never be shown.  In order to test the ***Error*** dialog, the `try` part of the [`try`/`catch`/`finally` statement in the `TagDialogFragment` class](https://github.com/Automattic/simplenote-android/blob/ae3f699ba9b659febb819f68a40dbac52a38463c/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java#L209-L226) can be commented out to force the ***Error*** dialog to be shown.
1. Open navigation drawer.
2. Tap ***Edit*** button in ***Tags*** header.
3. Tap any tag in list.
4. Edit tag name to any non-existing tag.
5. Tap ***Save*** button in dialog.
6. Notice ***Error*** dialog is shown with link to email support.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.