### PR TITLE
Fix for having a wrong them in the webviews when the app is launched from the widget

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteMarkdownFragment.java
@@ -13,6 +13,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.MenuCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -223,6 +224,10 @@ public class NoteMarkdownFragment extends Fragment implements Bucket.Listener<No
     @Override
     public void onResume() {
         super.onResume();
+        // First inflation of the webview may invalidate the value of uiMode,
+        // so we re-apply it to make sure that the webview has the right css files
+        // Check https://issuetracker.google.com/issues/37124582 for more details
+        ((AppCompatActivity)requireActivity()).getDelegate().applyDayNight();
         checkWebView();
         mNotesBucket.addListener(this);
         AppLog.add(Type.SYNC, "Added note bucket listener (NoteMarkdownFragment)");

--- a/Simplenote/src/main/java/com/automattic/simplenote/ThemedAppCompatActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/ThemedAppCompatActivity.java
@@ -51,6 +51,9 @@ abstract public class ThemedAppCompatActivity extends AppCompatActivity implemen
     public void recreate() {
         Intent intent = new Intent(this, getClass());
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        if (getIntent().getExtras() != null) {
+            intent.putExtras(getIntent().getExtras());
+        }
         startActivity(intent);
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
         finish();


### PR DESCRIPTION
### Fix
Fixes #1259.
When inflating the first Webview in the app, the `uiMode` value of the configuration may be reset to the system's mode, the issue: https://issuetracker.google.com/issues/37124582 explains the issue, and though it says it's fixed since `appcompat 1.1.0-alpha03`, it's happening in 1.1.0 and other commenters noticed too.
The fix is by re-applying the nightMode in NoteMarkdownFragment's `onResume`, the call will either recreate the activity if the uiMode is different or do nothing if it's already correct.


### Test
1. Add the notes list widget to the home screen.
2. Enable dark theme from the app's settings.
3. Close the app (to confirm the fix, please force close it).
4. Click on one markdown note in the widget, and open the preview tab.
5. Notice that the markdown preview is dark.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.