### PR TITLE
Add Save Scroll

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.17
 -----
+* Added scrolling to last position when opening a note [https://github.com/Automattic/simplenote-android/pull/1300]
 * Added sort bar at top of note list [https://github.com/Automattic/simplenote-android/pull/1284]
 
 2.16

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -580,6 +580,16 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         return mRootView;
     }
 
+    public void removeScrollListener() {
+        mRootView.setOnScrollChangeListener(
+            new View.OnScrollChangeListener() {
+                @Override
+                public void onScrollChange(View v, int scrollX, int scrollY, int oldScrollX, int oldScrollY) {
+                }
+            }
+        );
+    }
+
     public void scrollToMatch(int location) {
         if (isAdded()) {
             // Calculate how far to scroll to bring the match into view

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -581,13 +581,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     }
 
     public void removeScrollListener() {
-        mRootView.setOnScrollChangeListener(
-            new View.OnScrollChangeListener() {
-                @Override
-                public void onScrollChange(View v, int scrollX, int scrollY, int oldScrollX, int oldScrollY) {
-                }
-            }
-        );
+        mRootView.setOnScrollChangeListener(null);
     }
 
     public void scrollToMatch(int location) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -84,6 +84,7 @@ import java.lang.ref.WeakReference;
 import java.util.Calendar;
 import java.util.Set;
 
+import static com.automattic.simplenote.Simplenote.SCROLL_POSITION_PREFERENCES;
 import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_NOTE;
 import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.EDITOR_CHECKLIST_INSERTED;
 import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.EDITOR_NOTE_CONTENT_SHARED;
@@ -159,6 +160,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     private HistoryBottomSheetDialog mHistoryBottomSheet;
     private LinearLayout mError;
     private NoteMarkdownFragment mNoteMarkdownFragment;
+    private SharedPreferences mPreferences;
     private String mCss;
     private WebView mMarkdown;
     private boolean mIsPaused;
@@ -316,6 +318,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
         super.onCreate(savedInstanceState);
         AppLog.add(Type.NETWORK, NetworkUtils.getNetworkInfo(requireContext()));
         AppLog.add(Type.SCREEN, "Created (NoteEditorFragment)");
+        mPreferences = requireContext().getSharedPreferences(SCROLL_POSITION_PREFERENCES, Context.MODE_PRIVATE);
         mInfoBottomSheet = new InfoBottomSheetDialog(this);
         mShareBottomSheet = new ShareBottomSheetDialog(this, this);
         mHistoryBottomSheet = new HistoryBottomSheetDialog(this, this);
@@ -542,6 +545,16 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                     int lineTop = layout.getLineTop(layout.getLineForOffset(matchLocation));
                     ((NestedScrollView) mRootView).smoothScrollTo(0, lineTop);
                     mShouldScrollToSearchMatch = false;
+                } else if (mNote != null && mNote.getSimperiumKey() != null) {
+                    ((NestedScrollView) mRootView).scrollTo(0, mPreferences.getInt(mNote.getSimperiumKey(), 0));
+                    mRootView.setOnScrollChangeListener(
+                        new View.OnScrollChangeListener() {
+                            @Override
+                            public void onScrollChange(View v, int scrollX, int scrollY, int oldScrollX, int oldScrollY) {
+                                mPreferences.edit().putInt(mNote.getSimperiumKey(), scrollY).apply();
+                            }
+                        }
+                    );
                 }
             }
         });

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -460,6 +460,24 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                 mMarkdown.setWebViewClient(
                     new WebViewClient() {
                         @Override
+                        public void onPageFinished(final WebView view, String url) {
+                            super.onPageFinished(view, url);
+                            if (mMarkdown.getVisibility() == View.VISIBLE) {
+                                new Handler().postDelayed(
+                                    new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            if (mNote != null && mNote.getSimperiumKey() != null) {
+                                                ((NestedScrollView) mRootView).scrollTo(0, mPreferences.getInt(mNote.getSimperiumKey(), 0));
+                                            }
+                                        }
+                                    },
+                                    requireContext().getResources().getInteger(android.R.integer.config_mediumAnimTime)
+                                );
+                            }
+                        }
+
+                        @Override
                         public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request){
                             String url = request.getUrl().toString();
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1185,6 +1185,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
             startActivityForResult(editNoteIntent, Simplenote.INTENT_EDIT_NOTE);
         } else {
+            mNoteEditorFragment.removeScrollListener();
             mNoteEditorFragment.setNote(noteID, matchOffsets);
             getNoteListFragment().setNoteSelected(noteID);
             setMarkdownShowing(isPreviewEnabled && matchOffsets == null);

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -58,6 +58,7 @@ import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KE
 public class Simplenote extends Application implements HeartbeatListener {
     public static final String DELETED_NOTE_ID = "deletedNoteId";
     public static final String SELECTED_NOTE_ID = "selectedNoteId";
+    public static final String SCROLL_POSITION_PREFERENCES = "scroll_position";
     public static final String SYNC_TIME_PREFERENCES = "sync_time";
     public static final String TAG = "Simplenote";
     public static final int INTENT_EDIT_NOTE = 2;

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/AuthUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/AuthUtils.java
@@ -11,6 +11,7 @@ import com.automattic.simplenote.utils.AppLog.Type;
 
 import org.wordpress.passcodelock.AppLockManager;
 
+import static com.automattic.simplenote.Simplenote.SCROLL_POSITION_PREFERENCES;
 import static com.automattic.simplenote.Simplenote.SYNC_TIME_PREFERENCES;
 
 public class AuthUtils {
@@ -39,6 +40,9 @@ public class AuthUtils {
         // Remove WordPress sites
         editor.remove(PrefUtils.PREF_WORDPRESS_SITES);
         editor.apply();
+
+        // Remove note scroll positions
+        application.getSharedPreferences(SCROLL_POSITION_PREFERENCES, Context.MODE_PRIVATE).edit().clear().apply();
 
         // Remove note last sync times
         application.getSharedPreferences(SYNC_TIME_PREFERENCES, Context.MODE_PRIVATE).edit().clear().apply();


### PR DESCRIPTION
### Fix
Add saving the position when scrolling a note and automatically scrolling to the saved position when opening a note.  The scroll position is saved locally per note per device.  The scroll position for a note is saved and scrolled whether the editor and markdown view is shown.  In other words, opening a note will scroll to the last scrolled position whether the note is opened showing the editor or preview.

In my testing, automatically scrolling to a position in a `WebView` didn't work unless a short delay was added after the page was finished loading.  I chose `config_mediumAnimTime`, which is 400ms, since it worked well during testing.  That choice was rather arbitrary and I'm open to other solutions suggested.

### Test
1. Tap any note in list.
2. Notice note is opened with content scrolled to the top.
3. Scroll down any amount in note.
4. Tap back arrow or navigation button.
5. Tap note from Step 1 in note list.
6. Notice note is opened with content scroll to last position.

### Review
Only one developer is required to review these changes, but anyone can perform the review.  @SylvesterWilmott, I didn't request your review or include the `[status] needs design review` label since there isn't much to see in the interface, but feel free to check these changes if you would like.

### Release
`RELEASE-NOTES.txt` was updated in d16551a2 with:
> Added scrolling to last position when opening a note [https://github.com/Automattic/simplenote-android/pull/1300]