### PR TITLE
Improve theme and style changes handling

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/AboutActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AboutActivity.java
@@ -8,7 +8,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
 import com.automattic.simplenote.utils.DrawableUtils;
-import com.automattic.simplenote.utils.ThemeUtils;
 
 public class AboutActivity extends AppCompatActivity {
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/AboutActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AboutActivity.java
@@ -13,7 +13,6 @@ import com.automattic.simplenote.utils.ThemeUtils;
 public class AboutActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
-        ThemeUtils.setTheme(this);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_about);
         Toolbar toolbar = findViewById(R.id.toolbar);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -25,7 +25,6 @@ import com.automattic.simplenote.utils.AppLog;
 import com.automattic.simplenote.utils.AppLog.Type;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.NetworkUtils;
-import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.widgets.NoteEditorViewPager;
 import com.automattic.simplenote.widgets.RobotoMediumTextView;
 import com.google.android.material.tabs.TabLayout;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -76,7 +76,6 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        ThemeUtils.setTheme(this);
         super.onCreate(savedInstanceState);
 
         AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(NoteEditorActivity.this));

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -176,7 +176,6 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        ThemeUtils.setTheme(this);
         super.onCreate(savedInstanceState);
 
         AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(NotesActivity.this));

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1283,17 +1283,6 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
     }
 
     @Override
-    public void recreate() {
-        Handler handler = new Handler();
-        handler.post(new Runnable() {
-            @Override
-            public void run() {
-                NotesActivity.super.recreate();
-            }
-        });
-    }
-
-    @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         switch (requestCode) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesActivity.java
@@ -1,18 +1,14 @@
 package com.automattic.simplenote;
 
-import android.content.Intent;
 import android.os.Bundle;
-import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
 
 import androidx.appcompat.widget.Toolbar;
-import androidx.core.app.NavUtils;
 import androidx.fragment.app.FragmentManager;
 import androidx.preference.Preference;
 
 import com.automattic.simplenote.utils.BrowserUtils;
-import com.automattic.simplenote.utils.ThemeUtils;
 
 import org.wordpress.passcodelock.PasscodePreferenceFragment;
 import org.wordpress.passcodelock.PasscodePreferenceFragmentCompat;
@@ -23,11 +19,6 @@ import static com.automattic.simplenote.utils.DisplayUtils.disableScreenshotsIfL
 public class PreferencesActivity extends ThemedAppCompatActivity {
     private PasscodePreferenceFragmentCompat mPasscodePreferenceFragment;
     private PreferencesFragment mPreferencesFragment;
-
-    @Override
-    public void onBackPressed() {
-        NavUtils.navigateUpFromSameTask(PreferencesActivity.this);
-    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -79,28 +70,9 @@ public class PreferencesActivity extends ThemedAppCompatActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == android.R.id.home) {
-            NavUtils.navigateUpFromSameTask(PreferencesActivity.this);
-            return true;
-        } else {
-            return super.onOptionsItemSelected(item);
-        }
-    }
-
-    @Override
     protected void onResume() {
         super.onResume();
         disableScreenshotsIfLocked(this);
-    }
-
-    @Override
-    public void recreate() {
-        Intent intent = new Intent(PreferencesActivity.this, PreferencesActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-        startActivity(intent);
-        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
-        finish();
     }
 
     public void openBrowserForMembership(View view) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesActivity.java
@@ -31,7 +31,6 @@ public class PreferencesActivity extends ThemedAppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        ThemeUtils.setTheme(this);
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_preferences);

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -167,9 +167,6 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
                         AnalyticsTracker.CATEGORY_USER,
                         "theme_preference"
                 );
-
-                // recreate the activity so new theme is applied
-                activity.recreate();
             }
         });
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/StyleActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/StyleActivity.java
@@ -54,7 +54,6 @@ public class StyleActivity extends ThemedAppCompatActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        ThemeUtils.setTheme(this);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_style);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/StyleActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/StyleActivity.java
@@ -7,7 +7,6 @@ import android.text.Html;
 import android.text.SpannableString;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -18,7 +17,6 @@ import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
