### PR TITLE
Crash Empty Trash

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DrawableUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DrawableUtils.java
@@ -64,9 +64,9 @@ public class DrawableUtils {
     }
 
     public static void startAnimatedVectorDrawable(Drawable drawable) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        if (drawable instanceof AnimatedVectorDrawable && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             ((AnimatedVectorDrawable) drawable).start();
-        } else {
+        } else if (drawable instanceof AnimatedVectorDrawableCompat) {
             ((AnimatedVectorDrawableCompat) drawable).start();
         }
     }


### PR DESCRIPTION
### Fix
Add checking whether the `drawable` parameter is an instance of `AnimatedVectorDrawable` or `AnimatedVectorDrawableCompat` before casting the associated class to avoid the `ClassCastException` crash and close #1297.

### Test
The steps to reproduce the crash require two different devices.  They are labeled ***Device 1*** and ***Device 2*** in the steps below.
1. ***Device 1***: Tap any note in list.
2. ***Device 1***: Tap ellipsis/overflow menu action.
3. ***Device 1***: Tap ***Trash*** action in menu.
4. ***Device 1***: Tap back arrow or navigation button in app bar.
5. ***Device 1***: Open navigation drawer.
6. ***Device 1***: Tap ***Trash*** item in navigation drawer.
7. ***Device 1***: Tap ***Empty Trash*** action in app bar.
8. ***Device 2***: Open navigation drawer.
9. ***Device 2***: Tap ***Trash*** in navigation drawer.
10. ***Device 2***: Tap ***Empty Trash*** action in app bar.
11. ***Device 2***: Tap ***Empty*** button in dialog.
12. ***Device 2***: Notice trash is empty.
13. ***Device 1***: Tap ***Empty*** button in dialog.
14. ***Device 1***: Notice app does not crash.
15. ***Device 1***: Notice trash is empty.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.