### PR TITLE
Update Simperium References

### DIFF
--- a/Simplenote/src/main/res/layout/fragment_about.xml
+++ b/Simplenote/src/main/res/layout/fragment_about.xml
@@ -12,7 +12,7 @@
     <LinearLayout
         android:layout_gravity="center_horizontal"
         android:layout_height="wrap_content"
-        android:layout_width="@dimen/width_layout"
+        android:layout_width="@dimen/style_width"
         android:orientation="vertical"
         tools:layout_width="match_parent">
 

--- a/Simplenote/src/main/res/layout/fragment_about.xml
+++ b/Simplenote/src/main/res/layout/fragment_about.xml
@@ -12,7 +12,7 @@
     <LinearLayout
         android:layout_gravity="center_horizontal"
         android:layout_height="wrap_content"
-        android:layout_width="@dimen/style_width"
+        android:layout_width="@dimen/content_width"
         android:orientation="vertical"
         tools:layout_width="match_parent">
 

--- a/Simplenote/src/main/res/layout/style_list_row_black.xml
+++ b/Simplenote/src/main/res/layout/style_list_row_black.xml
@@ -15,7 +15,7 @@
         android:layout_marginEnd="@dimen/padding_large"
         android:layout_marginStart="@dimen/padding_large"
         android:layout_marginTop="@dimen/padding_small"
-        android:layout_width="@dimen/style_width"
+        android:layout_width="@dimen/content_width"
         app:cardCornerRadius="@dimen/corner_radius"
         app:cardElevation="0dp"
         style="@style/Style.Black">

--- a/Simplenote/src/main/res/layout/style_list_row_default.xml
+++ b/Simplenote/src/main/res/layout/style_list_row_default.xml
@@ -15,7 +15,7 @@
         android:layout_marginEnd="@dimen/padding_large"
         android:layout_marginStart="@dimen/padding_large"
         android:layout_marginTop="@dimen/padding_small"
-        android:layout_width="@dimen/style_width"
+        android:layout_width="@dimen/content_width"
         app:cardCornerRadius="@dimen/corner_radius"
         app:cardElevation="0dp"
         style="@style/Style.Default">

--- a/Simplenote/src/main/res/layout/style_list_row_matrix.xml
+++ b/Simplenote/src/main/res/layout/style_list_row_matrix.xml
@@ -15,7 +15,7 @@
         android:layout_marginEnd="@dimen/padding_large"
         android:layout_marginStart="@dimen/padding_large"
         android:layout_marginTop="@dimen/padding_small"
-        android:layout_width="@dimen/style_width"
+        android:layout_width="@dimen/content_width"
         app:cardCornerRadius="@dimen/corner_radius"
         app:cardElevation="0dp"
         style="@style/Style.Matrix">

--- a/Simplenote/src/main/res/layout/style_list_row_mono.xml
+++ b/Simplenote/src/main/res/layout/style_list_row_mono.xml
@@ -15,7 +15,7 @@
         android:layout_marginEnd="@dimen/padding_large"
         android:layout_marginStart="@dimen/padding_large"
         android:layout_marginTop="@dimen/padding_small"
-        android:layout_width="@dimen/style_width"
+        android:layout_width="@dimen/content_width"
         app:cardCornerRadius="@dimen/corner_radius"
         app:cardElevation="0dp"
         style="@style/Style.Mono">

--- a/Simplenote/src/main/res/layout/style_list_row_publication.xml
+++ b/Simplenote/src/main/res/layout/style_list_row_publication.xml
@@ -15,7 +15,7 @@
         android:layout_marginEnd="@dimen/padding_large"
         android:layout_marginStart="@dimen/padding_large"
         android:layout_marginTop="@dimen/padding_small"
-        android:layout_width="@dimen/style_width"
+        android:layout_width="@dimen/content_width"
         app:cardCornerRadius="@dimen/corner_radius"
         app:cardElevation="0dp"
         style="@style/Style.Publication">

--- a/Simplenote/src/main/res/layout/style_list_row_sepia.xml
+++ b/Simplenote/src/main/res/layout/style_list_row_sepia.xml
@@ -15,7 +15,7 @@
         android:layout_marginEnd="@dimen/padding_large"
         android:layout_marginStart="@dimen/padding_large"
         android:layout_marginTop="@dimen/padding_small"
-        android:layout_width="@dimen/style_width"
+        android:layout_width="@dimen/content_width"
         app:cardCornerRadius="@dimen/corner_radius"
         app:cardElevation="0dp"
         style="@style/Style.Sepia">

--- a/Simplenote/src/main/res/values-large/dimens.xml
+++ b/Simplenote/src/main/res/values-large/dimens.xml
@@ -3,6 +3,6 @@
 <resources>
 
     <!-- SIZE -->
-    <dimen name="style_width">560dp</dimen>
+    <dimen name="content_width">560dp</dimen>
 
 </resources>

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -39,6 +39,7 @@
     <dimen name="bottom_sheet_row_height">56dp</dimen>
     <dimen name="cell_widget">40dp</dimen>
     <dimen name="cell_widget_double">80dp</dimen>
+    <dimen name="content_width">-1px</dimen>  <!-- -1px fakes match_parent -->
     <dimen name="corner_radius">4dp</dimen>
     <dimen name="divider_height">1dp</dimen>
     <dimen name="elevation_bar">8dp</dimen>
@@ -57,7 +58,6 @@
     <dimen name="sort_switch_width">40dp</dimen>
     <dimen name="style_stroke">1dp</dimen>
     <dimen name="style_stroke_activated">2dp</dimen>
-    <dimen name="style_width">-1px</dimen>  <!-- -1px fakes match_parent -->
     <dimen name="tag_input_height">56dp</dimen>
     <dimen name="text_about_app">24sp</dimen>
     <dimen name="text_about_subtitle">14sp</dimen>


### PR DESCRIPTION
### Fix
Update references from Simperium to Simplenote dimension resources.  The `fragment_about` layout file was referencing the `width_layout` dimension resource, which comes from the Simperium library.  This pull request changes that reference to `style_width` and renames `style_width` to `content_width` since the dimension is no longer used for the **_Style_** screen only.  These changes update the layout width on large devices since the Simperium dimension resource `width_layout` has different values for `values-large` and `values-large-land`.  That is expected since we have updated the content width to mimic the **_Style_** screen.

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Tap ***About*** item under ***More*** section.
4. Notice ***About*** layout is full-width on phones and not full-width on tablets.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.