### PR TITLE
Issue/1279 crash log out

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -227,8 +227,8 @@ public class Simplenote extends Application implements HeartbeatListener {
             return;
         }
 
-        if (mSimperium == null || mSimperium.getUser() == null) {
-            // Show nothing when Simperium or user cannot be retrieved.
+        if (mSimperium == null || mSimperium.getUser() == null || mSimperium.getUser().getEmail() == null) {
+            // Show nothing when Simperium, user, or email cannot be retrieved.
             return;
         }
 


### PR DESCRIPTION
### Fix
Add a null check for the user email address to the email verification logic to close #1279.  When a user logs out, the Simperium object and user object retrieved from Simperium may not be null, but the email address from the user object could be.  These changes exit the email verification code in that case to avoid the `NullPointerException` described in #1279.

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Tap ***Log out*** item under ***Account*** section.
4. Notice app does not crash.
5. Notice login/signup screen is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.  @0nko, I requested your review to ensure the issue is fixed since you discovered the crash.

### Release
These changes do not require release notes.

#### Note
@mokagio, these changes will require a new release candidate build once they are merged.