### PR TITLE
Show the current note when rotating to portrait mode on large devices

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -277,6 +277,8 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
                 newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE && mNoteId != null) {
             Intent resultIntent = new Intent();
             resultIntent.putExtra(Simplenote.SELECTED_NOTE_ID, mNoteId);
+            resultIntent.putExtra(NoteEditorFragment.ARG_PREVIEW_ENABLED, isPreviewEnabled);
+            resultIntent.putExtra(NoteEditorFragment.ARG_MARKDOWN_ENABLED, isMarkdownEnabled);
             resultIntent.putExtra(ShortcutDialogFragment.DIALOG_VISIBLE,
                     getSupportFragmentManager().findFragmentByTag(ShortcutDialogFragment.DIALOG_TAG) != null);
             resultIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -283,7 +283,7 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
                     getSupportFragmentManager().findFragmentByTag(ShortcutDialogFragment.DIALOG_TAG) != null);
             setResult(Activity.RESULT_OK, resultIntent);
             finish();
-            overridePendingTransition(0,0);
+            overridePendingTransition(0, 0);
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -281,9 +281,9 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
             resultIntent.putExtra(NoteEditorFragment.ARG_MARKDOWN_ENABLED, isMarkdownEnabled);
             resultIntent.putExtra(ShortcutDialogFragment.DIALOG_VISIBLE,
                     getSupportFragmentManager().findFragmentByTag(ShortcutDialogFragment.DIALOG_TAG) != null);
-            resultIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
             setResult(Activity.RESULT_OK, resultIntent);
             finish();
+            overridePendingTransition(0,0);
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -844,8 +844,8 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             new Runnable() {
                 @Override
                 public void run() {
-                    if(getActivity() != null) {
-                        getActivity().invalidateOptionsMenu();
+                    if (!isDetached()) {
+                        requireActivity().invalidateOptionsMenu();
                     }
                 }
             },

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -844,7 +844,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
             new Runnable() {
                 @Override
                 public void run() {
-                    requireActivity().invalidateOptionsMenu();
+                    if(getActivity() != null) {
+                        getActivity().invalidateOptionsMenu();
+                    }
                 }
             },
             getResources().getInteger(R.integer.time_animation)

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1311,10 +1311,9 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                         }
                     } else if (DisplayUtils.isLargeScreenLandscape(this) && data.hasExtra(Simplenote.SELECTED_NOTE_ID)) {
                         String selectedNoteId = data.getStringExtra(Simplenote.SELECTED_NOTE_ID);
-                        mNoteListFragment.setNoteSelected(selectedNoteId);
-                        if (mNoteEditorFragment != null) {
-                            mNoteEditorFragment.setNote(selectedNoteId);
-                        }
+                        boolean isPreviewEnabled = data.getBooleanExtra(NoteEditorFragment.ARG_PREVIEW_ENABLED, false);
+                        boolean isMarkdownEnabled = data.getBooleanExtra(NoteEditorFragment.ARG_MARKDOWN_ENABLED, false);
+                        onNoteSelected(selectedNoteId, null, isMarkdownEnabled, isPreviewEnabled);
 
                         // Relaunch shortcut dialog if it was showing in editor (Chrome OS).
                         if (data.getBooleanExtra(ShortcutDialogFragment.DIALOG_VISIBLE, false)) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1408,7 +1408,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 }
 
                 invalidateOptionsMenu();
-                // Go to NoteEditorActivity if a note was selected and orientation was switched to portrait
+            // Go to NoteEditorActivity if a note was selected and orientation was switched to portrait
             } else if (mCurrentNote != null) {
                 onNoteSelected(mCurrentNote.getSimperiumKey(), null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
                 overridePendingTransition(0, 0);

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1413,8 +1413,8 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 }
 
                 invalidateOptionsMenu();
-            // Go to NoteEditorActivity if note editing was fullscreen and orientation was switched to portrait
-            } else if (mNoteListFragment.isHidden() && mCurrentNote != null) {
+            // Go to NoteEditorActivity if a note was selected and orientation was switched to portrait
+            } else if (mCurrentNote != null) {
                 onNoteSelected(mCurrentNote.getSimperiumKey(), null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
             }
         } else {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1164,10 +1164,6 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
             Intent editNoteIntent = new Intent(this, NoteEditorActivity.class);
             editNoteIntent.putExtras(arguments);
 
-            if (mNoteListFragment.isHidden()) {
-                editNoteIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-            }
-
             startActivityForResult(editNoteIntent, Simplenote.INTENT_EDIT_NOTE);
         } else {
             mNoteEditorFragment.setNote(noteID, matchOffsets);
@@ -1412,9 +1408,10 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 }
 
                 invalidateOptionsMenu();
-            // Go to NoteEditorActivity if a note was selected and orientation was switched to portrait
+                // Go to NoteEditorActivity if a note was selected and orientation was switched to portrait
             } else if (mCurrentNote != null) {
                 onNoteSelected(mCurrentNote.getSimperiumKey(), null, mCurrentNote.isMarkdownEnabled(), mCurrentNote.isPreviewEnabled());
+                overridePendingTransition(0, 0);
             }
         } else {
             // Show list/sidebar when it was hidden while in landscape orientation.


### PR DESCRIPTION
### Fix
Fixes #1239 
Currently when rotating a large device to portrait mode, and unless fullscreen was enabled, we will show just the list of notes, which is not ideal for continuing editing notes.
This PR fixes this by opening the editor when rotating to portrait mode if a note is selected.

### Test
Using a tablet and a Chrome device:
1. Open the app in landscape mode.
2. Select a note.
3. Rotate the device to portrait mode.
4. Confirm that the editor was opened using the last selected note.
5. Rotate to landscape mode.
6. Confirm that the dual-pane view is shown, and that note is still selected.

Repeat the previous steps using markdown notes, and confirm that the preview option is respected when rotating.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.