### PR TITLE
Add Heartbeat Listener

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
-    implementation 'com.simperium.android:simperium:0.9.14'
+    implementation 'com.simperium.android:simperium:0.9.16'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.2'
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -35,24 +35,23 @@ import org.wordpress.passcodelock.AppLockManager;
 import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
 
 public class Simplenote extends Application implements HeartbeatListener {
-    private static final long HEARTBEAT_TIMEOUT =  WebSocketManager.HEARTBEAT_INTERVAL * 2;
-    private static final int TEN_SECONDS_MILLIS = 10000;
-
-    // log tag
-    public static final String TAG = "Simplenote";
-
-    // intent IDs
-    public static final int INTENT_PREFERENCES = 1;
-    public static final int INTENT_EDIT_NOTE = 2;
     public static final String DELETED_NOTE_ID = "deletedNoteId";
     public static final String SELECTED_NOTE_ID = "selectedNoteId";
+    public static final String TAG = "Simplenote";
+    public static final int INTENT_EDIT_NOTE = 2;
+    public static final int INTENT_PREFERENCES = 1;
+
     private static final String AUTH_PROVIDER = "simplenote.com";
-    private Simperium mSimperium;
+    private static final int TEN_SECONDS_MILLIS = 10000;
+    private static final long HEARTBEAT_TIMEOUT =  WebSocketManager.HEARTBEAT_INTERVAL * 2;
+
+    private static Bucket<Preferences> mPreferencesBucket;
+
     private Bucket<Note> mNotesBucket;
     private Bucket<Tag> mTagsBucket;
     private Handler mHeartbeatHandler;
     private Runnable mHeartbeatRunnable;
-    private static Bucket<Preferences> mPreferencesBucket;
+    private Simperium mSimperium;
 
     public void onCreate() {
         super.onCreate();

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -73,6 +73,7 @@ public class Simplenote extends Application implements HeartbeatListener {
         mHeartbeatRunnable = new Runnable() {
             @Override
             public void run() {
+                AppLog.add(Type.NETWORK, "Heartbeat stopped");
                 mHeartbeatHandler.removeCallbacks(mHeartbeatRunnable);
                 mHeartbeatHandler.postDelayed(mHeartbeatRunnable, HEARTBEAT_TIMEOUT);
             }
@@ -107,6 +108,7 @@ public class Simplenote extends Application implements HeartbeatListener {
 
     @Override
     public void onBeat() {
+        AppLog.add(Type.NETWORK, "Heartbeat received");
         mHeartbeatHandler.removeCallbacks(mHeartbeatRunnable);
         mHeartbeatHandler.postDelayed(mHeartbeatRunnable, HEARTBEAT_TIMEOUT);
     }


### PR DESCRIPTION
### Fix
Add a heartbeat listener to the Simplenote application class for the Simperium WebSocket.  When a heartbeat is received or stopped, an item is added to the application log.  The frequency of the heartbeat is `WebSocketManager.HEARTBEAT_INTERVAL`, which is ten seconds.  A stopped heartbeat is determined by the heartbeat timeout, which is double `WebSocketManager.HEARTBEAT_INTERVAL` or twenty seconds.

### Test
1. Open app.
2. Wait twenty or thirty seconds.
3. Enable airplane mode.
4. Wait forty to fifty seconds.
5. Open navigation drawer.
6. Tap ***Settings*** item in navigation drawer.
7. Tap ***Send logs*** item under ***More*** section.
8. Choose option in ***Share*** sheet to view application log.
9. Notice ***NETWORK: Heartbeat received*** and ***NETWORK: Heartbeat stopped*** items in application log.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.