### PR TITLE
Select next note after trashing/restoring a note in tablet landscape

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -266,12 +266,9 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     }
 
     public void updateSelectionAfterTrashAction() {
-        updateSelectionAfterTrashAction(getSelectedNotesPositions());
-    }
-
-    private void updateSelectionAfterTrashAction(List<Integer> deletedNotesPositions) {
         if (DisplayUtils.isLargeScreenLandscape(getActivity())) {
             // Try to find the nearest note to the first deleted item
+            List<Integer> deletedNotesPositions = getSelectedNotesPositions();
             int firstDeletedNote = deletedNotesPositions.get(0);
             int positionToSelect = -1;
             // Loop through the notes below

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -205,6 +205,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         inflater.inflate(R.menu.bulk_edit, menu);
         DrawableUtils.tintMenuWithAttribute(getActivity(), menu, R.attr.actionModeTextColor);
         mActionMode = actionMode;
+        requireActivity().getWindow().setStatusBarColor(ThemeUtils.getColorFromAttribute(requireContext(), R.attr.mainBackgroundColor));
         return true;
     }
 
@@ -313,6 +314,15 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                 notesActivity.showDetailPlaceholder();
             }
         }
+        new Handler().postDelayed(
+            new Runnable() {
+                @Override
+                public void run() {
+                    requireActivity().getWindow().setStatusBarColor(getResources().getColor(android.R.color.transparent, requireActivity().getTheme()));
+                }
+            },
+            requireContext().getResources().getInteger(android.R.integer.config_longAnimTime)
+        );
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -309,7 +309,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         if (getActivity() != null) {
             NotesActivity notesActivity = (NotesActivity) getActivity();
             setActivateOnItemClick(DisplayUtils.isLargeScreenLandscape(notesActivity));
-            if (mSelectedNoteId == null){
+            if (mSelectedNoteId == null) {
                 notesActivity.showDetailPlaceholder();
             }
         }
@@ -356,7 +356,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         NotesActivity notesActivity = (NotesActivity) requireActivity();
 
         if (ACTION_NEW_NOTE.equals(notesActivity.getIntent().getAction()) &&
-                !notesActivity.userIsUnauthorized()){
+            !notesActivity.userIsUnauthorized()) {
             //if user tap on "app shortcut", create a new note
             createNewNote("", "new_note_shortcut");
         }
@@ -411,8 +411,8 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             @Override
             public void onClick(View v) {
                 Context context = ThemeUtils.getStyle(requireContext()) == R.style.Style_Sepia ?
-                        new ContextThemeWrapper(requireContext(), R.style.ToolbarTheme_Popup_Sepia) :
-                        mSortOrder.getContext();
+                    new ContextThemeWrapper(requireContext(), R.style.ToolbarTheme_Popup_Sepia) :
+                    mSortOrder.getContext();
                 PopupMenu popup = new PopupMenu(context, mSortOrder, Gravity.START);
                 MenuInflater inflater = popup.getMenuInflater();
                 inflater.inflate(R.menu.search_sort, popup.getMenu());
@@ -531,7 +531,8 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         );
     }
 
