### PR TITLE
Make sure that the cursor doesn't get hidden behind the search results bar

### DIFF
--- a/Simplenote/src/main/res/layout/activity_note_editor.xml
+++ b/Simplenote/src/main/res/layout/activity_note_editor.xml
@@ -37,7 +37,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <FrameLayout
+    <LinearLayout
         android:id="@+id/main_parent_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -49,7 +49,8 @@
         <com.automattic.simplenote.widgets.NoteEditorViewPager
             android:id="@+id/pager"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="0dp"
+            android:layout_weight="1">
         </com.automattic.simplenote.widgets.NoteEditorViewPager>
 
         <RelativeLayout
@@ -143,6 +144,6 @@
 
         </RelativeLayout>
 
-    </FrameLayout>
+    </LinearLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
### Fix
Currently when opening a note from the search results, a part of its fragment goes behind the search results bar, which causes the cursor to be hidden behind the bar if the last line is clicked.
The fix replaces the FrameLayout by a LinearLayout, and gives the main content a layout_weight of 1, to resize when the results bar gets displayed.

### Test
1. Search for a term with a match in a note
2. Tap to open the note (the note should be long enough to be scrollable when the keyboard is shown)
3. Tap on the bottom line of the note
4. Confirm that the cursor is visible.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
