### PR TITLE
Update Password Policy

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
-    implementation 'com.simperium.android:simperium:0.9.13'
+    implementation 'com.simperium.android:simperium:0.9.14'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.2'
 

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -325,7 +325,7 @@
     <string name="simperium_dialog_message_login_reset">Your password is insecure and must be reset.  The password requirements are:\n\n- Password cannot match email\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
     <string name="simperium_dialog_message_network">There is no network available.  Please, connect to a network and try again.</string>
     <string name="simperium_dialog_message_password">The password requirements are:\n\n- Password cannot match email\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
-    <string name="simperium_dialog_message_password_login">Passwords must be a minimum of %1$d characters excluding new lines, spaces, and tabs.</string>
+    <string name="simperium_dialog_message_password_login">Passwords must be a minimum of %1$d characters.</string>
     <string name="simperium_dialog_message_signup">Could not sign up with the provided email address and password.</string>
     <string name="simperium_dialog_message_signup_existing">The email address you entered is already associated with a Simplenote account.</string>
     <string name="simperium_dialog_progress_logging_in">Logging in&#8230;</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -324,7 +324,7 @@
     <string name="simperium_dialog_message_login">Could not log in with the provided email address and password.</string>
     <string name="simperium_dialog_message_login_reset">Your password is insecure and must be reset.  The password requirements are:\n\n- Password cannot match email\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
     <string name="simperium_dialog_message_network">There is no network available.  Please, connect to a network and try again.</string>
-    <string name="simperium_dialog_message_password">The password requirements are:\n\n- Password cannot match email\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
+    <string name="simperium_dialog_message_password">The password requirements are:\n\n- Password cannot match email\n- Minimum of %1$d characters\n- No new lines\n- No returns\n- No tabs</string>
     <string name="simperium_dialog_message_password_login">Passwords must be a minimum of %1$d characters.</string>
     <string name="simperium_dialog_message_signup">Could not sign up with the provided email address and password.</string>
     <string name="simperium_dialog_message_signup_existing">The email address you entered is already associated with a Simplenote account.</string>


### PR DESCRIPTION
### Fix
Update the `simperium` dependency, which includes removing the restriction on spaces in passwords as described in https://github.com/Simperium/simperium-android/pull/227/.  The new password policy requirements remain:
- Password cannot match username
- Minimum of 8 characters
- No new lines
- No returns
- No tabs

### Test
In order to test this pull request specifically, change your Simplenote password to include one or more spaces. Then, follow the steps below.

0. Clear app data.
1. Tap ***Log In*** button.
2. Tap ***Log In with Email*** button.
3. Enter email address in ***Email*** field.
4. Notice ***Log In*** button is disabled.
5. Enter incorrect password with one or more spaces in ***Password*** field.
6. Notice ***Log In*** button is enabled after four characters are input.
7. Tap ***Log In*** button.
8. Notice ***Error*** dialog without password requirements is shown.
9. Tap ***OK*** button in dialog.
10. Enter correct password with one or more spaces in ***Password*** field.
11. Notice ***Log In*** button is enabled after four characters are input.
12. Tap ***Log In*** button.
13. Notice app is successfully logged in.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.