-    private @StringRes int getSortOrderText() {
+    private @StringRes
+    int getSortOrderText() {
         switch (PrefUtils.getIntPref(requireContext(), PrefUtils.PREF_SORT_ORDER)) {
             case ALPHABETICAL_ASCENDING:
             case ALPHABETICAL_DESCENDING:
@@ -601,7 +602,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         }
     }
 
-    public void createNewNote(String title, String label){
+    public void createNewNote(String title, String label) {
         if (!isAdded()) {
             return;
         }
@@ -773,8 +774,9 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     }
 
     public void refreshList(boolean fromNav) {
-        if (mRefreshListTask != null && mRefreshListTask.getStatus() != AsyncTask.Status.FINISHED)
+        if (mRefreshListTask != null && mRefreshListTask.getStatus() != AsyncTask.Status.FINISHED) {
             mRefreshListTask.cancel(true);
+        }
 
         mRefreshListTask = new RefreshListTask(this);
         mRefreshListTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, fromNav);
@@ -1055,10 +1057,12 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
          * Callback for when action mode is created.
          */
         void onActionModeCreated();
+
         /**
          * Callback for when action mode is destroyed.
          */
         void onActionModeDestroyed();
+
         /**
          * Callback for when a note has been selected.
          */
@@ -1089,7 +1093,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         private ObjectCursor<Note> mCursor;
 
         private SearchSnippetFormatter.SpanFactory mSnippetHighlighter = new TextHighlighter(requireActivity(),
-                R.attr.listSearchHighlightForegroundColor, R.attr.listSearchHighlightBackgroundColor);
+            R.attr.listSearchHighlightForegroundColor, R.attr.listSearchHighlightBackgroundColor);
 
         public NotesCursorAdapter(Context context, ObjectCursor<Note> c, int flags) {
             super(context, c, flags);
@@ -1134,10 +1138,11 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                 holder.mDate.setTextSize(TypedValue.COMPLEX_UNIT_SP, mPreviewFontSize);
             }
 
-            if (position == getListView().getCheckedItemPosition())
+            if (position == getListView().getCheckedItemPosition()) {
                 view.setActivated(true);
-            else
+            } else {
                 view.setActivated(false);
+            }
 
             // for performance reasons we are going to get indexed values
             // from the cursor instead of instantiating the entire bucket object
@@ -1158,15 +1163,15 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
             if (TextUtils.isEmpty(title)) {
                 SpannableString newNoteString = new SpannableString(getString(R.string.new_note_list));
-                newNoteString.setSpan(new TextAppearanceSpan(getActivity(),R.style.UntitledNoteAppearance),
-                        0,
-                        newNoteString.length(),
-                        SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE
+                newNoteString.setSpan(new TextAppearanceSpan(getActivity(), R.style.UntitledNoteAppearance),
+                    0,
+                    newNoteString.length(),
+                    SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE
                 );
                 newNoteString.setSpan(new AbsoluteSizeSpan(mTitleFontSize, true),
-                        0,
-                        newNoteString.length(),
-                        SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE
+                    0,
+                    newNoteString.length(),
+                    SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE
                 );
                 holder.mTitle.setText(newNoteString);
             } else {
@@ -1191,14 +1196,14 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
                 try {
                     holder.mContent.setText(SearchSnippetFormatter.formatString(
-                            getContext(),
-                            snippet,
-                            mSnippetHighlighter,
-                            R.color.text_title_disabled));
+                        getContext(),
+                        snippet,
+                        mSnippetHighlighter,
+                        R.color.text_title_disabled));
                     holder.mTitle.setText(SearchSnippetFormatter.formatString(
-                            getContext(),
-                            title,
-                            mSnippetHighlighter, ThemeUtils.getThemeTextColorId(getContext())));
+                        getContext(),
+                        title,
+                        mSnippetHighlighter, ThemeUtils.getThemeTextColorId(getContext())));
                 } catch (NullPointerException e) {
                     title = StrUtils.notNullStr(mCursor.getString(mCursor.getColumnIndex(Note.TITLE_INDEX_NAME)));
                     holder.mTitle.setText(title);
@@ -1208,9 +1213,9 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             } else if (!mIsCondensedNoteList) {
                 String contentPreview = mCursor.getString(mCursor.getColumnIndex(Note.CONTENT_PREVIEW_INDEX_NAME));
 
-                if (title == null || title.equals(contentPreview) || title.equals(getString(R.string.new_note_list)))
+                if (title == null || title.equals(contentPreview) || title.equals(getString(R.string.new_note_list))) {
                     holder.mContent.setVisibility(View.GONE);
-                else {
+                } else {
                     holder.mContent.setText(contentPreview);
                     SpannableStringBuilder checklistString = new SpannableStringBuilder(contentPreview);
                     checklistString = (SpannableStringBuilder) ChecklistUtils.addChecklistSpansForRegexAndColor(

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -296,9 +296,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                 mSelectedNoteId = noteToSelect.getSimperiumKey();
             } else {
                 // The list of notes is empty
-                if (getActivity() != null) {
-                    ((NotesActivity) requireActivity()).showDetailPlaceholder();
-                }
+                ((NotesActivity) requireActivity()).showDetailPlaceholder();
             }
         }
     }
@@ -1714,9 +1712,11 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                 notesActivity.showUndoBarWithNoteIds(mDeletedNoteIds);
             }
 
