### PR TITLE
Update Sort Tracking

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -430,7 +430,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                         switch (item.getItemId()) {
                             case R.id.sort_alphabetical:
                                 AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.SORT_TAPPED,
+                                    AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
                                     AnalyticsTracker.CATEGORY_SETTING,
                                     "alphabetical_az"
                                 );
@@ -441,7 +441,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                                 return true;
                             case R.id.sort_alphabetical_reverse:
                                 AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.SORT_TAPPED,
+                                    AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
                                     AnalyticsTracker.CATEGORY_SETTING,
                                     "alphabetical_za"
                                 );
@@ -452,7 +452,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                                 return true;
                             case R.id.sort_newest_created:
                                 AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.SORT_TAPPED,
+                                    AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
                                     AnalyticsTracker.CATEGORY_SETTING,
                                     "created_newest"
                                 );
@@ -463,7 +463,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                                 return true;
                             case R.id.sort_oldest_created:
                                 AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.SORT_TAPPED,
+                                    AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
                                     AnalyticsTracker.CATEGORY_SETTING,
                                     "created_oldest"
                                 );
@@ -474,7 +474,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                                 return true;
                             case R.id.sort_newest_modified:
                                 AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.SORT_TAPPED,
+                                    AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
                                     AnalyticsTracker.CATEGORY_SETTING,
                                     "modified_newest"
                                 );
@@ -485,7 +485,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                                 return true;
                             case R.id.sort_oldest_modified:
                                 AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.SORT_TAPPED,
+                                    AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
                                     AnalyticsTracker.CATEGORY_SETTING,
                                     "modified_oldest"
                                 );

--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
@@ -168,7 +168,7 @@ public final class AnalyticsTracker {
         VERIFICATION_CHANGE_EMAIL_BUTTON_TAPPED,
         VERIFICATION_RESEND_EMAIL_BUTTON_TAPPED,
         VERIFICATION_DISMISSED,
-        SORT_TAPPED
+        SETTINGS_SEARCH_SORT_MODE
     }
 
     public interface Tracker {


### PR DESCRIPTION
### Fix
Update the statistic for sort analytics tracking added in https://github.com/Automattic/simplenote-android/pull/1285 so that it is consistent across platforms.

### Test
Since there are no user-facing changes in this pull request, there are no test steps to perform.  Verifying the `SORT_TAPPED` statistic was refactored to `SETTINGS_SEARCH_SORT_MODE` is sufficient.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.