### PR TITLE
Add Sorting Tracking

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -429,38 +429,68 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
                         switch (item.getItemId()) {
                             case R.id.sort_alphabetical:
+                                AnalyticsTracker.track(
+                                    AnalyticsTracker.Stat.SORT_TAPPED,
+                                    AnalyticsTracker.CATEGORY_SORT,
+                                    "alphabetical_az"
+                                );
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
                                     String.valueOf(ALPHABETICAL_ASCENDING)
                                 ).apply();
                                 refreshList();
                                 return true;
                             case R.id.sort_alphabetical_reverse:
+                                AnalyticsTracker.track(
+                                    AnalyticsTracker.Stat.SORT_TAPPED,
+                                    AnalyticsTracker.CATEGORY_SORT,
+                                    "alphabetical_za"
+                                );
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
                                     String.valueOf(ALPHABETICAL_DESCENDING)
                                 ).apply();
                                 refreshList();
                                 return true;
                             case R.id.sort_newest_created:
+                                AnalyticsTracker.track(
+                                    AnalyticsTracker.Stat.SORT_TAPPED,
+                                    AnalyticsTracker.CATEGORY_SORT,
+                                    "created_newest"
+                                );
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
                                     String.valueOf(DATE_CREATED_DESCENDING)
                                 ).apply();
                                 refreshList();
                                 return true;
                             case R.id.sort_oldest_created:
+                                AnalyticsTracker.track(
+                                    AnalyticsTracker.Stat.SORT_TAPPED,
+                                    AnalyticsTracker.CATEGORY_SORT,
+                                    "created_oldest"
+                                );
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
                                     String.valueOf(DATE_CREATED_ASCENDING)
                                 ).apply();
                                 refreshList();
                                 return true;
                             case R.id.sort_newest_modified:
+                                AnalyticsTracker.track(
+                                    AnalyticsTracker.Stat.SORT_TAPPED,
+                                    AnalyticsTracker.CATEGORY_SORT,
+                                    "modified_newest"
+                                );
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
                                     String.valueOf(DATE_MODIFIED_DESCENDING)
                                 ).apply();
                                 refreshList();
                                 return true;
                             case R.id.sort_oldest_modified:
+                                AnalyticsTracker.track(
+                                    AnalyticsTracker.Stat.SORT_TAPPED,
+                                    AnalyticsTracker.CATEGORY_SORT,
+                                    "modified_oldest"
+                                );
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
-                                        String.valueOf(DATE_MODIFIED_ASCENDING)
+                                    String.valueOf(DATE_MODIFIED_ASCENDING)
                                 ).apply();
                                 refreshList();
                                 return true;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -431,7 +431,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                             case R.id.sort_alphabetical:
                                 AnalyticsTracker.track(
                                     AnalyticsTracker.Stat.SORT_TAPPED,
-                                    AnalyticsTracker.CATEGORY_SORT,
+                                    AnalyticsTracker.CATEGORY_SETTING,
                                     "alphabetical_az"
                                 );
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
@@ -442,7 +442,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                             case R.id.sort_alphabetical_reverse:
                                 AnalyticsTracker.track(
                                     AnalyticsTracker.Stat.SORT_TAPPED,
-                                    AnalyticsTracker.CATEGORY_SORT,
+                                    AnalyticsTracker.CATEGORY_SETTING,
                                     "alphabetical_za"
                                 );
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
@@ -453,7 +453,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                             case R.id.sort_newest_created:
                                 AnalyticsTracker.track(
                                     AnalyticsTracker.Stat.SORT_TAPPED,
-                                    AnalyticsTracker.CATEGORY_SORT,
+                                    AnalyticsTracker.CATEGORY_SETTING,
                                     "created_newest"
                                 );
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
@@ -464,7 +464,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                             case R.id.sort_oldest_created:
                                 AnalyticsTracker.track(
                                     AnalyticsTracker.Stat.SORT_TAPPED,
-                                    AnalyticsTracker.CATEGORY_SORT,
+                                    AnalyticsTracker.CATEGORY_SETTING,
                                     "created_oldest"
                                 );
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
@@ -475,7 +475,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                             case R.id.sort_newest_modified:
                                 AnalyticsTracker.track(
                                     AnalyticsTracker.Stat.SORT_TAPPED,
-                                    AnalyticsTracker.CATEGORY_SORT,
+                                    AnalyticsTracker.CATEGORY_SETTING,
                                     "modified_newest"
                                 );
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
@@ -486,7 +486,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                             case R.id.sort_oldest_modified:
                                 AnalyticsTracker.track(
                                     AnalyticsTracker.Stat.SORT_TAPPED,
-                                    AnalyticsTracker.CATEGORY_SORT,
+                                    AnalyticsTracker.CATEGORY_SETTING,
                                     "modified_oldest"
                                 );
                                 mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,

--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
@@ -11,6 +11,7 @@ public final class AnalyticsTracker {
     public static String CATEGORY_NOTE = "note";
     public static String CATEGORY_LINK = "link";
     public static String CATEGORY_SEARCH = "search";
+    public static String CATEGORY_SORT = "sort";
     public static String CATEGORY_TAG = "tag";
     public static String CATEGORY_USER = "user";
     public static String CATEGORY_WIDGET = "widget";
@@ -166,7 +167,8 @@ public final class AnalyticsTracker {
         VERIFICATION_CONFIRM_BUTTON_TAPPED,
         VERIFICATION_CHANGE_EMAIL_BUTTON_TAPPED,
         VERIFICATION_RESEND_EMAIL_BUTTON_TAPPED,
-        VERIFICATION_DISMISSED
+        VERIFICATION_DISMISSED,
+        SORT_TAPPED
     }
 
     public interface Tracker {

--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
@@ -11,7 +11,7 @@ public final class AnalyticsTracker {
     public static String CATEGORY_NOTE = "note";
     public static String CATEGORY_LINK = "link";
     public static String CATEGORY_SEARCH = "search";
-    public static String CATEGORY_SORT = "sort";
+    public static String CATEGORY_SETTING = "setting";
     public static String CATEGORY_TAG = "tag";
     public static String CATEGORY_USER = "user";
     public static String CATEGORY_WIDGET = "widget";


### PR DESCRIPTION
### Fix
Add analytics tracking events to the sort bar from https://github.com/Automattic/simplenote-android/pull/1284.  Events are triggered only when the sort selection is changed.

### Test
Adding a breakpoint in the code can verify the event is triggered at the right time. The steps below can be tested using a breakpoint [here](https://github.com/Automattic/simplenote-android/blob/64878f5d544e4b29eb22347a7825f92541af35c9/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java#L428).
1. Tap sort bar.
2. Tap currently selected sort option.
3. Notice breakpoint is not triggered.
4. Tap sort bar.
5. Tap currently unselected sort option.
6. Notice breakpoint is triggered.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.