-            fragment.updateSelectionAfterTrashAction();
-            fragment.mActionMode.finish();
-            fragment.refreshList();
+            if (!fragment.isDetached()) {
+                fragment.updateSelectionAfterTrashAction();
+                fragment.mActionMode.finish();
+                fragment.refreshList();
+            }
         }
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -253,6 +253,23 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         return links.toString();
     }
 
+    public List<Integer> getSelectedNotesPositions() {
+        SparseBooleanArray checkedPositions = getListView().getCheckedItemPositions();
+        ArrayList<Integer> positions = new ArrayList<>();
+
+        for (int i = 0; i < checkedPositions.size(); i++) {
+            if (checkedPositions.valueAt(i)) {
+                positions.add(checkedPositions.keyAt(i) - mList.getHeaderViewsCount());
+            }
+        }
+
+        return positions;
+    }
+
+    public Note getItemAtPosition(int position) {
+        return mNotesAdapter.getItem(position + mList.getHeaderViewsCount());
+    }
+
     @Override
     public void onDestroyActionMode(ActionMode mode) {
         mCallbacks.onActionModeDestroyed();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -309,7 +309,9 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         if (getActivity() != null) {
             NotesActivity notesActivity = (NotesActivity) getActivity();
             setActivateOnItemClick(DisplayUtils.isLargeScreenLandscape(notesActivity));
-            if(mSelectedNoteId == null) notesActivity.showDetailPlaceholder();
+            if (mSelectedNoteId == null){
+                notesActivity.showDetailPlaceholder();
+            }
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1415,7 +1415,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 }
 
                 invalidateOptionsMenu();
-                // Go to NoteEditorActivity if note editing was fullscreen and orientation was switched to portrait
+            // Go to NoteEditorActivity if note editing was fullscreen and orientation was switched to portrait
             } else if (mNoteListFragment.isHidden() && mCurrentNote != null) {
                 onNoteSelected(mCurrentNote.getSimperiumKey(), null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
             }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -101,8 +101,8 @@ import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
 import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
 
 public class NotesActivity extends ThemedAppCompatActivity implements NoteListFragment.Callbacks,
-        User.StatusChangeListener, Simperium.OnUserCreatedListener, UndoBarController.UndoListener,
-        Bucket.Listener<Note> {
+    User.StatusChangeListener, Simperium.OnUserCreatedListener, UndoBarController.UndoListener,
+    Bucket.Listener<Note> {
     public static String TAG_NOTE_LIST = "noteList";
     public static String TAG_NOTE_EDITOR = "noteEditor";
 
@@ -323,7 +323,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         }
 
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-        if(DisplayUtils.isLargeScreenLandscape(this)) {
+        if (DisplayUtils.isLargeScreenLandscape(this)) {
             if (mIsTabletFullscreen) {
                 ft.hide(mNoteListFragment);
             } else {
@@ -384,13 +384,13 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
     private ColorStateList getIconSelector() {
         int[][] states = new int[][] {
-                new int[] { android.R.attr.state_checked}, // checked
-                new int[] {-android.R.attr.state_checked}  // unchecked
+            new int[] {android.R.attr.state_checked}, // checked
+            new int[] {-android.R.attr.state_checked}  // unchecked
         };
 
         int[] colors = new int[] {
-                ThemeUtils.getColorFromAttribute(NotesActivity.this, R.attr.colorAccent),
-                ThemeUtils.getColorFromAttribute(NotesActivity.this, R.attr.toolbarIconColor)
+            ThemeUtils.getColorFromAttribute(NotesActivity.this, R.attr.colorAccent),
+            ThemeUtils.getColorFromAttribute(NotesActivity.this, R.attr.toolbarIconColor)
         };
 
         return new ColorStateList(states, colors);
@@ -399,7 +399,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
     private ColorStateList getTextSelector() {
         int[][] states = new int[][] {
             new int[] {-android.R.attr.state_enabled}, // disabled
-            new int[] { android.R.attr.state_checked}, // checked
+            new int[] {android.R.attr.state_checked}, // checked
             new int[] {-android.R.attr.state_checked}  // unchecked
         };
 
@@ -431,7 +431,9 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                             LIST_TAG_VIEWED,
                             CATEGORY_TAG,
                             "selected_tag_in_navigation_drawer",
-                            new HashMap<String, String>(1){{put("tag", "settings");}}
+                            new HashMap<String, String>(1) {{
+                                put("tag", "settings");
+                            }}
                         );
                         mIsSettingsClicked = true;
                         return false;
@@ -450,11 +452,12 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         mNavigationMenu.add(GROUP_PRIMARY, SETTINGS_ID, Menu.NONE, getString(R.string.settings)).setIcon(R.drawable.ic_settings_24dp).setCheckable(false);
         mTagsAdapter = new TagsAdapter(this, mNotesBucket);
 
-        if (mSelectedTag == null)
+        if (mSelectedTag == null) {
             mSelectedTag = mTagsAdapter.getDefaultItem();
+        }
 
         mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, toolbar, R.string.open_drawer,
-                R.string.close_drawer) {
+            R.string.close_drawer) {
             public void onDrawerClosed(View view) {
                 supportInvalidateOptionsMenu();
 
@@ -522,10 +525,10 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         }
 
         AnalyticsTracker.track(
-                LIST_TAG_VIEWED,
-                CATEGORY_TAG,
-                "selected_tag_in_navigation_drawer",
-                properties
+            LIST_TAG_VIEWED,
+            CATEGORY_TAG,
+            "selected_tag_in_navigation_drawer",
+            properties
         );
 
         setSelectedTagActive();
@@ -586,8 +589,8 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                     // Lock screen activities are enabled again in NoteEditorActivity.onPause()
                     if (AppLockManager.getInstance().isAppLockFeatureEnabled()) {
                         AppLockManager.getInstance().getAppLock().setExemptActivities(
-                                new String[]{"com.automattic.simplenote.NotesActivity",
-                                        "com.automattic.simplenote.NoteEditorActivity"});
+                            new String[] {"com.automattic.simplenote.NotesActivity",
+                                "com.automattic.simplenote.NoteEditorActivity"});
                         AppLockManager.getInstance().getAppLock().setOneTimeTimeout(0);
                     }
                 }
@@ -727,7 +730,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         User user = simperium.getUser();
         boolean isNotAuthorized = user.getStatus().equals(User.Status.NOT_AUTHORIZED);
         return (user.hasAccessToken() && isNotAuthorized) ||
-                (userAccountRequired() && isNotAuthorized);
+            (userAccountRequired() && isNotAuthorized);
     }
 
     public boolean userIsUnauthorized() {
@@ -753,8 +756,9 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
         // restore the search query if on a landscape tablet
         String searchQuery = null;
-        if (DisplayUtils.isLargeScreenLandscape(this) && mSearchView != null)
+        if (DisplayUtils.isLargeScreenLandscape(this) && mSearchView != null) {
             searchQuery = mSearchView.getQuery().toString();
+        }
 
         mSearchMenuItem = menu.findItem(R.id.menu_search);
         mSearchView = (SearchView) mSearchMenuItem.getActionView();
@@ -849,8 +853,9 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         mSearchMenuItem.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
-                if (!mSearchMenuItem.isActionViewExpanded())
+                if (!mSearchMenuItem.isActionViewExpanded()) {
                     showDetailPlaceholder();
+                }
                 return false;
             }
         });
@@ -1073,19 +1078,19 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
             mUndoBarController.setDeletedNoteIds(deletedNoteIds);
             mUndoBarController.showUndoBar(getUndoView(), getString(R.string.note_deleted));
             AnalyticsTracker.track(
-                    LIST_NOTE_DELETED,
-                    CATEGORY_NOTE,
-                    "overflow_menu"
+                LIST_NOTE_DELETED,
+                CATEGORY_NOTE,
+                "overflow_menu"
             );
         } else {
             AnalyticsTracker.track(
-                    EDITOR_NOTE_RESTORED,
-                    CATEGORY_NOTE,
-                    "overflow_menu"
+                EDITOR_NOTE_RESTORED,
+                CATEGORY_NOTE,
+                "overflow_menu"
             );
         }
 
