### PR TITLE
Add Link Error

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -232,6 +232,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                             try {
                                 BrowserUtils.launchBrowserOrShowError(requireContext(), mLinkText);
                             } catch (Exception e) {
+                                BrowserUtils.showDialogErrorException(requireContext(), mLinkText);
                                 e.printStackTrace();
                             }
                         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/BrowserUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/BrowserUtils.java
@@ -78,4 +78,25 @@ public class BrowserUtils {
             .setPositiveButton(android.R.string.ok, null)
             .show();
     }
+
+    public static void showDialogErrorException(Context base, final String url) {
+        final Context context = new ContextThemeWrapper(base, base.getTheme());
+        new AlertDialog.Builder(context)
+            .setTitle(R.string.dialog_browser_exception_title)
+            .setMessage(R.string.dialog_browser_exception_message)
+            .setNeutralButton(R.string.dialog_browser_exception_button_copy_url,
+                    new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            if (copyToClipboard(context, url)) {
+                                Toast.makeText(context, R.string.dialog_browser_exception_toast_copy_success, Toast.LENGTH_SHORT).show();
+                            } else {
+                                Toast.makeText(context, R.string.dialog_browser_exception_toast_copy_failure, Toast.LENGTH_SHORT).show();
+                        }
+                    }
+                }
+            )
+            .setPositiveButton(android.R.string.ok, null)
+            .show();
+    }
 }

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -271,6 +271,11 @@
     <string name="description_up">Up</string>
     <string name="description_warning">Warning</string>
 
+    <string name="dialog_browser_exception_button_copy_url">Copy URL</string>
+    <string name="dialog_browser_exception_message">An app could not be opened with that link.</string>
+    <string name="dialog_browser_exception_title">Link Error</string>
+    <string name="dialog_browser_exception_toast_copy_failure">URL could not be copied to clipboard</string>
+    <string name="dialog_browser_exception_toast_copy_success">URL copied to clipboard</string>
     <string name="dialog_tag_conflict_button_positive">Merge</string>
     <string name="dialog_tag_conflict_message">The tag \"%1$s\" already exists. Would you like to merge \"%2$s\" into the \"%3$s\" tag?</string>
     <string name="dialog_tag_conflict_title">Tag Conflict</string>


### PR DESCRIPTION
### Fix
Add showing a dialog titled ***Link Error*** with the ***An app could not be opened with that link.*** message and ***Copy Url***/***OK*** buttons when trying to open a link with an external browser app and an exception occurs to close #1289.  This dialog mimics the ***No Browser Installed*** dialog shown when trying to open a link when no browser is installed on the device.  See the screenshots below for illustration.

![add_link_error](https://user-images.githubusercontent.com/3827611/106340311-94e9ec80-6256-11eb-83f1-1229dc89192f.png)

### Test
1. Tap any note in list.
2. Enter ***wp.com*** in note content.
3. Wait two seconds for note to save.
4. Notice ***wp.com*** is linkified.
5. Tap inside link text.
6. Notice ***Link*** app bar.
7. Tap ***View in Browser*** action in app bar.
8. Notice ***Link Error*** dialog is shown.
9. Tap ***OK*** button in dialog.
10. Tap inside link text.
11. Notice ***Link*** app bar.
12. Tap ***View in Browser*** action in app bar.
13. Notice ***Link Error*** dialog is shown.
14. Tap ***Copy URL*** button in dialog.
15. Notice ***URL copied to clipboard*** message is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.  @zdenys, I requested your review to ensure the issue is fixed since you discovered the issue.

### Release
These changes do not require release notes.