### PR TITLE
Fixed issue with capturing screenshot on the about screen

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/AboutActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AboutActivity.java
@@ -1,7 +1,6 @@
 package com.automattic.simplenote;
 
 import android.os.Bundle;
-import android.view.WindowManager;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -24,12 +23,6 @@ public class AboutActivity extends AppCompatActivity {
                 this, R.drawable.ic_cross_24dp, android.R.color.white
             ));
         }
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
     }
 
     @Override


### PR DESCRIPTION
### Fix
The user wasn't able to capture a screenshot on About screen.


### Test
1. Open app
2. Go to the settings
3. Scroll down
4. Tap on "About"
5. Try to capture the screenshot - you will see the notification that you can't save the screenshot. This pr is fixing this issue.


### Review
Only one developer required to review this issue.

### Release
These changes do not require release notes.