-        if(getNoteListFragment() != null) {
+        if (getNoteListFragment() != null) {
             NoteListFragment fragment = getNoteListFragment();
             if (DisplayUtils.isLargeScreenLandscape(this)) {
                 fragment.updateSelectionAfterTrashAction();
@@ -1097,8 +1102,8 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         if (mInvalidateOptionsMenuHandler != null) {
             mInvalidateOptionsMenuHandler.removeCallbacks(mInvalidateOptionsMenuRunnable);
             mInvalidateOptionsMenuHandler.postDelayed(
-                    mInvalidateOptionsMenuRunnable,
-                    getResources().getInteger(android.R.integer.config_shortAnimTime)
+                mInvalidateOptionsMenuRunnable,
+                getResources().getInteger(android.R.integer.config_shortAnimTime)
             );
         }
     }
@@ -1410,7 +1415,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 }
 
                 invalidateOptionsMenu();
-            // Go to NoteEditorActivity if note editing was fullscreen and orientation was switched to portrait
+                // Go to NoteEditorActivity if note editing was fullscreen and orientation was switched to portrait
             } else if (mNoteListFragment.isHidden() && mCurrentNote != null) {
                 onNoteSelected(mCurrentNote.getSimperiumKey(), null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
             }
@@ -1633,8 +1638,8 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
     private View getUndoView() {
         View undoView = mFragmentsContainer;
         if (!DisplayUtils.isLargeScreenLandscape(this) &&
-                getNoteListFragment() != null &&
-                getNoteListFragment().getRootView() != null) {
+            getNoteListFragment() != null &&
+            getNoteListFragment().getRootView() != null) {
             undoView = getNoteListFragment().getRootView();
         }
 
@@ -1645,8 +1650,8 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         if (mUndoBarController != null) {
             mUndoBarController.setDeletedNoteIds(noteIds);
             mUndoBarController.showUndoBar(
-                    getUndoView(),
-                    getResources().getQuantityString(R.plurals.trashed_notes, noteIds.size(), noteIds.size())
+                getUndoView(),
+                getResources().getQuantityString(R.plurals.trashed_notes, noteIds.size(), noteIds.size())
             );
         }
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1084,13 +1084,18 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
             );
         }
 
