### PR TITLE
Crash Tags Edit

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -634,6 +634,15 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
         if (mTagsAdapter.getCountCustom() > 0) {
             mNavigationMenu.add(GROUP_SECONDARY, TAGS_ID, Menu.NONE, getString(R.string.tags)).setActionView(R.layout.drawer_action_edit).setEnabled(false);
+            MenuItem tagsHeader = mNavigationMenu.add(GROUP_SECONDARY, TAGS_ID, Menu.NONE, getString(R.string.tags)).setActionView(R.layout.drawer_action_edit).setEnabled(false);
+            tagsHeader.getActionView().findViewById(R.id.edit).setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        launchEditTags();
+                    }
+                }
+            );
 
             for (int i = 0; i < mTagsAdapter.getCount(); i++) {
                 String name = mTagsAdapter.getItem(i).name;
@@ -654,7 +663,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         }
     }
 
-    public void launchEditTags(View view) {
+    public void launchEditTags() {
         startActivity(new Intent(NotesActivity.this, TagsActivity.class));
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -638,7 +638,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
                 new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        launchEditTags();
+                        startActivity(new Intent(NotesActivity.this, TagsActivity.class));
                     }
                 }
             );
@@ -660,10 +660,6 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
             emptyTagsDivider.setVisibility(View.VISIBLE);
             emptyTagsHint.setVisibility(View.VISIBLE);
         }
-    }
-
-    public void launchEditTags() {
-        startActivity(new Intent(NotesActivity.this, TagsActivity.class));
     }
 
     public void createNewNote(View view) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -633,7 +633,6 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         View emptyTagsHint = findViewById(R.id.empty_tags_hint_text);
 
         if (mTagsAdapter.getCountCustom() > 0) {
-            mNavigationMenu.add(GROUP_SECONDARY, TAGS_ID, Menu.NONE, getString(R.string.tags)).setActionView(R.layout.drawer_action_edit).setEnabled(false);
             MenuItem tagsHeader = mNavigationMenu.add(GROUP_SECONDARY, TAGS_ID, Menu.NONE, getString(R.string.tags)).setActionView(R.layout.drawer_action_edit).setEnabled(false);
             tagsHeader.getActionView().findViewById(R.id.edit).setOnClickListener(
                 new View.OnClickListener() {

--- a/Simplenote/src/main/res/layout/drawer_action_edit.xml
+++ b/Simplenote/src/main/res/layout/drawer_action_edit.xml
@@ -15,7 +15,6 @@
         android:layout_gravity="center_vertical"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
-        android:onClick="launchEditTags"
         android:padding="@dimen/padding_small"
         android:text="@string/edit"
         android:textAllCaps="true"


### PR DESCRIPTION
### Fix
Update the method for launching the ***Edit Tags*** screen by tapping the ***Edit*** button in the ***Tags*** header of the navigation drawer to avoid an `IllegalStateException` crash on Android 6.0.x devices.

I don't think a hotfix is required after merging these changes since there is a very small number of Android 6.0.x devices using Simplenote, this crash appears to have been around for seventeen months, and it hasn't been reported before now.

### Test
Follow the steps below on a device running Android 6.0.x since the crash only occurs on devices running that version.
1. Open navigation drawer.
2. Tap ***Edit*** button in ***Tags*** header.
3. Notice app does not crash.
4. Notice ***Edit Tags*** screen is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.