### PR TITLE
Right Arrow Hardware Keyboard Key Blanks Out Note Editor

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/NoteEditorViewPager.java
@@ -37,6 +37,11 @@ public class NoteEditorViewPager extends ViewPager {
         return this.mIsEnabled && super.performClick();
     }
 
+    @Override
+    public boolean arrowScroll(int direction) {
+        return this.mIsEnabled && super.arrowScroll(direction);
+    }
+
     public void setPagingEnabled(boolean enabled) {
         this.mIsEnabled = enabled;
     }


### PR DESCRIPTION
Fixes #472 

### Fix
This PR fixed the bug which causes the note editor to blank out when markdown is disabled.

The problem was that, when markdown was disabled, the note editor will still switch to the preview tab when the `right arrow` hardware keyboard key was pressed, when being at the end of the text editor's selection. This behavior makes sense when the markdown is enabled, but should not be allowed when markdown is disabled.

The bug is effectively fixed by disabling the `right arrow` hardware keyboard key when being at the end of the text editor's selection. Also, the same bug occurs on the tags section, and as such, this was fixed as well.

For the tags section, it was consider to not allow switching tabs even when markdown was enabled, but this was dropped because when markdown is enabled, clicking on the `right arrow` hardware keyboard key, when being at the end of the text editor's selection, the cursor jumps down to the tags sections instead, and from there if the user clicks the `right arrow` hardware keyboard key again, they can switch to the markdown tab. Since this might be intended, I decided to keep this functionality untampered.

### Note
I considered RTL support as well, but giving the fact that the text editor is not to a 100% RTL ready, adding the fix for RTL will break current functionality. This is due to the fact that when adding a text while on RTL, the text starts from left to right anyway, and as such the `right arrow` hardware keyboard key solution continues to apply. In order to improve that, the text editor needs to first start supporting RLT for that scenario. @theck13 please correct me if I am wrong. 🙏 

### Test
1) Use an emulator with keyboard input enabled.
1) Tap `New Note` floating action button.
1) Make sure that the `Markdown` is disabled on this note.
1) Enter `Test` in new note.
1) Notice `Test` is displayed.
1) Notice software keyboard is shown.
1) Press `right arrow` key on hardware keyboard.
1) Notice software keyboard is **NOT** dismissed.
1) Notice `Test` **DOESN'T** slide to left.
1) Notice `Test` is **STILL** displayed.
1) Finally, follow the above same steps on the tags sections and verify correctness.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.