### PR TITLE
Update Padding Preference

### DIFF
--- a/Simplenote/src/main/res/layout/preference_button.xml
+++ b/Simplenote/src/main/res/layout/preference_button.xml
@@ -6,7 +6,7 @@
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
     android:paddingEnd="@dimen/padding_preference_end"
-    android:paddingStart="@dimen/padding_preference"
+    android:paddingStart="@dimen/padding_preference_start"
     tools:context=".PreferencesActivity">
 
     <TextView

--- a/Simplenote/src/main/res/layout/preference_button.xml
+++ b/Simplenote/src/main/res/layout/preference_button.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
-    android:paddingEnd="@dimen/padding_large"
+    android:paddingEnd="@dimen/padding_preference_end"
     android:paddingStart="@dimen/padding_preference"
     tools:context=".PreferencesActivity">
 

--- a/Simplenote/src/main/res/layout/preference_default.xml
+++ b/Simplenote/src/main/res/layout/preference_default.xml
@@ -7,7 +7,7 @@
     android:layout_width="match_parent"
     android:paddingBottom="@dimen/padding_large"
     android:paddingEnd="@dimen/padding_preference_end"
-    android:paddingStart="@dimen/padding_preference"
+    android:paddingStart="@dimen/padding_preference_start"
     android:paddingTop="@dimen/padding_large">
 
     <TextView

--- a/Simplenote/src/main/res/layout/preference_default.xml
+++ b/Simplenote/src/main/res/layout/preference_default.xml
@@ -6,7 +6,7 @@
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
     android:paddingBottom="@dimen/padding_large"
-    android:paddingEnd="@dimen/padding_large"
+    android:paddingEnd="@dimen/padding_preference_end"
     android:paddingStart="@dimen/padding_preference"
     android:paddingTop="@dimen/padding_large">
 

--- a/Simplenote/src/main/res/values-large/dimens.xml
+++ b/Simplenote/src/main/res/values-large/dimens.xml
@@ -4,5 +4,6 @@
 
     <!-- SIZE -->
     <dimen name="content_width">560dp</dimen>
+    <dimen name="padding_preference">80dp</dimen>
 
 </resources>

--- a/Simplenote/src/main/res/values-large/dimens.xml
+++ b/Simplenote/src/main/res/values-large/dimens.xml
@@ -5,6 +5,6 @@
     <!-- SIZE -->
     <dimen name="content_width">560dp</dimen>
     <dimen name="padding_preference_end">24dp</dimen>
-    <dimen name="padding_preference">80dp</dimen>
+    <dimen name="padding_preference_start">80dp</dimen>
 
 </resources>

--- a/Simplenote/src/main/res/values-large/dimens.xml
+++ b/Simplenote/src/main/res/values-large/dimens.xml
@@ -4,6 +4,7 @@
 
     <!-- SIZE -->
     <dimen name="content_width">560dp</dimen>
+    <dimen name="padding_preference_end">24dp</dimen>
     <dimen name="padding_preference">80dp</dimen>
 
 </resources>

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -12,7 +12,7 @@
     <dimen name="padding_extra_extra_large">24dp</dimen>
     <dimen name="padding_error">48dp</dimen>
     <dimen name="padding_preference_end">@dimen/padding_large</dimen>
-    <dimen name="padding_preference">72dp</dimen>
+    <dimen name="padding_preference_start">72dp</dimen>
     <dimen name="padding_suggestion">40dp</dimen>
 
     <!-- http://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-keylines-spacing -->

--- a/Simplenote/src/main/res/values/dimens.xml
+++ b/Simplenote/src/main/res/values/dimens.xml
@@ -11,6 +11,7 @@
     <dimen name="padding_extra_large">20dp</dimen>
     <dimen name="padding_extra_extra_large">24dp</dimen>
     <dimen name="padding_error">48dp</dimen>
+    <dimen name="padding_preference_end">@dimen/padding_large</dimen>
     <dimen name="padding_preference">72dp</dimen>
     <dimen name="padding_suggestion">40dp</dimen>
 


### PR DESCRIPTION
### Fix
Update the padding of custom preference items for large devices.  The start and end padding on small devices remains unchanged.  The `padding_preference` (72dp) and `padding_large` (16dp) dimensions were used for the start and end padding of custom preference items for both small and large devices, which did not line up with preferences on large devices.  Currently, the only custom preference is the **_Membership_** item under the **_Account_** section.  See the screenshots below for illustration.

![update_padding_preference_landscape](https://user-images.githubusercontent.com/3827611/102573138-fd1baf00-40aa-11eb-86f4-15095ea1d4ff.png)

![update_padding_preference_portrait](https://user-images.githubusercontent.com/3827611/102573141-fe4cdc00-40aa-11eb-9fe5-cfa506f38727.png)

### Test
Since the dimensions for small devices remain unchanged and this pull request only affects large devices, it's only required to perform the following steps with a large device (e.g. tablet).  For complete test coverage, the steps can be done on a small device (e.g. phone) as well.
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Notice ***Membership*** item under ***Account*** setting is vertically aligned with other preferences.
4. Rotate device ninety degrees.
5. Notice ***Membership*** item under ***Account*** setting is vertically aligned with other preferences.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.