### PR TITLE
Fix the issue of adding checkboxes to long lines

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,6 @@
 2.15
 -----
 * Added permanently deleting notes from trash individually [https://github.com/Automattic/simplenote-android/pull/1224]
-* Fixed a bug with adding checkboxes to long lines [https://github.com/Automattic/simplenote-android/pull/1237]
  
 2.14
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.15
 -----
 * Added permanently deleting notes from trash individually [https://github.com/Automattic/simplenote-android/pull/1224]
+* Fixed a bug with adding checkboxes to long lines [https://github.com/Automattic/simplenote-android/pull/1237]
  
 2.14
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -191,13 +191,11 @@ public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView imple
         }
     }
 
-    /**
-     *  Finds the start of line containing the start of selection
-     */
     private int findStartOfLineOfSelection() {
         int position = getSelectionStart();
-        if(position == -1) {
-            position = 0;
+        // getSelectionStart may return -1 if there is no selection nor cursor
+        if (position == -1) {
+            return 0;
         }
         Editable editable = getText();
         for (int i = position - 1; i >= 0; i--) {
@@ -208,16 +206,12 @@ public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView imple
         return 0;
     }
 
-    /**
-     *  Finds the end of line containing the end of selection
-     */
     private int findEndOfLineOfSelection() {
-        int position = getSelectionEnd();
-        if(position == -1) {
-            position = 0;
-        }
+        // getSelectionEnd may return -1 if there is no selection nor cursor
+        // and as the minimum position is 0, use the max value between 0 and getSelectionEnd()
+        int position = Math.max(0, getSelectionEnd());
         Editable editable = getText();
-        for (int i = position; i < editable.length() ; i++) {
+        for (int i = position; i < editable.length(); i++) {
             if (editable.charAt(i) == '\n') {
                 // We return the max here, because when the cursor is at an empty line,
                 // i-1 would point to the start of line

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -191,28 +191,45 @@ public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView imple
         }
     }
 
-    // Returns the line position of the text cursor
-    private int getCurrentCursorLine() {
-        int selectionStart = getSelectionStart();
-        Layout layout = getLayout();
-
-        if (!(selectionStart == -1)) {
-            return layout.getLineForOffset(selectionStart);
+    /**
+     *  Finds the start of line containing the start of selection
+     */
+    private int findStartOfLineOfSelection() {
+        int position = getSelectionStart();
+        if(position == -1) {
+            position = 0;
         }
-
+        Editable editable = getText();
+        for (int i = position - 1; i >= 0; i--) {
+            if (editable.charAt(i) == '\n') {
+                return i + 1;
+            }
+        }
         return 0;
     }
 
-    public void insertChecklist() {
-        int start, end;
-        int lineNumber = getCurrentCursorLine();
-        start = getLayout().getLineStart(lineNumber);
-
-        if (getSelectionEnd() > getSelectionStart() && !selectionIsOnSameLine()) {
-            end = getSelectionEnd();
-        } else {
-            end = getLayout().getLineEnd(lineNumber);
+    /**
+     *  Finds the end of line containing the end of selection
+     */
+    private int findEndOfLineOfSelection() {
+        int position = getSelectionEnd();
+        if(position == -1) {
+            position = 0;
         }
+        Editable editable = getText();
+        for (int i = position; i < editable.length() ; i++) {
+            if (editable.charAt(i) == '\n') {
+                // We return the max here, because when the cursor is at an empty line,
+                // i-1 would point to the start of line
+                return Math.max(i - 1, position);
+            }
+        }
+        return editable.length();
+    }
+
+    public void insertChecklist() {
+        final int start = findStartOfLineOfSelection();
+        final int end = findEndOfLineOfSelection();
 
         SpannableStringBuilder workingString = new SpannableStringBuilder(getText().subSequence(start, end));
         Editable editable = getText();


### PR DESCRIPTION
Fixes #1221 

### Fix
Currently when trying to add checkboxes for long lines (lines that wrapped) it gets added at the wrong position, the cause is the start and end of line used to create the span use the `layout` methods, which are different from the content positions if the line is wrapped.
I added two utility methods to calculate the start of end of line(s) of selection.

### Test
#### 1. Confirm the issue is solved

1. Type a line so long that it wraps
2. Put the cursor inside the line, or select a portion
2. Tap the checkbox button
3. Confirm that a checkbox is added at the beginning of the line

#### 2. Non regression
Smoke test the checkbox feature, and confirm that it works as expected.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
RELEASE-NOTES.txt` was updated in 4eda620591492b26121ec90077004a085200a736 with:
> Fixed a bug with adding checkboxes to long lines
