### PR TITLE
Add Dismiss Verify

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/ReviewAccountVerifyEmailFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/ReviewAccountVerifyEmailFragment.java
@@ -1,6 +1,8 @@
 package com.automattic.simplenote;
 
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.Html;
 import android.util.Base64;
 import android.view.LayoutInflater;
@@ -160,6 +162,30 @@ public class ReviewAccountVerifyEmailFragment extends Fragment implements FullSc
 
     @Override
     public void onNetworkChange(Bucket<Account> bucket, Bucket.ChangeType type, String key) {
+        dismissIfVerified();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        new Handler(Looper.getMainLooper()).postDelayed(
+            new Runnable() {
+                @Override
+                public void run() {
+                    dismissIfVerified();
+                }
+            },
+            getResources().getInteger(android.R.integer.config_mediumAnimTime)
+        );
+    }
+
+    @Override
+    public void onViewCreated(FullScreenDialogController controller) {
+        mDialogController = controller;
+    }
+
+    private void dismissIfVerified() {
         if (isDetached() || isRemoving()) {
             return;
         }
@@ -173,11 +199,6 @@ public class ReviewAccountVerifyEmailFragment extends Fragment implements FullSc
         } catch (BucketObjectMissingException bucketObjectMissingException) {
             // Do nothing if account cannot be retrieved.
         }
-    }
-
-    @Override
-    public void onViewCreated(FullScreenDialogController controller) {
-        mDialogController = controller;
     }
 
     public static Bundle newBundle(boolean hasSentEmail) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/ReviewAccountVerifyEmailFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/ReviewAccountVerifyEmailFragment.java
@@ -169,14 +169,13 @@ public class ReviewAccountVerifyEmailFragment extends Fragment implements FullSc
     public void onResume() {
         super.onResume();
 
-        new Handler(Looper.getMainLooper()).postDelayed(
+        new Handler(Looper.getMainLooper()).post(
             new Runnable() {
                 @Override
                 public void run() {
                     dismissIfVerified();
                 }
-            },
-            getResources().getInteger(android.R.integer.config_mediumAnimTime)
+            }
         );
     }
 


### PR DESCRIPTION
### Fix
Add dismissing the **_Review Your Account_** / **_Verify Your Email_** interface when it is shown and returning to the app after verifying the email address.

### Test
1. Remove app from recents/overview list if present.
2. Launch app.
3. Notice ***Review Your Account*** interface is shown.
4. Tap ***Confirm*** button.
5. Notice ***Verify Your Email*** interface is shown.
6. Notice verification email is sent to email address shown.
7. Tap link in verification email.
8. Notice web browser is shown with ***Email Verified*** page.
9. Tap recents/overview system navigation button.
10. Tap app in recents/overview list.
11. Notice ***Verify Your Email*** interface is dismissed.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.