### PR TITLE
Update Internote Autocomplete

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -400,6 +400,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 Query<Note> query = application.getNotesBucket().query();
                 query.include(Note.PINNED_INDEX_NAME);
                 query.include(Note.TITLE_INDEX_NAME);
+                query.where(Note.DELETED_PROPERTY, Query.ComparisonType.NOT_EQUAL_TO, true);
                 query.where(Note.TITLE_INDEX_NAME, Query.ComparisonType.LIKE, String.format("%%%s%%", filter));
                 PrefUtils.sortNoteQuery(query, requireContext(), true);
                 Cursor cursor = query.execute();


### PR DESCRIPTION
### Fix
Update the list of notes returned in the internote link autocomplete popup menu to exclude trashed notes in order to mimic other SImplenote platforms.

### Test
1. Tap the ***New Note*** floating action button.
2. Enter text to create a note with a unique title.
3. Tap ellipsis/overflow action in app bar.
4. Tap ***Trash*** option in ellipsis/overflow menu.
5. Open navigation drawer.
6. Tap ***Trash*** item in navigation drawer.
7. Notice note from Step 2 is shown.
8. Open navigation drawer.
9. Tap ***All Notes*** item navigation drawer.
10. Tap any note in list.
11. Enter `[` character followed by text from Step 2.
12. Notice autocomplete popup menu list is empty and hidden.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.