### PR TITLE
Reset the buckets if the user is unauthenticated

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1278,6 +1278,13 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         // Remove Passcode Lock password
         AppLockManager.getInstance().getAppLock().setPassword("");
 
+        // Reset Buckets
+        Simplenote application = (Simplenote) getApplication();
+
+        application.getNotesBucket().reset();
+        application.getTagsBucket().reset();
+        application.getPreferencesBucket().reset();
+
         Intent intent = new Intent(NotesActivity.this, SimplenoteAuthenticationActivity.class);
         startActivityForResult(intent, Simperium.SIGNUP_SIGNIN_REQUEST);
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1259,7 +1259,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        AppLog.add(Type.ACCOUNT, "Token not authorized");
+                        AppLog.add(Type.ACCOUNT, "Access token not authorized");
                         startLoginActivity();
                     }
                 });

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/AuthUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/AuthUtils.java
@@ -1,0 +1,45 @@
+package com.automattic.simplenote.utils;
+
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+
+import com.automattic.simplenote.Simplenote;
+import com.automattic.simplenote.analytics.AnalyticsTracker;
+import com.automattic.simplenote.utils.AppLog.Type;
+
+import org.wordpress.passcodelock.AppLockManager;
+
+public class AuthUtils {
+    public static void logOut(Simplenote application) {
+        application.getSimperium().deauthorizeUser();
+
+        application.getNotesBucket().reset();
+        application.getTagsBucket().reset();
+        application.getPreferencesBucket().reset();
+
+        application.getNotesBucket().stop();
+        AppLog.add(Type.SYNC, "Stopped note bucket (AuthUtils)");
+        application.getTagsBucket().stop();
+        AppLog.add(Type.SYNC, "Stopped tag bucket (AuthUtils)");
+        application.getPreferencesBucket().stop();
+        AppLog.add(Type.SYNC, "Stopped preference bucket (AuthUtils)");
+
+        // Resets analytics user back to 'anon' type
+        AnalyticsTracker.refreshMetadata(null);
+        CrashUtils.clearCurrentUser();
+
+        // Remove wp.com token
+        SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(application).edit();
+        editor.remove(PrefUtils.PREF_WP_TOKEN);
+
+        // Remove WordPress sites
+        editor.remove(PrefUtils.PREF_WORDPRESS_SITES);
+        editor.apply();
+
+        // Remove Passcode Lock password
+        AppLockManager.getInstance().getAppLock().setPassword("");
+
+        WidgetUtils.updateNoteWidgets(application);
+    }
+}


### PR DESCRIPTION
### Fix
Fixes #1258 by making sure to reset the buckets if the user is unauthenticated (token expired, or password changed...), and avoids keeping the old notes if the user signs in using a different account.

### Test
1. Sign in to the app.
2. Force close the app.
3. Trigger the unauthentication scenario (personally I deleted the simperium.xml shared pref file using the device explorer in Android Studio, a password change on the web app triggers it too)
4. Open the app.
5. Notice that the login screen is displayed
5. Sign in using a different account.
6. Confirm that notes from the old account have been deleted.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.