### PR TITLE
Issue/1222 long tag drawer

### DIFF
--- a/Simplenote/src/main/res/layout/activity_notes.xml
+++ b/Simplenote/src/main/res/layout/activity_notes.xml
@@ -43,7 +43,8 @@
         android:layout_height="match_parent"
         android:layout_width="wrap_content"
         app:insetForeground="@android:color/transparent"
-        app:itemShapeFillColor="?attr/drawerBackgroundSelector">
+        app:itemShapeFillColor="?attr/drawerBackgroundSelector"
+        app:theme="@style/NavigationMenuItem">
     </com.google.android.material.navigation.NavigationView>
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -376,6 +376,10 @@
         <item name="android:textStyle">italic</item>
     </style>
 
+    <style name="NavigationMenuItem">
+        <item name="android:ellipsize">end</item>
+    </style>
+
     <style name="PasscodeEditTextStyle">
         <item name="android:background">@android:color/transparent</item>
         <item name="android:layout_margin">@dimen/padding_large</item>


### PR DESCRIPTION
### Fix
Add a style with the `ellipsize` attribute as a theme to the navigation view in order to show an ellipsis at the end of long tags in the navigation drawer.  This is one part of https://github.com/Automattic/simplenote-android/issues/1222.  See the screenshots below for illustration.

![1222_long_tag_drawer](https://user-images.githubusercontent.com/3827611/102291875-44663c00-3f01-11eb-904c-200cc16cbc7b.png)

### Test
1. Create a tag with about fifty characters or more.
2. Open the navigation drawer.
3. Notice tag from Step 1 has an ellipsis at the end.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.