### PR TITLE
Update Link Error

### DIFF
--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -272,7 +272,7 @@
     <string name="description_warning">Warning</string>
 
     <string name="dialog_browser_exception_button_copy_url">Copy URL</string>
-    <string name="dialog_browser_exception_message">An app could not be opened with that link.</string>
+    <string name="dialog_browser_exception_message">Cannot open link.  Copy the URL to paste it into a browser.</string>
     <string name="dialog_browser_exception_title">Link Error</string>
     <string name="dialog_browser_exception_toast_copy_failure">URL could not be copied to clipboard</string>
     <string name="dialog_browser_exception_toast_copy_success">URL copied to clipboard</string>


### PR DESCRIPTION
### Fix
Update the message copy in the **_Link Error_** dialog added in https://github.com/Automattic/simplenote-android/pull/1292.  See the screenshots below for illustration.

![update_error_link](https://user-images.githubusercontent.com/3827611/106620792-272c1200-652f-11eb-9864-ebfbeb94cebb.png)

### Test
1. Tap any note in list.
2. Enter ***wp.com*** in note content.
3. Wait two seconds for note to save.
4. Notice ***wp.com*** is linkified.
5. Tap inside link text.
6. Notice ***Link*** app bar.
7. Tap ***View in Browser*** action in app bar.
8. Notice ***Link Error*** dialog is shown.
9. Tap ***OK*** button in dialog.
10. Tap inside link text.
11. Notice ***Link*** app bar.
12. Tap ***View in Browser*** action in app bar.
13. Notice ***Link Error*** dialog is shown.
14. Notice updated copy as shown above.
15. Tap ***Copy URL*** button in dialog.
16. Notice ***URL copied to clipboard*** message is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.  @nbradbury, I requested your review since you reviewed the original pull request that I accidentally merged prematurely.

### Release
These changes do not require release notes.