### PR TITLE
Fix search of terms containing dash character

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
@@ -97,7 +97,10 @@ public class SearchTokenizer {
                 continue;
             }
 
-            if (current == HYPHEN && (!inStrictTerm || quoteChar == SINGLE_QUOTE)) {
+            if (current == HYPHEN
+                    && last != SPACE
+                    && position != 0
+                    && (!inStrictTerm || quoteChar == SINGLE_QUOTE)) {
                 String tempQuery = query.toString();
                 int tokenStartIndex = tempQuery.lastIndexOf(SPACE, tempQuery.indexOf(last));
                 query.insert(Math.max(0, tokenStartIndex + 1), DOUBLE_QUOTE);
@@ -123,6 +126,7 @@ public class SearchTokenizer {
         // close the strict term
         if (inStrictTerm) query.append(quoteChar);
         if (inTerm && !inStrictTerm && !isLiteral) query.append(GLOB);
+        if (hasHyphen) query.append(DOUBLE_QUOTE);
 
         return query.toString();
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
@@ -11,6 +11,7 @@ public class SearchTokenizer {
     static public final char GLOB = '*';
     static public final char COLON = ':';
     static public final char ESCAPE = '\\';
+    static public final char HYPHEN = '-';
 
     private String mRawQuery;
 
@@ -42,6 +43,8 @@ public class SearchTokenizer {
 
         // if the previous char was an escape char
         boolean isEscaped = false;
+
+        boolean hasHyphen = false;
 
         // the current character
         char current = '\0', last, quoteChar = '\0';
@@ -94,10 +97,21 @@ public class SearchTokenizer {
                 continue;
             }
 
+            if (current == HYPHEN && (!inStrictTerm || quoteChar == SINGLE_QUOTE)) {
+                String tempQuery = query.toString();
+                int tokenStartIndex = tempQuery.lastIndexOf(SPACE, tempQuery.indexOf(last));
+                query.insert(Math.max(0, tokenStartIndex + 1), DOUBLE_QUOTE);
+                query.append(current);
+                hasHyphen = true;
+                continue;
+            }
+
             if (current == SPACE) {
                 if (inTerm && !isLiteral) query.append(GLOB);
+                if (hasHyphen) query.append(DOUBLE_QUOTE);
                 query.append(current);
                 inTerm = false;
+                hasHyphen = false;
                 continue;
             }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
@@ -97,10 +97,7 @@ public class SearchTokenizer {
                 continue;
             }
 
-            if (current == HYPHEN
-                    && last != SPACE
-                    && position != 0
-                    && (!inStrictTerm || quoteChar == SINGLE_QUOTE)) {
+            if (current == HYPHEN && last != SPACE && position != 0) {
                 // If we have a hyphen character between two terms, with no space between them
                 String space = Character.toString(SPACE);
                 String lastCharacter = Character.toString(last);

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
@@ -101,8 +101,9 @@ public class SearchTokenizer {
                     && last != SPACE
                     && position != 0
                     && (!inStrictTerm || quoteChar == SINGLE_QUOTE)) {
-                String tempQuery = query.toString();
-                int tokenStartIndex = tempQuery.lastIndexOf(SPACE, tempQuery.indexOf(last));
+                String space = Character.toString(SPACE);
+                String lastCharacter = Character.toString(last);
+                int tokenStartIndex = query.lastIndexOf(space, query.indexOf(lastCharacter));
                 query.insert(Math.max(0, tokenStartIndex + 1), DOUBLE_QUOTE);
                 query.append(current);
                 hasHyphen = true;

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
@@ -101,6 +101,7 @@ public class SearchTokenizer {
                     && last != SPACE
                     && position != 0
                     && (!inStrictTerm || quoteChar == SINGLE_QUOTE)) {
+                // If we have a hyphen character between two terms, with no space between them
                 String space = Character.toString(SPACE);
                 String lastCharacter = Character.toString(last);
                 int tokenStartIndex = query.lastIndexOf(space, query.indexOf(lastCharacter));


### PR DESCRIPTION
Fixes #1190 

### Fix
Searching for terms that include the dash character are not working currently, while they work on other platforms.
The cause is that Simperium uses FTS3 for the full text search, and the dash character is a special character that translates to NOT:
> The NOT operator (or, if using the standard syntax, a unary "-" operator)
https://www.sqlite.org/fts3.html#section_3_2

To fix this, the term including the dash character has to be converted to a Phrase query, which means enclosed in double quotation.
The fix impacts only the situation where the dash is between two words, but we are keeping the logic to exclude terms preceded by a dash.

### Test
#### Issue fix:

1. Go to a new or existing note and add the text 16-3
2. Tap on search and search for 16-3
3. Make sure that the note is part of the search results.

#### Exclude the words preceded by a dash

1. Go to a new or existing note and add the text 16-3
2. Tap on search and search for 16 -3
3. Make sure that the note is not part of the search results.

#### Non regression:
Smoke test the search feature

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.