-        // If we just deleted/restored the active note, show the placeholder
-        if (mCurrentNote != null && mCurrentNote.getSimperiumKey().equals(note.getSimperiumKey())) {
-            showDetailPlaceholder();
-        }
-
         NoteListFragment fragment = getNoteListFragment();
         if (fragment != null) {
+            // Try to find the next note in the list to select it
+            int deletedNotePosition = fragment.getSelectedNotesPositions().get(0);
+            if( deletedNotePosition < fragment.mNotesAdapter.getCount() - 1) {
+                Note nextNote = fragment.getItemAtPosition(deletedNotePosition + 1);
+                fragment.setNoteSelected(nextNote.getSimperiumKey());
+                if(mNoteEditorFragment != null) mNoteEditorFragment.setNote(nextNote.getSimperiumKey());
+            } else {
+                // The deleted note is the last in the list
+                showDetailPlaceholder();
+            }
             fragment.getPrefs();
             fragment.refreshList();
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1086,14 +1086,21 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
         NoteListFragment fragment = getNoteListFragment();
         if (fragment != null) {
-            // Try to find the next note in the list to select it
+            // Try to find the next or previous note in the list to select it
             int deletedNotePosition = fragment.getSelectedNotesPositions().get(0);
-            if( deletedNotePosition < fragment.mNotesAdapter.getCount() - 1) {
+            if (deletedNotePosition < fragment.mNotesAdapter.getCount() - 1) {
                 Note nextNote = fragment.getItemAtPosition(deletedNotePosition + 1);
                 fragment.setNoteSelected(nextNote.getSimperiumKey());
-                if(mNoteEditorFragment != null) mNoteEditorFragment.setNote(nextNote.getSimperiumKey());
+                if (mNoteEditorFragment != null)
+                    mNoteEditorFragment.setNote(nextNote.getSimperiumKey());
+            } else if (deletedNotePosition > 0) {
+                // The deleted note is the latest in the list, select the previous one
+                Note previousNote = fragment.getItemAtPosition(deletedNotePosition - 1);
+                fragment.setNoteSelected(previousNote.getSimperiumKey());
+                if (mNoteEditorFragment != null)
+                    mNoteEditorFragment.setNote(previousNote.getSimperiumKey());
             } else {
-                // The deleted note is the last in the list
+                // The list of notes is empty
                 showDetailPlaceholder();
             }
             fragment.getPrefs();

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
@@ -75,7 +75,12 @@ public class NoteUtils {
 
                             // Show empty placeholder for large devices in landscape.
                             if (activity instanceof NotesActivity) {
-                                ((NotesActivity) activity).showDetailPlaceholder();
+                                NotesActivity notesActivity = (NotesActivity) activity;
+                                if(notesActivity.getNoteListFragment() != null) {
+                                    notesActivity.getNoteListFragment().updateSelectionAfterTrashAction();
+                                } else {
+                                    ((NotesActivity) activity).showDetailPlaceholder();
+                                }
                             // Close editor for small devices and large devices in portrait.
                             } else if (activity instanceof NoteEditorActivity) {
                                 ((NoteEditorActivity) activity).finish();

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
@@ -79,7 +79,7 @@ public class NoteUtils {
                                 if(notesActivity.getNoteListFragment() != null) {
                                     notesActivity.getNoteListFragment().updateSelectionAfterTrashAction();
                                 } else {
-                                    ((NotesActivity) activity).showDetailPlaceholder();
+                                    notesActivity.showDetailPlaceholder();
                                 }
                             // Close editor for small devices and large devices in portrait.
                             } else if (activity instanceof NoteEditorActivity) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
@@ -25,10 +25,10 @@ public class NoteUtils {
             note.save();
 
             AnalyticsTracker.track(
-                    isPinned ? AnalyticsTracker.Stat.EDITOR_NOTE_PINNED :
-                            AnalyticsTracker.Stat.EDITOR_NOTE_UNPINNED,
-                    AnalyticsTracker.CATEGORY_NOTE,
-                    "pin_button"
+                isPinned ? AnalyticsTracker.Stat.EDITOR_NOTE_PINNED :
+                    AnalyticsTracker.Stat.EDITOR_NOTE_UNPINNED,
+                AnalyticsTracker.CATEGORY_NOTE,
+                "pin_button"
             );
         }
     }
@@ -45,9 +45,9 @@ public class NoteUtils {
             activity.setResult(Activity.RESULT_OK, resultIntent);
 
             AnalyticsTracker.track(
-                    AnalyticsTracker.Stat.EDITOR_NOTE_DELETED,
-                    AnalyticsTracker.CATEGORY_NOTE,
-                    "trash_menu_item"
+                AnalyticsTracker.Stat.EDITOR_NOTE_DELETED,
+                AnalyticsTracker.CATEGORY_NOTE,
+                "trash_menu_item"
             );
         }
     }
@@ -76,12 +76,12 @@ public class NoteUtils {
                             // Show empty placeholder for large devices in landscape.
                             if (activity instanceof NotesActivity) {
                                 NotesActivity notesActivity = (NotesActivity) activity;
-                                if(notesActivity.getNoteListFragment() != null) {
+                                if (notesActivity.getNoteListFragment() != null) {
                                     notesActivity.getNoteListFragment().updateSelectionAfterTrashAction();
                                 } else {
                                     notesActivity.showDetailPlaceholder();
                                 }
-                            // Close editor for small devices and large devices in portrait.
+                                // Close editor for small devices and large devices in portrait.
                             } else if (activity instanceof NoteEditorActivity) {
                                 ((NoteEditorActivity) activity).finish();
                             }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/NoteUtils.java
@@ -81,7 +81,7 @@ public class NoteUtils {
                                 } else {
                                     notesActivity.showDetailPlaceholder();
                                 }
-                                // Close editor for small devices and large devices in portrait.
+                            // Close editor for small devices and large devices in portrait.
                             } else if (activity instanceof NoteEditorActivity) {
                                 ((NoteEditorActivity) activity).finish();
                             }

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- APPLICATION -->
     <color name="blue">@color/simplenote_blue_50</color>
@@ -234,5 +234,8 @@
     <color name="yellow_80">#4f3500</color>
     <color name="yellow_90">#332200</color>
     <color name="yellow_100">#1c1300</color>
+
+    <!-- Update the status guard color to avoid a black status bar on ActionMode -->
+    <color name="abc_input_method_navigation_guard" tools:override="true">@android:color/transparent</color>
 
 </resources>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
     <!-- APPLICATION -->
     <color name="blue">@color/simplenote_blue_50</color>
@@ -234,4 +234,5 @@
     <color name="yellow_80">#4f3500</color>
     <color name="yellow_90">#332200</color>
     <color name="yellow_100">#1c1300</color>
+
 </resources>

--- a/Simplenote/src/main/res/values/colors.xml
+++ b/Simplenote/src/main/res/values/colors.xml
@@ -234,8 +234,4 @@
     <color name="yellow_80">#4f3500</color>
     <color name="yellow_90">#332200</color>
     <color name="yellow_100">#1c1300</color>
-
-    <!-- Update the status guard color to avoid a black status bar on ActionMode -->
-    <color name="abc_input_method_navigation_guard" tools:override="true">@android:color/transparent</color>
-
 </resources>


### PR DESCRIPTION
Fixes #1021 

### Fix
This PR adds implementation of the bellow suggestions:
- Select the note below a recently trashed note.
- Select the note below a recently restored note in trash view.

The goal is to offer feature parity with other platforms.

![trash_select](https://user-images.githubusercontent.com/1657201/102495624-9aa8bb80-4076-11eb-8570-b66b35f8e160.gif)


### Test
#### Selecting the note below the trashed note:
1. Open the notes list using a tablet in landscape mode
2. Open a note that's not the latest in the list.
3. Trash the note.
4. Make sure that the note below is selected.

#### Selecting the note above the trashed note:
1. Open the notes list using a tablet in landscape mode
2. Open a latest note in the list.
3. Trash the note.
4. Make sure that the note above is selected.

#### Trashing the latest note:
1. Open the notes list using a tablet in landscape mode
2. Trash all note except one, and open it.
3. Trash the note.
4. Make sure that the note placeholder is shown.

**Important** Please try to run the tests on a Chromebook too, as I don't have one to test.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.