### PR TITLE
Update screenshots automation – 2021/02

### DIFF
--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
@@ -258,18 +258,23 @@ public class ScreenshotTest {
     }
 
     private void loadSearchFromNotesList(String query) {
-        final int searchViewId = R.id.search_src_text;
-
         // Tap the search button in the toolbar
-        onView(withId(R.id.menu_search)).perform(click());
+        final int searchButtonId = R.id.menu_search;
+        waitForViewMatching(withId(searchButtonId), 5000);
+        onView(withId(searchButtonId)).perform(click());
+
         // Type the search query
+        final int searchViewId = R.id.search_src_text;
         onView(withId(searchViewId)).perform(typeSearchViewText(query));
         onView(withId(searchViewId)).perform(pressImeActionButton());
     }
 
     private void loadSideMenuFromNotesList() {
         // There is no R.id for the menu drawer button
-        onView(allOf(withContentDescription("Open drawer"))).perform(click());
+        final String contentDescription = "Open drawer";
+
+        waitForViewToBeDisplayed(withContentDescription(contentDescription), 2000);
+        onView(allOf(withContentDescription(contentDescription))).perform(click());
     }
 
     private void loadSettingsFromNotesList() {

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
@@ -2,21 +2,15 @@ package com.automattic.simplenote.screenshots;
 
 import android.content.Context;
 import android.content.Intent;
-import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
-import android.widget.ListView;
 
 import androidx.appcompat.widget.SearchView;
-import androidx.recyclerview.widget.RecyclerView;
 import androidx.test.core.app.ApplicationProvider;
-import androidx.test.espresso.IdlingResource;
-import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.espresso.PerformException;
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
-import androidx.test.espresso.ViewAssertion;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.assertion.ViewAssertions;
@@ -39,7 +33,6 @@ import com.google.android.material.textfield.TextInputLayout;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -48,7 +41,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
@@ -66,13 +58,10 @@ import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
-import static androidx.test.espresso.matcher.ViewMatchers.withChild;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 import static tools.fastlane.screengrab.cleanstatusbar.BarsMode.TRANSPARENT;
@@ -135,6 +124,10 @@ public class ScreenshotTest {
         }
 
         selectNoteFromNotesList();
+
+        // It can happen that the email verification screen appears on the note editor instead of
+        // the note list screen, so look for one and dismiss it if found.
+        dismissVerifyEmailScreenIfNeeded();
 
         Screengrab.screenshot("note");
 
@@ -321,7 +314,9 @@ public class ScreenshotTest {
     // Notes Editor Screen
 
     private void dismissNoteEditor() {
-        onView(withContentDescription("Navigate up")).perform(click());
+        final String contentDescripion = "Navigate up";
+        waitForViewToBeDisplayed(withContentDescription(contentDescripion), 5000);
+        onView(withContentDescription(contentDescripion)).perform(click());
     }
 
     // Search Screen

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
@@ -113,11 +113,7 @@ public class ScreenshotTest {
 
         Screengrab.screenshot("note");
 
-        // On the tablet, the editor is side-by-side the notes list by default. We only need to
-        // dismiss it when running on the phone.
-        if (isPhone()) {
-            dismissNoteEditor();
-        }
+        dismissNoteEditor();
 
         loadSearchFromNotesList("Recipe");
         // Make sure the results have been rendered
@@ -130,12 +126,6 @@ public class ScreenshotTest {
         enableDarkModeFromNotesList();
 
         dismissSettings();
-
-        // On the tablet, at this point of the flow, there is no note selected. That would make for
-        // an "empty" screenshot. Select one note to make it more interesting.
-        if (!isPhone()) {
-            selectNoteFromNotesList();
-        }
 
         Screengrab.screenshot("notes-list");
 
@@ -549,15 +539,5 @@ public class ScreenshotTest {
                         .build();
             }
         };
-    }
-
-    // Modified from https://stackoverflow.com/a/30270939/809944
-    private boolean isPhone() {
-        DisplayMetrics displayMetrics = new DisplayMetrics();
-        this.mActivityTestRule.getActivity().getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
-        float widthDp = displayMetrics.widthPixels / displayMetrics.density;
-        float heightDp = displayMetrics.heightPixels / displayMetrics.density;
-        float screenSw = Math.min(widthDp, heightDp);
-        return screenSw < 600;
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
@@ -94,6 +94,8 @@ public class ScreenshotTest {
     public void screenshotTest() throws InterruptedException {
         // Pre-checks if the state is dirty
         enterThenDisablePasscodeIfNeeded();
+        dismissVerifyEmailScreenIfNeeded();
+
         logoutIfNeeded();
 
         login();
@@ -104,6 +106,7 @@ public class ScreenshotTest {
         // app changing root activity (from login to notes list) but I haven't had the time to
         // research it properly
         Thread.sleep(2000);
+        dismissVerifyEmailScreenIfNeeded();
         waitForViewMatching(allOf(withId(R.id.note_title), withText(NOTE_TITLE)), 5000);
 
         selectNoteFromNotesList();
@@ -174,6 +177,15 @@ public class ScreenshotTest {
     }
 
     // Flows
+
+    private void dismissVerifyEmailScreenIfNeeded() {
+        // This is quite brittle. Would be good to have a unique identifier instead.
+        final String contentDescription = "Close";
+
+        if (isViewDisplayed(getViewByContent(contentDescription))) {
+            onView(withContentDescription(contentDescription)).perform(click());
+        }
+    }
 
     private void logoutIfNeeded() {
         if (!isViewDisplayed(getViewById(R.id.list_root))) {
@@ -379,6 +391,10 @@ public class ScreenshotTest {
 
     private ViewInteraction getViewById(Integer id) {
         return onView(allOf(ViewMatchers.withId(id), isDisplayed()));
+    }
+
+    private ViewInteraction getViewByContent(String contentDescription) {
+        return onView(allOf(withContentDescription(contentDescription), isDisplayed()));
     }
 
     private Boolean isViewDisplayed(ViewInteraction view) {

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
@@ -128,6 +128,12 @@ public class ScreenshotTest {
 
         dismissSettings();
 
+        // On the tablet, at this point of the flow, there is no note selected. That would make for
+        // an "empty" screenshot. Select one note to make it more interesting.
+        if (!isPhone()) {
+            selectNoteFromNotesList();
+        }
+
         Screengrab.screenshot("notes-list");
 
         loadSideMenuFromNotesList();

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
@@ -6,12 +6,17 @@ import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.widget.ListView;
 
 import androidx.appcompat.widget.SearchView;
+import androidx.recyclerview.widget.RecyclerView;
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.IdlingResource;
+import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.espresso.PerformException;
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.ViewAssertion;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.assertion.ViewAssertions;
@@ -34,6 +39,7 @@ import com.google.android.material.textfield.TextInputLayout;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -42,6 +48,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import tools.fastlane.screengrab.Screengrab;
@@ -57,10 +66,13 @@ import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
+import static androidx.test.espresso.matcher.ViewMatchers.withChild;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 import static tools.fastlane.screengrab.cleanstatusbar.BarsMode.TRANSPARENT;
@@ -107,7 +119,20 @@ public class ScreenshotTest {
         // research it properly
         Thread.sleep(2000);
         dismissVerifyEmailScreenIfNeeded();
-        waitForViewMatching(allOf(withId(R.id.note_title), withText(NOTE_TITLE)), 5000);
+        // We want the full list of notes to be on screen when taking the screenshots, so let's wait
+        // for enough notes to be on screen to be relatively confident that's happened.
+        //
+        // Obviously, it would be better to have something like "wait for notes to load" but I
+        // wasn't able to find a way to achieve this – Gio
+        List<String> noteTitles = Arrays.asList(
+                NOTE_TITLE,
+                "Bret Victor's Quote Collection",
+                "Back on track",
+                "# Colors"
+        );
+        for (String title:noteTitles) {
+            waitForViewMatching(allOf(withId(R.id.note_title), withText(title)), 5000);
+        }
 
         selectNoteFromNotesList();
 

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
@@ -2,6 +2,7 @@ package com.automattic.simplenote.screenshots;
 
 import android.content.Context;
 import android.content.Intent;
+import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
@@ -109,7 +110,11 @@ public class ScreenshotTest {
 
         Screengrab.screenshot("note");
 
-        dismissNoteEditor();
+        // On the tablet, the editor is side-by-side the notes list by default. We only need to
+        // dismiss it when running on the phone.
+        if (isPhone()) {
+            dismissNoteEditor();
+        }
 
         loadSearchFromNotesList("Recipe");
         // Make sure the results have been rendered
@@ -522,5 +527,15 @@ public class ScreenshotTest {
                         .build();
             }
         };
+    }
+
+    // Modified from https://stackoverflow.com/a/30270939/809944
+    private boolean isPhone() {
+        DisplayMetrics displayMetrics = new DisplayMetrics();
+        this.mActivityTestRule.getActivity().getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+        float widthDp = displayMetrics.widthPixels / displayMetrics.density;
+        float heightDp = displayMetrics.heightPixels / displayMetrics.density;
+        float screenSw = Math.min(widthDp, heightDp);
+        return screenSw < 600;
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
@@ -69,7 +69,7 @@ import static tools.fastlane.screengrab.cleanstatusbar.IconVisibility.SHOW;
 @RunWith(AndroidJUnit4.class)
 public class ScreenshotTest {
     private static final int LAUNCH_TIMEOUT = 5000;
-    private static final String NOTE_TITLE = "# Lemon Cake & Blueberry";
+    private static final String NOTE_TITLE = "Lemon Cake & Blueberry";
 
     @ClassRule
     public static final LocaleTestRule localeTestRule = new LocaleTestRule();

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/screenshots/ScreenshotTest.java
@@ -132,7 +132,7 @@ public class ScreenshotTest {
         // the note list screen, so look for one and dismiss it if found.
         dismissVerifyEmailScreenIfNeeded();
 
-        Screengrab.screenshot("note");
+        Screengrab.screenshot("01-note");
 
         dismissNoteEditor();
 
@@ -145,7 +145,7 @@ public class ScreenshotTest {
         // Make sure the results have been rendered
         waitForViewMatching(allOf(withId(R.id.note_title), withText(NOTE_FOR_EDITOR_SHOT_TITLE)), 1000);
 
-        Screengrab.screenshot("search");
+        Screengrab.screenshot("05-search");
 
         dismissSearch();
 
@@ -153,11 +153,11 @@ public class ScreenshotTest {
 
         dismissSettings();
 
-        Screengrab.screenshot("notes-list");
+        Screengrab.screenshot("02-notes-list");
 
         loadSideMenuFromNotesList();
 
-        Screengrab.screenshot("tags");
+        Screengrab.screenshot("04-tags");
 
         loadSettingsFromSideMenu();
 
@@ -176,7 +176,7 @@ public class ScreenshotTest {
         tapPasscodeKeypad();
         tapPasscodeKeypad();
         tapPasscodeKeypad();
-        Screengrab.screenshot("pin");
+        Screengrab.screenshot("06-pin");
         tapPasscodeKeypad();
 
         loadSettingsFromNotesList();
@@ -357,7 +357,7 @@ public class ScreenshotTest {
 
         // Give the inter-note linking picker time to appear before taking the screenshot
         Thread.sleep(500);
-        Screengrab.screenshot("inter-note-linking");
+        Screengrab.screenshot("03-inter-note-linking");
 
         onView(withContentDescription("More Options")).perform(click());
 


### PR DESCRIPTION
### Fix

It's time to update the screenshots on the Store.
This PR contains ~~prep-work to make the automated test suite that generates the screenshots work with the latest version of the app~~ all the necessary code. _I initially planned to do it in two steps, first make the current automation work, then update it, but the second step turned out to be only a hundred lines or so and 
 didn't impact the diff size much, so I put it all in one PR to simplify the review._

### Test

- Run the tests for the "SimplenoteScreenshots" configuration and ensure the pass on both a phone and a tablet (I used Pixel 3 and Pixel C emulators)
- Run `bundle install` from the root of the project. You need to do this only once.
- Make sure you only have one Emulator running and run `bundle exec fastlane take_screeshots`. The task should succeed and open a browser window with the screenshots it took.
- Quit the Emulator and launch one for the opposite device type
- Run `bundle exec fastlane take_screeshots`. The task should succeed and open a browser window with the screenshots it took.

_If the test fails, try running them again. It worked for me the few times that happened..._ 😳 

<img width="1231" alt="Screen Shot 2021-02-12 at 9 32 30 pm" src="https://user-images.githubusercontent.com/1218433/107757652-f1322d80-6d79-11eb-83ae-4386cb131029.png">

<img width="1230" alt="Screen Shot 2021-02-12 at 9 29 36 pm" src="https://user-images.githubusercontent.com/1218433/107757434-a87a7480-6d79-11eb-9c0a-c08ce62bc6a3.png">


### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.