### PR TITLE
Update release-toolkit to 0.13.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: a932bd25320f2b82be0774b66e550c6862cd8765
-  tag: 0.12.0
+  revision: 48f500bd9212f13d2bf71220c89a8794cdd46e03
+  tag: 0.13.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.12.0)
+    fastlane-plugin-wpmreleasetoolkit (0.13.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.12.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.13.0'

--- a/tools/release-checks.sh
+++ b/tools/release-checks.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-APPDIR=Simplenote
-


### PR DESCRIPTION
This PR updates `release-toolkit` to the latest `0.13.0`.
This version doesn't call `release-checks.sh` anymore, so this PR removes the placeholder script from the repository

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
