### PR TITLE
Update Simperium Dimensions

### DIFF
--- a/Simplenote/src/main/res/layout/activity_note_editor.xml
+++ b/Simplenote/src/main/res/layout/activity_note_editor.xml
@@ -75,7 +75,7 @@
                 android:layout_width="wrap_content"
                 android:minHeight="@dimen/minimum_target"
                 android:minWidth="@dimen/minimum_target"
-                android:padding="@dimen/margin_default"
+                android:padding="@dimen/padding_large"
                 android:src="@drawable/ic_chevron_left_24dp"
                 android:tint="@color/toolbar_icon_alpha_40_selector"
                 android:tintMode="src_in">
@@ -129,7 +129,7 @@
                 android:layout_width="wrap_content"
                 android:minHeight="@dimen/minimum_target"
                 android:minWidth="@dimen/minimum_target"
-                android:padding="@dimen/margin_default"
+                android:padding="@dimen/padding_large"
                 android:src="@drawable/ic_chevron_right_24dp"
                 android:tint="@color/toolbar_icon_alpha_40_selector"
                 android:tintMode="src_in">

--- a/Simplenote/src/main/res/layout/activity_note_editor.xml
+++ b/Simplenote/src/main/res/layout/activity_note_editor.xml
@@ -86,7 +86,7 @@
                 android:layout_centerInParent="true"
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
-                android:padding="@dimen/margin_default_half"
+                android:padding="@dimen/padding_small"
                 android:text="@string/of"
                 android:textColor="?attr/noteTitleColor"
                 android:textSize="@dimen/text_content_title">

--- a/Simplenote/src/main/res/layout/edit_tag.xml
+++ b/Simplenote/src/main/res/layout/edit_tag.xml
@@ -14,9 +14,9 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/input_tag_name"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_default_quarter"
-        android:layout_marginEnd="@dimen/margin_default_quarter"
-        android:layout_marginStart="@dimen/margin_default_quarter"
+        android:layout_marginBottom="@dimen/padding_extra_small"
+        android:layout_marginEnd="@dimen/padding_extra_small"
+        android:layout_marginStart="@dimen/padding_extra_small"
         android:layout_marginTop="@dimen/margin_default"
         android:layout_width="match_parent"
         android:hint="@string/tag_name"
@@ -36,8 +36,8 @@
     <TextView
         android:id="@+id/message"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_default_quarter"
-        android:layout_marginStart="@dimen/margin_default_quarter"
+        android:layout_marginEnd="@dimen/padding_extra_small"
+        android:layout_marginStart="@dimen/padding_extra_small"
         android:layout_width="match_parent"
         android:visibility="gone"
         tools:text="@string/dialog_tag_conflict_message"

--- a/Simplenote/src/main/res/layout/edit_tag.xml
+++ b/Simplenote/src/main/res/layout/edit_tag.xml
@@ -17,7 +17,7 @@
         android:layout_marginBottom="@dimen/padding_extra_small"
         android:layout_marginEnd="@dimen/padding_extra_small"
         android:layout_marginStart="@dimen/padding_extra_small"
-        android:layout_marginTop="@dimen/margin_default"
+        android:layout_marginTop="@dimen/padding_large"
         android:layout_width="match_parent"
         android:hint="@string/tag_name"
         android:visibility="gone"


### PR DESCRIPTION
### Fix
Update references from Simperium to Simplenote dimension resources.  The `activity_note_editor` and `edit_tag` layout files were referencing `margin_default`, `margin_default_half`, and `margin_default_quarter` dimension resources, which come from the Simperium library.  This pull request changes those references to `padding_large`, `padding_small`, and `padding_extra_small` respectively.  The dimension values were not changed.  They are still 16dp, 8dp, and 4dp.  Therefore, the rendered layouts should remain unchanged.

### Test
Since the `activity_note_editor` and `edit_tag` layout files were affected, testing the search match bar in the note editor and the ***Rename Tag*** dialog on the ***Edit Tags*** screen is best.

#### Note Editor
1. Tap ***Search*** action in app bar.
2. Enter any text matching at least one note in search field.
3. Submit search with **_Enter_**/**_Return_** key.
4. Tap any note in search results list.
5. Notice search match bar layout at bottom is unchanged.

#### Edit Tag
1. Open navigation drawer.
2. Tap ***Edit*** button in ***Tags*** header.
3. Tap any tag in list.
4. Notice ***Rename Tag*** layout is unchanged.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.