### PR TITLE
Update Sort Tracking

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -430,7 +430,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                         switch (item.getItemId()) {
                             case R.id.sort_alphabetical:
                                 AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                                    AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
                                     AnalyticsTracker.CATEGORY_SETTING,
                                     "alphabetical_az"
                                 );
@@ -441,7 +441,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                                 return true;
                             case R.id.sort_alphabetical_reverse:
                                 AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                                    AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
                                     AnalyticsTracker.CATEGORY_SETTING,
                                     "alphabetical_za"
                                 );
@@ -452,7 +452,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                                 return true;
                             case R.id.sort_newest_created:
                                 AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                                    AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
                                     AnalyticsTracker.CATEGORY_SETTING,
                                     "created_newest"
                                 );
@@ -463,7 +463,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                                 return true;
                             case R.id.sort_oldest_created:
                                 AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                                    AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
                                     AnalyticsTracker.CATEGORY_SETTING,
                                     "created_oldest"
                                 );
@@ -474,7 +474,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                                 return true;
                             case R.id.sort_newest_modified:
                                 AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                                    AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
                                     AnalyticsTracker.CATEGORY_SETTING,
                                     "modified_newest"
                                 );
@@ -485,7 +485,7 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
                                 return true;
                             case R.id.sort_oldest_modified:
                                 AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                                    AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
                                     AnalyticsTracker.CATEGORY_SETTING,
                                     "modified_oldest"
                                 );

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -97,11 +97,17 @@ import static com.automattic.simplenote.models.Suggestion.Type.QUERY;
 import static com.automattic.simplenote.models.Suggestion.Type.TAG;
 import static com.automattic.simplenote.models.Tag.NAME_PROPERTY;
 import static com.automattic.simplenote.utils.PrefUtils.ALPHABETICAL_ASCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.ALPHABETICAL_ASCENDING_LABEL;
 import static com.automattic.simplenote.utils.PrefUtils.ALPHABETICAL_DESCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.ALPHABETICAL_DESCENDING_LABEL;
 import static com.automattic.simplenote.utils.PrefUtils.DATE_CREATED_ASCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.DATE_CREATED_ASCENDING_LABEL;
 import static com.automattic.simplenote.utils.PrefUtils.DATE_CREATED_DESCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.DATE_CREATED_DESCENDING_LABEL;
 import static com.automattic.simplenote.utils.PrefUtils.DATE_MODIFIED_ASCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.DATE_MODIFIED_ASCENDING_LABEL;
 import static com.automattic.simplenote.utils.PrefUtils.DATE_MODIFIED_DESCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.DATE_MODIFIED_DESCENDING_LABEL;
 
 /**
  * A list fragment representing a list of Notes. This fragment also supports
@@ -429,22 +435,22 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
                         switch (item.getItemId()) {
                             case R.id.sort_alphabetical:
-                                updateSortOrder("alphabetical_az", ALPHABETICAL_ASCENDING);
+                                updateSortOrder(ALPHABETICAL_ASCENDING_LABEL, ALPHABETICAL_ASCENDING);
                                 return true;
                             case R.id.sort_alphabetical_reverse:
-                                updateSortOrder("alphabetical_za", ALPHABETICAL_DESCENDING);
+                                updateSortOrder(ALPHABETICAL_DESCENDING_LABEL, ALPHABETICAL_DESCENDING);
                                 return true;
                             case R.id.sort_newest_created:
-                                updateSortOrder("created_newest", DATE_CREATED_DESCENDING);
+                                updateSortOrder(DATE_CREATED_DESCENDING_LABEL, DATE_CREATED_DESCENDING);
                                 return true;
                             case R.id.sort_oldest_created:
-                                updateSortOrder("created_oldest", DATE_CREATED_ASCENDING);
+                                updateSortOrder(DATE_CREATED_ASCENDING_LABEL, DATE_CREATED_ASCENDING);
                                 return true;
                             case R.id.sort_newest_modified:
-                                updateSortOrder("modified_newest", DATE_MODIFIED_DESCENDING);
+                                updateSortOrder(DATE_MODIFIED_DESCENDING_LABEL, DATE_MODIFIED_DESCENDING);
                                 return true;
                             case R.id.sort_oldest_modified:
-                                updateSortOrder("modified_oldest", DATE_MODIFIED_ASCENDING);
+                                updateSortOrder(DATE_MODIFIED_ASCENDING_LABEL, DATE_MODIFIED_ASCENDING);
                                 return true;
                             default:
                                 return false;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java
@@ -429,70 +429,22 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
                         switch (item.getItemId()) {
                             case R.id.sort_alphabetical:
-                                AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
-                                    AnalyticsTracker.CATEGORY_SETTING,
-                                    "alphabetical_az"
-                                );
-                                mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
-                                    String.valueOf(ALPHABETICAL_ASCENDING)
-                                ).apply();
-                                refreshList();
+                                updateSortOrder("alphabetical_az", ALPHABETICAL_ASCENDING);
                                 return true;
                             case R.id.sort_alphabetical_reverse:
-                                AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
-                                    AnalyticsTracker.CATEGORY_SETTING,
-                                    "alphabetical_za"
-                                );
-                                mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
-                                    String.valueOf(ALPHABETICAL_DESCENDING)
-                                ).apply();
-                                refreshList();
+                                updateSortOrder("alphabetical_za", ALPHABETICAL_DESCENDING);
                                 return true;
                             case R.id.sort_newest_created:
-                                AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
-                                    AnalyticsTracker.CATEGORY_SETTING,
-                                    "created_newest"
-                                );
-                                mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
-                                    String.valueOf(DATE_CREATED_DESCENDING)
-                                ).apply();
-                                refreshList();
+                                updateSortOrder("created_newest", DATE_CREATED_DESCENDING);
                                 return true;
                             case R.id.sort_oldest_created:
-                                AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
-                                    AnalyticsTracker.CATEGORY_SETTING,
-                                    "created_oldest"
-                                );
-                                mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
-                                    String.valueOf(DATE_CREATED_ASCENDING)
-                                ).apply();
-                                refreshList();
+                                updateSortOrder("created_oldest", DATE_CREATED_ASCENDING);
                                 return true;
                             case R.id.sort_newest_modified:
-                                AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
-                                    AnalyticsTracker.CATEGORY_SETTING,
-                                    "modified_newest"
-                                );
-                                mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
-                                    String.valueOf(DATE_MODIFIED_DESCENDING)
-                                ).apply();
-                                refreshList();
+                                updateSortOrder("modified_newest", DATE_MODIFIED_DESCENDING);
                                 return true;
                             case R.id.sort_oldest_modified:
-                                AnalyticsTracker.track(
-                                    AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
-                                    AnalyticsTracker.CATEGORY_SETTING,
-                                    "modified_oldest"
-                                );
-                                mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER,
-                                    String.valueOf(DATE_MODIFIED_ASCENDING)
-                                ).apply();
-                                refreshList();
+                                updateSortOrder("modified_oldest", DATE_MODIFIED_ASCENDING);
                                 return true;
                             default:
                                 return false;
@@ -510,6 +462,16 @@ public class NoteListFragment extends ListFragment implements AdapterView.OnItem
 
         getListView().setOnItemLongClickListener(this);
         getListView().setMultiChoiceModeListener(this);
+    }
+
+    private void updateSortOrder(String label, int index) {
+        AnalyticsTracker.track(
+            AnalyticsTracker.Stat.LIST_SORTBAR_MODE_CHANGED,
+            AnalyticsTracker.CATEGORY_SETTING,
+            label
+        );
+        mPreferences.edit().putString(PrefUtils.PREF_SORT_ORDER, String.valueOf(index)).apply();
+        refreshList();
     }
 
     public void showListPadding(boolean show) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -45,6 +45,12 @@ import java.util.List;
 
 import static android.app.Activity.RESULT_OK;
 import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
+import static com.automattic.simplenote.utils.PrefUtils.ALPHABETICAL_ASCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.ALPHABETICAL_DESCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.DATE_CREATED_ASCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.DATE_CREATED_DESCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.DATE_MODIFIED_ASCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.DATE_MODIFIED_DESCENDING;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -208,47 +214,23 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
 
                 if (!sortPreference.getValue().equals(newValue)) {
                     switch (index) {
-                        case 0:
-                            AnalyticsTracker.track(
-                                AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
-                                AnalyticsTracker.CATEGORY_SETTING,
-                                "modified_newest"
-                            );
+                        case ALPHABETICAL_ASCENDING:
+                            trackSortOrder("alphabetical_az");
                             break;
-                        case 1:
-                            AnalyticsTracker.track(
-                                AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
-                                AnalyticsTracker.CATEGORY_SETTING,
-                                "modified_oldest"
-                            );
+                        case ALPHABETICAL_DESCENDING:
+                            trackSortOrder("alphabetical_za");
                             break;
-                        case 2:
-                            AnalyticsTracker.track(
-                                AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
-                                AnalyticsTracker.CATEGORY_SETTING,
-                                "created_newest"
-                            );
+                        case DATE_CREATED_ASCENDING:
+                            trackSortOrder("created_oldest");
                             break;
-                        case 3:
-                            AnalyticsTracker.track(
-                                AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
-                                AnalyticsTracker.CATEGORY_SETTING,
-                                "created_oldest"
-                            );
+                        case DATE_CREATED_DESCENDING:
+                            trackSortOrder("created_newest");
                             break;
-                        case 4:
-                            AnalyticsTracker.track(
-                                AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
-                                AnalyticsTracker.CATEGORY_SETTING,
-                                "alphabetical_az"
-                            );
+                        case DATE_MODIFIED_ASCENDING:
+                            trackSortOrder("modified_oldest");
                             break;
-                        case 5:
-                            AnalyticsTracker.track(
-                                AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
-                                AnalyticsTracker.CATEGORY_SETTING,
-                                "alphabetical_za"
-                            );
+                        case DATE_MODIFIED_DESCENDING:
+                            trackSortOrder("modified_newest");
                             break;
                     }
                 }
@@ -466,6 +448,14 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
         } catch (Exception e) {
             Toast.makeText(requireContext(), getString(R.string.export_message_failure), Toast.LENGTH_SHORT).show();
         }
+    }
+
+    private void trackSortOrder(String label) {
+        AnalyticsTracker.track(
+            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+            AnalyticsTracker.CATEGORY_SETTING,
+            label
+        );
     }
 
     private void updateAnalyticsSwitchState() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -22,8 +22,8 @@ import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Preferences;
 import com.automattic.simplenote.utils.AppLog;
-import com.automattic.simplenote.utils.AuthUtils;
 import com.automattic.simplenote.utils.AppLog.Type;
+import com.automattic.simplenote.utils.AuthUtils;
 import com.automattic.simplenote.utils.BrowserUtils;
 import com.automattic.simplenote.utils.CrashUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
@@ -205,6 +205,51 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
                 int index = Integer.parseInt(newValue.toString());
                 CharSequence[] entries = sortPreference.getEntries();
                 sortPreference.setSummary(entries[index]);
+
+                switch (index) {
+                    case 0:
+                        AnalyticsTracker.track(
+                            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                            AnalyticsTracker.CATEGORY_SETTING,
+                            "modified_newest"
+                        );
+                        break;
+                    case 1:
+                        AnalyticsTracker.track(
+                            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                            AnalyticsTracker.CATEGORY_SETTING,
+                            "modified_oldest"
+                        );
+                        break;
+                    case 2:
+                        AnalyticsTracker.track(
+                            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                            AnalyticsTracker.CATEGORY_SETTING,
+                            "created_newest"
+                        );
+                        break;
+                    case 3:
+                        AnalyticsTracker.track(
+                            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                            AnalyticsTracker.CATEGORY_SETTING,
+                            "created_oldest"
+                        );
+                        break;
+                    case 4:
+                        AnalyticsTracker.track(
+                            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                            AnalyticsTracker.CATEGORY_SETTING,
+                            "alphabetical_az"
+                        );
+                        break;
+                    case 5:
+                        AnalyticsTracker.track(
+                            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                            AnalyticsTracker.CATEGORY_SETTING,
+                            "alphabetical_za"
+                        );
+                        break;
+                }
 
                 return true;
             }

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -46,11 +46,17 @@ import java.util.List;
 import static android.app.Activity.RESULT_OK;
 import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
 import static com.automattic.simplenote.utils.PrefUtils.ALPHABETICAL_ASCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.ALPHABETICAL_ASCENDING_LABEL;
 import static com.automattic.simplenote.utils.PrefUtils.ALPHABETICAL_DESCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.ALPHABETICAL_DESCENDING_LABEL;
 import static com.automattic.simplenote.utils.PrefUtils.DATE_CREATED_ASCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.DATE_CREATED_ASCENDING_LABEL;
 import static com.automattic.simplenote.utils.PrefUtils.DATE_CREATED_DESCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.DATE_CREATED_DESCENDING_LABEL;
 import static com.automattic.simplenote.utils.PrefUtils.DATE_MODIFIED_ASCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.DATE_MODIFIED_ASCENDING_LABEL;
 import static com.automattic.simplenote.utils.PrefUtils.DATE_MODIFIED_DESCENDING;
+import static com.automattic.simplenote.utils.PrefUtils.DATE_MODIFIED_DESCENDING_LABEL;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -215,22 +221,22 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
                 if (!sortPreference.getValue().equals(newValue)) {
                     switch (index) {
                         case ALPHABETICAL_ASCENDING:
-                            trackSortOrder("alphabetical_az");
+                            trackSortOrder(ALPHABETICAL_ASCENDING_LABEL);
                             break;
                         case ALPHABETICAL_DESCENDING:
-                            trackSortOrder("alphabetical_za");
+                            trackSortOrder(ALPHABETICAL_DESCENDING_LABEL);
                             break;
                         case DATE_CREATED_ASCENDING:
-                            trackSortOrder("created_oldest");
+                            trackSortOrder(DATE_CREATED_ASCENDING_LABEL);
                             break;
                         case DATE_CREATED_DESCENDING:
-                            trackSortOrder("created_newest");
+                            trackSortOrder(DATE_CREATED_DESCENDING_LABEL);
                             break;
                         case DATE_MODIFIED_ASCENDING:
-                            trackSortOrder("modified_oldest");
+                            trackSortOrder(DATE_MODIFIED_ASCENDING_LABEL);
                             break;
                         case DATE_MODIFIED_DESCENDING:
-                            trackSortOrder("modified_newest");
+                            trackSortOrder(DATE_MODIFIED_DESCENDING_LABEL);
                             break;
                     }
                 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -206,49 +206,51 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
                 CharSequence[] entries = sortPreference.getEntries();
                 sortPreference.setSummary(entries[index]);
 
-                switch (index) {
-                    case 0:
-                        AnalyticsTracker.track(
-                            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
-                            AnalyticsTracker.CATEGORY_SETTING,
-                            "modified_newest"
-                        );
-                        break;
-                    case 1:
-                        AnalyticsTracker.track(
-                            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
-                            AnalyticsTracker.CATEGORY_SETTING,
-                            "modified_oldest"
-                        );
-                        break;
-                    case 2:
-                        AnalyticsTracker.track(
-                            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
-                            AnalyticsTracker.CATEGORY_SETTING,
-                            "created_newest"
-                        );
-                        break;
-                    case 3:
-                        AnalyticsTracker.track(
-                            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
-                            AnalyticsTracker.CATEGORY_SETTING,
-                            "created_oldest"
-                        );
-                        break;
-                    case 4:
-                        AnalyticsTracker.track(
-                            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
-                            AnalyticsTracker.CATEGORY_SETTING,
-                            "alphabetical_az"
-                        );
-                        break;
-                    case 5:
-                        AnalyticsTracker.track(
-                            AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
-                            AnalyticsTracker.CATEGORY_SETTING,
-                            "alphabetical_za"
-                        );
-                        break;
+                if (!sortPreference.getValue().equals(newValue)) {
+                    switch (index) {
+                        case 0:
+                            AnalyticsTracker.track(
+                                AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                                AnalyticsTracker.CATEGORY_SETTING,
+                                "modified_newest"
+                            );
+                            break;
+                        case 1:
+                            AnalyticsTracker.track(
+                                AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                                AnalyticsTracker.CATEGORY_SETTING,
+                                "modified_oldest"
+                            );
+                            break;
+                        case 2:
+                            AnalyticsTracker.track(
+                                AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                                AnalyticsTracker.CATEGORY_SETTING,
+                                "created_newest"
+                            );
+                            break;
+                        case 3:
+                            AnalyticsTracker.track(
+                                AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                                AnalyticsTracker.CATEGORY_SETTING,
+                                "created_oldest"
+                            );
+                            break;
+                        case 4:
+                            AnalyticsTracker.track(
+                                AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                                AnalyticsTracker.CATEGORY_SETTING,
+                                "alphabetical_az"
+                            );
+                            break;
+                        case 5:
+                            AnalyticsTracker.track(
+                                AnalyticsTracker.Stat.SETTINGS_SEARCH_SORT_MODE,
+                                AnalyticsTracker.CATEGORY_SETTING,
+                                "alphabetical_za"
+                            );
+                            break;
+                    }
                 }
 
                 return true;

--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
@@ -168,7 +168,8 @@ public final class AnalyticsTracker {
         VERIFICATION_CHANGE_EMAIL_BUTTON_TAPPED,
         VERIFICATION_RESEND_EMAIL_BUTTON_TAPPED,
         VERIFICATION_DISMISSED,
-        SETTINGS_SEARCH_SORT_MODE
+        SETTINGS_SEARCH_SORT_MODE,
+        LIST_SORTBAR_MODE_CHANGED
     }
 
     public interface Tracker {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -87,6 +87,12 @@ public class PrefUtils {
     // string. Store notes linked to note widget instances.
     public static final String PREF_NOTE_WIDGET_NOTE = "pref_key_note_widget_";
 
+    public static final String ALPHABETICAL_ASCENDING_LABEL = "alphabetical_az";
+    public static final String ALPHABETICAL_DESCENDING_LABEL = "alphabetical_za";
+    public static final String DATE_CREATED_ASCENDING_LABEL = "created_oldest";
+    public static final String DATE_CREATED_DESCENDING_LABEL = "created_newest";
+    public static final String DATE_MODIFIED_ASCENDING_LABEL = "modified_oldest";
+    public static final String DATE_MODIFIED_DESCENDING_LABEL = "modified_newest";
     public static final int ALPHABETICAL_ASCENDING = 4;
     public static final int ALPHABETICAL_DESCENDING = 5;
     public static final int DATE_CREATED_ASCENDING = 3;


### PR DESCRIPTION
### Fix
Update the name of the analytics statistic for the sort order bar at the top of the note list updated in https://github.com/Automattic/simplenote-android/pull/1286 and add analytics for the sort order item in **_Settings_**.

### Test
Adding a breakpoint in the code can verify the event is triggered at the right time.  The steps below can be tested using a breakpoint [here](https://github.com/Automattic/simplenote-android/blob/c515a01897c094a0dfb21da0049ec93d4f86dbc1/Simplenote/src/main/java/com/automattic/simplenote/NoteListFragment.java#L430) for the sort order bar and [here](https://github.com/Automattic/simplenote-android/blob/c515a01897c094a0dfb21da0049ec93d4f86dbc1/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java#L209) for the sort order setting.

#### Bar
1. Tap sort bar.
2. Tap currently unselected sort option.
3. Notice breakpoint is triggered.
4. Tap sort bar.
5. Tap currently selected sort option.
6. Notice breakpoint is not triggered.

#### Setting
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Tap ***Sort order*** item under ***Notes*** section.
4. Tap currently unselected sort option.
5. Notice breakpoint is triggered.
6. Tap ***Sort order*** item under ***Notes*** section.
7. Tap currently selected sort option.
8. Notice breakpoint is not triggered.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.