-import androidx.core.app.NavUtils;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -46,11 +44,6 @@ public class StyleActivity extends ThemedAppCompatActivity {
 
     private LinearLayoutManager mLayoutManager;
     private boolean mIsPremium;
-
-    @Override
-    public void onBackPressed() {
-        NavUtils.navigateUpFromSameTask(StyleActivity.this);
-    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -82,20 +75,14 @@ public class StyleActivity extends ThemedAppCompatActivity {
         }
     }
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == android.R.id.home) {
-            NavUtils.navigateUpFromSameTask(StyleActivity.this);
-        }
-
-        return super.onOptionsItemSelected(item);
-    }
-
+    /**
+     *  Overrides recreate to allow restoring the scroll position
+     */
     @Override
     public void recreate() {
         Intent intent = new Intent(StyleActivity.this, StyleActivity.class);
         intent.putExtra(EXTRA_SCROLL, mLayoutManager.onSaveInstanceState());
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         startActivity(intent);
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
         finish();
@@ -168,7 +155,6 @@ public class StyleActivity extends ThemedAppCompatActivity {
                             mSelectedPosition = position;
                             notifyItemChanged(mSelectedPosition);
                             PrefUtils.setStyleIndex(StyleActivity.this, position);
-                            recreate();
                         } else if (holder.mLocked.getVisibility() == View.VISIBLE) {
                             showDialogLocked();
                         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -62,7 +62,6 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        ThemeUtils.setTheme(this);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_tags);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -36,7 +36,6 @@ import com.automattic.simplenote.utils.BaseCursorAdapter;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
-import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.widgets.EmptyViewRecyclerView;
 import com.simperium.client.Bucket;
 import com.simperium.client.Query;

--- a/Simplenote/src/main/java/com/automattic/simplenote/ThemedAppCompatActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/ThemedAppCompatActivity.java
@@ -1,9 +1,13 @@
 package com.automattic.simplenote;
 
+import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.Lifecycle;
+import androidx.preference.PreferenceManager;
 
 import com.automattic.simplenote.utils.PrefUtils;
 import com.automattic.simplenote.utils.ThemeUtils;
@@ -12,11 +16,49 @@ import com.automattic.simplenote.utils.ThemeUtils;
  * Abstract class to apply theme based on {@link PrefUtils#PREF_STYLE_INDEX}
  * to any {@link AppCompatActivity} that extends it.
  */
-abstract public class ThemedAppCompatActivity extends AppCompatActivity {
+abstract public class ThemedAppCompatActivity extends AppCompatActivity implements SharedPreferences.OnSharedPreferenceChangeListener {
+    private Boolean mThemeChanged = false;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         ThemeUtils.setTheme(this);
         super.onCreate(savedInstanceState);
-        setTheme(ThemeUtils.getStyle(ThemedAppCompatActivity.this));
+        setTheme(ThemeUtils.getStyle(this));
+        PreferenceManager.getDefaultSharedPreferences(this).registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    protected void onRestart() {
+        super.onRestart();
+        if (mThemeChanged) {
+            recreate();
+            mThemeChanged = false;
+        }
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if (key.equals(PrefUtils.PREF_THEME) || key.equals(PrefUtils.PREF_STYLE_INDEX)) {
+            if (getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.RESUMED)) {
+                recreate();
+            } else {
+                mThemeChanged = true;
+            }
+        }
+    }
+
+    @Override
+    public void recreate() {
+        Intent intent = new Intent(this, getClass());
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        startActivity(intent);
+        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
+        finish();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        PreferenceManager.getDefaultSharedPreferences(this).unregisterOnSharedPreferenceChangeListener(this);
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/ThemedAppCompatActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/ThemedAppCompatActivity.java
@@ -15,6 +15,7 @@ import com.automattic.simplenote.utils.ThemeUtils;
 abstract public class ThemedAppCompatActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
+        ThemeUtils.setTheme(this);
         super.onCreate(savedInstanceState);
         setTheme(ThemeUtils.getStyle(ThemedAppCompatActivity.this));
     }


### PR DESCRIPTION
### Fix
This improves theme/style changes handling, by centralizing the logic in the `ThemedAppCompatActivity`, and responding to changes in the same place, instead of relying `NavUtils.navigateUpTo`.
One of the advantages of this way too, is that it decouples it from the navigation logic, so if the navigation order gets changed later, or we add ability to open the settings from somewhere else, the theme changes will continue to be applied without having to change anything.

This also fixes the current bug of not saving changes of the sort order preference (see #1252 for details), as the `NotesActivity` won't get recreated until there is some theme or style changes.

### Test
#### Sort order fix
1. Open settings.
2. Change the sort order value.
3. Go back to notes list.
4. Confirm the new sort order value is applied.

#### Change theme
1. Open settings.
2. Change theme.
3. Confirm the theme is applied to the current screen.
4. Go back to the notes list.
5. Confirm the theme is applied here too.

#### Change style
1. Change return value of `PrefUtils.isPremium()` to true.
2. Open settings, then open style settings.
3. Change style.
4. Confirm the style is applied to the current screen.
5. Go back to the previous screens.
6. Confirm the theme is applied here too.

### Review
Only one developer is required to review these changes, but anyone can perform the review.


### Release
These changes do not require release notes.