### PR TITLE
Separate search sort order from the default sort order

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -402,7 +402,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 query.include(Note.TITLE_INDEX_NAME);
                 query.where(Note.DELETED_PROPERTY, Query.ComparisonType.NOT_EQUAL_TO, true);
                 query.where(Note.TITLE_INDEX_NAME, Query.ComparisonType.LIKE, String.format("%%%s%%", filter));
-                PrefUtils.sortNoteQuery(query, requireContext(), true);
+                PrefUtils.sortNoteQuery(query, requireContext());
                 Cursor cursor = query.execute();
 
                 final int heightAutocomplete = DisplayUtils.dpToPx(requireContext(), cursor.getCount() * 48);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -119,6 +119,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
      * The preferences key representing the activated item position. Only used on tablets.
      */
     private static final String STATE_ACTIVATED_POSITION = "activated_position";
+    private static final String SEARCH_SORT_ORDER = "search_sort_order";
     private static final int POPUP_MENU_FIRST_ITEM_POSITION = 0;
     public static final String ACTION_NEW_NOTE = "com.automattic.simplenote.NEW_NOTE";
     /**
@@ -342,7 +343,11 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         AppLog.add(Type.SCREEN, "Created (NoteListFragment)");
         mBucketPreferences = ((Simplenote) requireActivity().getApplication()).getPreferencesBucket();
         mBucketTag = ((Simplenote) requireActivity().getApplication()).getTagsBucket();
-        mSearchSortOrder = PrefUtils.getIntPref(requireContext(), PrefUtils.PREF_SORT_ORDER);
+        if(savedInstanceState != null && savedInstanceState.containsKey(SEARCH_SORT_ORDER)) {
+            mSearchSortOrder = savedInstanceState.getInt(SEARCH_SORT_ORDER);
+        } else {
+            mSearchSortOrder = PrefUtils.getIntPref(requireContext(), PrefUtils.PREF_SORT_ORDER);
+        }
     }
 
     protected void getPrefs() {
@@ -723,6 +728,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
             // Serialize and persist the activated item position.
             outState.putInt(STATE_ACTIVATED_POSITION, mActivatedPosition);
         }
+        outState.putInt(SEARCH_SORT_ORDER, mSearchSortOrder);
     }
 
     public View getRootView() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
@@ -129,7 +129,7 @@ public class NoteListWidgetDark extends AppWidgetProvider {
             Bucket<Note> notesBucket = currentApp.getNotesBucket();
             Query<Note> query = Note.all(notesBucket);
             query.include(Note.TITLE_INDEX_NAME, Note.CONTENT_PREVIEW_INDEX_NAME);
-            PrefUtils.sortNoteQuery(query, context, true);
+            PrefUtils.sortNoteQuery(query, context);
             Bucket.ObjectCursor<Note> cursor = query.execute();
 
             if (cursor.getCount() > 0) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetFactory.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetFactory.java
@@ -104,7 +104,7 @@ public class NoteListWidgetFactory implements RemoteViewsFactory {
         Bucket<Note> notesBucket = ((Simplenote) mContext.getApplicationContext()).getNotesBucket();
         Query<Note> query = Note.all(notesBucket);
         query.include(Note.TITLE_INDEX_NAME, Note.CONTENT_PREVIEW_INDEX_NAME);
-        PrefUtils.sortNoteQuery(query, mContext, true);
+        PrefUtils.sortNoteQuery(query, mContext);
         mCursor = query.execute();
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
@@ -129,7 +129,7 @@ public class NoteListWidgetLight extends AppWidgetProvider {
             Bucket<Note> notesBucket = currentApp.getNotesBucket();
             Query<Note> query = Note.all(notesBucket);
             query.include(Note.TITLE_INDEX_NAME, Note.CONTENT_PREVIEW_INDEX_NAME);
-            PrefUtils.sortNoteQuery(query, context, true);
+            PrefUtils.sortNoteQuery(query, context);
             Bucket.ObjectCursor<Note> cursor = query.execute();
 
             if (cursor.getCount() > 0) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
@@ -102,7 +102,7 @@ public class NoteWidgetDarkConfigureActivity extends AppCompatActivity {
         Bucket<Note> mNotesBucket = mApplication.getNotesBucket();
         Query<Note> query = Note.all(mNotesBucket);
         query.include(Note.TITLE_INDEX_NAME, Note.CONTENT_PREVIEW_INDEX_NAME);
-        PrefUtils.sortNoteQuery(query, NoteWidgetDarkConfigureActivity.this, true);
+        PrefUtils.sortNoteQuery(query, NoteWidgetDarkConfigureActivity.this);
         ObjectCursor<Note> cursor = query.execute();
 
         Context context = new ContextThemeWrapper(NoteWidgetDarkConfigureActivity.this, PrefUtils.getStyleWidgetDialog(NoteWidgetDarkConfigureActivity.this));

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLightConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLightConfigureActivity.java
@@ -102,7 +102,7 @@ public class NoteWidgetLightConfigureActivity extends AppCompatActivity {
         Bucket<Note> mNotesBucket = mApplication.getNotesBucket();
         Query<Note> query = Note.all(mNotesBucket);
         query.include(Note.TITLE_INDEX_NAME, Note.CONTENT_PREVIEW_INDEX_NAME);
-        PrefUtils.sortNoteQuery(query, NoteWidgetLightConfigureActivity.this, true);
+        PrefUtils.sortNoteQuery(query, NoteWidgetLightConfigureActivity.this);
         ObjectCursor<Note> cursor = query.execute();
 
         Context context = new ContextThemeWrapper(NoteWidgetLightConfigureActivity.this, PrefUtils.getStyleWidgetDialog(NoteWidgetLightConfigureActivity.this));

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -309,12 +309,20 @@ public class PrefUtils {
         return getIntPref(context, PREF_FONT_SIZE, defaultFontSize);
     }
 
-    public static void sortNoteQuery(Query<Note> query, Context context, boolean includePinnedOrdering) {
+    public static void sortNoteQuery(Query<Note> query, Context context) {
+        sortNoteQueryInternal(query, PrefUtils.getIntPref(context, PREF_SORT_ORDER), context, true);
+    }
+
+    public static void sortNoteQueryForSearch(Query<Note> query, int sortOrder, Context context) {
+        sortNoteQueryInternal(query, sortOrder, context, false);
+    }
+
+    private static void sortNoteQueryInternal(Query<Note> query, int sortOrder, Context context, boolean includePinnedOrdering) {
         if (includePinnedOrdering) {
             query.order(PINNED_INDEX_NAME, Query.SortType.DESCENDING);
         }
 
-        switch (PrefUtils.getIntPref(context, PrefUtils.PREF_SORT_ORDER)) {
+        switch (sortOrder) {
             case DATE_MODIFIED_DESCENDING:
                 query.order(Note.MODIFIED_INDEX_NAME, Query.SortType.DESCENDING);
                 break;


### PR DESCRIPTION
### Fix

Fixes two issues:
1. Fixes #907, as we save temporarily the selected search sort order using the same key of the default sort order in the shared preferences, so if the fragment doesn't get a chance to call `onDetach` or `clearSearch`, the search sort order will replace the default sort order.
2. The sort order is totally broken in the develop branch, I think since merging #1227. As when we leave PreferenceActivity, we allways call `NavUtils.navigateUpFromSameTask`, the previous NotesActivity gets destroyed, and we create a new one, which means that `NoteListFragment` will call `detach` and override the saved sort order.

The fix I did is adding a new field that saves the search sort order locally in the fragment, and use it for everything related to the search, which avoids modifying the default sort order, and fixes both the above issues. 

### Test
#### Test sort order
1. Open preferences, and change the sort order.
2. Go back to the notes list.
3. Confirm that the sort order is applied.

#### Fix for overriding the sort order
1. Open the app and confirm the note sort order (under Settings > Sort order).
2. Open notes list.
3. Enter any text to search your notes.
4. Change the sort order and/or direction for the search.
5. Force close the app.
6. Reopen the app and confirm the search order wasn't impacted by the selected search order.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.