### PR TITLE
Attempt to fix the duplication of shared notes

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -237,11 +237,17 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         checkForFirstLaunch();
 
         if (savedInstanceState == null) {
-            checkForSharedContent();
+            checkForSharedContent(getIntent());
         }
 
         currentApp.getSimperium().setOnUserCreatedListener(this);
         currentApp.getSimperium().setUserStatusChangeListener(this);
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        checkForSharedContent(intent);
     }
 
     @Override
@@ -555,10 +561,9 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         }
     }
 
-    private void checkForSharedContent() {
-        if (getIntent().hasExtra(Intent.EXTRA_TEXT)) {
+    private void checkForSharedContent(Intent intent) {
+        if (intent.hasExtra(Intent.EXTRA_TEXT)) {
             // Check share action
-            Intent intent = getIntent();
             String subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
             String text = intent.getStringExtra(Intent.EXTRA_TEXT);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -236,7 +236,9 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         // Creates 'Welcome' note
         checkForFirstLaunch();
 
-        checkForSharedContent();
+        if (savedInstanceState == null) {
+            checkForSharedContent();
+        }
 
         currentApp.getSimperium().setOnUserCreatedListener(this);
         currentApp.getSimperium().setUserStatusChangeListener(this);


### PR DESCRIPTION
### Fix
This PR attempts to fix #917, from the video in the issue, it seems that Android is recreating the NotesActivity after going back, and by re-reading the intent we add it another time.
I wasn't able to replicate the same behavior, but by enabling `don't keep activities` option in my device, and sharing a note from the browser, I ended up in a loop where every time I leave the note editor, the note gets duplicated.

@ParaskP7 identified another bug in the same issue, in some cases (the identified one in the issue is quick share from Chrome), the browser attempts to re-use the same activity instance, instead of creating a new one, and then the shared note will be delivered via the callback `onNewIntent`, which wasn't handled.

So the changes here are:
1. Don't add the note if the activity is being recreated by the platform 4c5611c
2. Handle the `onNewIntent` callback f613d80

### Test
#### Activity recreation
1. Enable "Don't keep activities" in the developer options.
2. Open the browser, then share a website.
3. Pick Simplenote.
4. The note will be added.
5. Go back.
6. Confirm that the note won't get duplicated.

#### Quick share from Chrome
1. Make sure that "don't keep activities" is disabled, and that Simplenote is closed.
2. Open chrome, then share a website.
3. Pick Simplenote.
4. Click on the home button.
5. Open Chrome again.
6. Share another website but using the quick share button.
7. Confirm that the note was added.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.