### PR TITLE
Make the note preview mobile friendly

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -275,6 +275,7 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
     public static String getMarkdownFormattedContent(String cssContent, String sourceContent) {
         String header = "<html><head>" +
                 "<link href=\"https://fonts.googleapis.com/css?family=Noto+Serif\" rel=\"stylesheet\">" +
+                "<meta name=\"viewport\" content=\"width=device-width,minimum-scale=1,initial-scale=1\">\n" +
                 cssContent + "</head><body>";
 
         String parsedMarkdown = new AndDown().markdownToHtml(


### PR DESCRIPTION
### Fix
When previewing a note that has a large table in portrait, then rotate to landscape, the webview content gets zoomed in.
To fix this, I added the viewport meta to make it mobile friendly, and specify the scale options, I applied the same options we use for the note publish page: https://github.com/Automattic/simplenote-gae/blob/trunk/site/publish.html#L9

| Before | After |
| :-: | :-: |
| Portrait <br /> ![Screenshot_20201221_120840](https://user-images.githubusercontent.com/1657201/102771689-a05c1500-4386-11eb-9084-be254d6e5d90.png) | Portrait <br /> ![Screenshot_20201221_120902](https://user-images.githubusercontent.com/1657201/102771710-a7832300-4386-11eb-8740-5d679b32768a.png) |
| Landscape <br /> ![Screenshot_20201221_120852](https://user-images.githubusercontent.com/1657201/102771737-b36ee500-4386-11eb-9da0-93232e66d75a.png) | Landscape <br /> ![Screenshot_20201221_120906](https://user-images.githubusercontent.com/1657201/102771745-b8cc2f80-4386-11eb-9b36-4719c0f28f94.png) |





### Test
1. Create a note that has some text and a large table, use this as a sample:
``` markdown
Note
 
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


| Header A | Header B | Header C | Header D | Header E | Header F | Header G |
|----------|----------|----------|----------|----------|----------|----------|
| Value A1 | Value B1 | Value C1 | Value D1 | Value E1 | Value F1 | Value G1 |
| Value A2 | Value B2 | Value C2 | Value D2 | Value E2 | Value F2 | Value G2 |
| Value A2 | Value B2 | Value C2 | Value D3 | Value E3 | Value F3 | Value G3 |
```
Or this one: https://app.simplenote.com/p/F941bG (shared by the user having the issue)
2. Preview the note in portrait mode.
3. Rotate the device to landscape mode.
3. Confirm that the text is not zoomed.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
