### PR TITLE
Make the sort bar always visible in the notes list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Added synced date/time to note information sheet [https://github.com/Automattic/simplenote-android/pull/1140]
 * Added syncing in the background to avoid data loss when exiting the app [https://github.com/Automattic/simplenote-android/pull/1255]
 * Added permanently deleting notes from trash individually [https://github.com/Automattic/simplenote-android/pull/1224]
+* Make the sort bar always visible in the notes list [https://github.com/Automattic/simplenote-android/pull/1270]
 
 2.14
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -165,7 +165,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     private RefreshListTask mRefreshListTask;
     private RefreshListForSearchTask mRefreshListForSearchTask;
     private int mDeletedItemIndex;
-    private int mPreferenceSortOrder;
     private int mTitleFontSize;
     private int mPreviewFontSize;
     private boolean mIsSortDown;
@@ -347,7 +346,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     }
 
     protected void getPrefs() {
-        mPreferenceSortOrder = PrefUtils.getIntPref(requireContext(), PrefUtils.PREF_SORT_ORDER);
         mIsCondensedNoteList = PrefUtils.getBoolPref(getActivity(), PrefUtils.PREF_CONDENSED_LIST, false);
         mTitleFontSize = PrefUtils.getFontSize(getActivity());
         mPreviewFontSize = mTitleFontSize - 2;
@@ -414,8 +412,8 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
         @SuppressLint("InflateParams")
         LinearLayout sortLayoutContainer = (LinearLayout) getLayoutInflater().inflate(R.layout.search_sort, null, false);
         mSortLayoutContent = sortLayoutContainer.findViewById(R.id.sort_content);
-        mSortLayoutContent.setVisibility(mIsSearching ? View.VISIBLE : View.GONE);
         mSortOrder = sortLayoutContainer.findViewById(R.id.sort_order);
+        mSortOrder.setText(getSortOrderText());
         mSortLayoutContent.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -667,8 +665,6 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
     @Override
     public void onDetach() {
         super.onDetach();
-        // Restore sort order from Settings.
-        mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER, String.valueOf(mPreferenceSortOrder)).apply();
         // Reset the active callbacks interface to the dummy implementation.
         mCallbacks = sCallbacks;
     }
@@ -936,9 +932,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
     public void searchNotes(String searchString, boolean isSubmit) {
         mIsSearching = true;
-        mSortLayoutContent.setVisibility(View.VISIBLE);
         mSuggestionLayout.setVisibility(View.VISIBLE);
-        mSortOrder.setText(getSortOrderText());
 
         if (!searchString.equals(mSearchString)) {
             mSearchString = searchString;
@@ -961,10 +955,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
      */
     public void clearSearch() {
         mIsSearching = false;
-        mSortLayoutContent.setVisibility(View.GONE);
         mSuggestionLayout.setVisibility(View.GONE);
-        // Restore sort order from Settings.
-        mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER, String.valueOf(mPreferenceSortOrder)).apply();
         refreshList();
 
         if (mSearchString != null && !mSearchString.equals("")) {


### PR DESCRIPTION
### Fix
This PR makes the sort bar always visible in the notes list, instead of being visible only during the search:

<img src="https://user-images.githubusercontent.com/1657201/103987652-1d5ffa80-518d-11eb-9422-6a1181a2c337.png" width=360 />


It's a draft as I have one question: should it be visible also when viewing the trashed notes? Can you check it @SylvesterWilmott 

### Test
1. Open the notes list.
2. Notice that the sort bar is visible.
3. Change the sort order, and confirm that it's applied.
4. Go to Settings.
5. Confirm that the last sort order in the bar is saved to settings.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in fb66fd149cec59e1fe16a2f14d44e44d9dbf8899 with:
> Make the sort bar always visible in the notes list
