### PR TITLE
Ability to preview and edit checkboxes in the markdown preview

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -372,6 +372,10 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
         return (NoteMarkdownFragment) mNoteEditorFragmentPagerAdapter.getItem(1);
     }
 
+    public NoteEditorFragment getNoteEditorFragment() {
+        return mNoteEditorFragment;
+    }
+
     public void hideTabs() {
         mTabLayout.setVisibility(View.GONE);
         mViewPager.setPagingEnabled(false);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -30,6 +30,7 @@ import android.view.ViewGroup;
 import android.view.ViewStub;
 import android.view.ViewTreeObserver;
 import android.view.inputmethod.InputMethodManager;
+import android.webkit.JavascriptInterface;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -72,6 +73,7 @@ import com.automattic.simplenote.utils.TagsMultiAutoCompleteTextView.OnTagAddedL
 import com.automattic.simplenote.utils.TextHighlighter;
 import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.utils.WidgetUtils;
+import com.automattic.simplenote.widgets.CheckableSpan;
 import com.automattic.simplenote.widgets.SimplenoteEditText;
 import com.google.android.material.chip.Chip;
 import com.google.android.material.chip.ChipGroup;
@@ -475,6 +477,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                     }
                 );
                 mCss = ContextUtils.readCssFile(requireContext(), ThemeUtils.getCssFromStyle(requireContext()));
+                mMarkdown.getSettings().setJavaScriptEnabled(true);
+                mMarkdown.addJavascriptInterface(this, "injection");
             } else {
                 ((ViewStub) mRootView.findViewById(R.id.stub_error)).inflate();
                 mError = mRootView.findViewById(R.id.error);
@@ -1606,6 +1610,23 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             return;
 
         note.setContent(mContentEditText.getPlainTextContent());
+    }
+
+    @JavascriptInterface
+    public void toggleCheckbox(final int index) {
+        new Handler(getContext().getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                toggleCheckboxSpan(index);
+            }
+        });
+    }
+
+    public void toggleCheckboxSpan(int index) {
+        Editable content = mContentEditText.getText();
+        CheckableSpan span = mContentEditText.getText().getSpans(0, content.length(), CheckableSpan.class)[index];
+        span.setChecked(!span.isChecked());
+        mContentEditText.toggleCheckbox(span);
     }
 
     private static class LoadNoteTask extends AsyncTask<String, Void, Void> {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -752,6 +752,10 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         return mNoteListFragment;
     }
 
+    public NoteEditorFragment getNoteEditorFragment() {
+        return mNoteEditorFragment;
+    }
+
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         super.onCreateOptionsMenu(menu);

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -342,13 +342,14 @@ public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView imple
 
         SpannableStringBuilder content = new SpannableStringBuilder(getText());
         CheckableSpan[] spans = content.getSpans(0, content.length(), CheckableSpan.class);
-        for(CheckableSpan span: spans) {
+        for (int i = 0; i < spans.length; i++) {
+            CheckableSpan span = spans[i];
             int start = content.getSpanStart(span);
             int end = content.getSpanEnd(span);
             ((Editable) content).replace(
                     start,
                     end,
-                    span.isChecked() ? ChecklistUtils.CHECKED_MARKDOWN_PREVIEW : ChecklistUtils.UNCHECKED_MARKDOWN);
+                    (span.isChecked() ? ChecklistUtils.CHECKED_MARKDOWN : ChecklistUtils.UNCHECKED_MARKDOWN) + "c" + i + " ");
         }
 
         return content.toString();


### PR DESCRIPTION
This attempts to fix #872, it replaces all the checkboxes by `<input type="checkbox"/>`, and uses javascript injection to allow toggling the checkbox from the preview tab:

![checkboxs](https://user-images.githubusercontent.com/1657201/103211315-238de580-4908-11eb-8bc2-7ec51f530988.gif)

I know the plan is to use or write a different parser in the future that supports them, but IMO this can work as a short term solution, @theck13 please let me know what you think? I'm keeping this as draft for now until I get your opinion, and then clean it up, and test it properly. 

### Fix
<!--
***(Required)*** Add a concise description of what you fixed.  If this is related to an issue, add a link to it.  If applicable, add screenshots, animations, or videos to help illustrate the fix.
-->

### Test
<!--
***(Required)*** List the steps to test the behavior.  For example:
1. Go to...
2. Tap on...
3. See error...
-->

### Review
<!--
***(Required)*** Add instructions for reviewers.  For example:
Only one developer and one designer are required to review these changes, but anyone can perform the review.
-->

### Release
<!--
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.txt` was updated in d3adb3ef with:
> Added markdown support
-->
<!--
If the changes should not be included in release notes, add a statement to this section. For example:
These changes do not require release notes.
-->
