### PR TITLE
Enable Installable Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,4 +69,4 @@ workflows:
     jobs:
       - Test
       - Lint
-#      - Installable Build
+      - Installable Build


### PR DESCRIPTION
### Fix
Remove the comment from the line in the CircleCI configuration file that runs the installable build job, which effectively enables installable builds by reverting the change in https://github.com/Automattic/simplenote-android/pull/1120.

### Test
Verify this pull request has an installable build once the CircleCI job completes.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.