### PR TITLE
Add Logout Account

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/AuthUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/AuthUtils.java
@@ -17,10 +17,13 @@ public class AuthUtils {
     public static void logOut(Simplenote application) {
         application.getSimperium().deauthorizeUser();
 
+        application.getAccountBucket().reset();
         application.getNotesBucket().reset();
         application.getTagsBucket().reset();
         application.getPreferencesBucket().reset();
 
+        application.getAccountBucket().stop();
+        AppLog.add(Type.SYNC, "Stopped account bucket (AuthUtils)");
         application.getNotesBucket().stop();
         AppLog.add(Type.SYNC, "Stopped note bucket (AuthUtils)");
         application.getTagsBucket().stop();


### PR DESCRIPTION
### Fix
Add resetting and stopping the `Account` bucket when logging out to mimic the other buckets and close #1296.  Even though the `Account` bucket does not contain note data, that data is being kept if the `Account` bucket is not reset and stopped.

### Test
Since the issue involves showing the previous account's notes after logout/login, two different Simplenote accounts with different note data is required to confirm the fix.  They are labeled Account 1 and Account 2 in the steps below.
1. Notice notes from ***Account 1***.
2. Open navigation drawer.
3. Tap ***Settings*** in navigation drawer.
4. Tap ***Log out*** under ***Account*** section.
5. Tap ***Log In*** button.
6. Tap ***Log In with Email*** button.
7. Enter email and password in ***Email*** and ***Password*** fields for ***Account 2***.
8. Tap ***Log In*** button.
9. Notice note from ***Account 2***.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Note
@mokagio, these changes will require a new release candidate build once they are merged.