### PR TITLE
Update View Link

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -2,11 +2,13 @@ package com.automattic.simplenote;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.ColorStateList;
 import android.database.Cursor;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
@@ -235,6 +237,11 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                                 BrowserUtils.showDialogErrorException(requireContext(), mLinkText);
                                 e.printStackTrace();
                             }
+                        } else {
+                            Uri uri = Uri.parse(mLinkUrl);
+                            Intent i = new Intent(Intent.ACTION_VIEW);
+                            i.setData(uri);
+                            startActivity(i);
                         }
 
                         mode.finish(); // Action picked, so close the CAB

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -228,7 +228,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                                 "internote_link_tapped_editor"
                             );
                             SimplenoteLinkify.openNote(requireActivity(), mLinkText.replace(SIMPLENOTE_LINK_PREFIX, ""));
-                        } else {
+                        } else if (!mLinkUrl.startsWith("geo:") && !mLinkUrl.startsWith("mailto:") && !mLinkUrl.startsWith("tel:")) {
                             try {
                                 BrowserUtils.launchBrowserOrShowError(requireContext(), mLinkText);
                             } catch (Exception e) {


### PR DESCRIPTION
### Fix
Update the view link action in the contextual action bar to include a default branch when the link is not an internote link, email address, map address, or telephone number to close #1307.  The default branch uses the original view link action that was removed in d20d5489f2a1265281b9486ae4891d6370d1ead6.

### Test
There are five types of links recognized by Simplenote; internote link, email address, map address, telephone number, and URL.  Each link type shows a specialized action in the contextual action bar when selected.  Follow the steps below for each link type to ensure the specialized action performs the expected behavior.
1. Tap any note in list with link.
2. Tap link within note content.
3. Notice contextual action bar.
4. Tap specialized action for link.
5. Notice activity started based on specialized action.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.