### PR TITLE
Use comma as tag delimiter

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/AddTagActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AddTagActivity.java
@@ -131,6 +131,12 @@ public class AddTagActivity extends AppCompatActivity implements TextWatcher {
             return;
         }
 
+        if (tag.contains(",")) {
+            mButtonPositive.setEnabled(false);
+            mTagLayout.setError(getString(R.string.tag_error_commas));
+            return;
+        }
+
         if (!TagUtils.hashTagValid(tag)) {
             mButtonPositive.setEnabled(false);
             mTagLayout.setError(getString(R.string.tag_error_length));

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
@@ -154,6 +154,9 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
         } else if (isTagNameInvalidSpaces()) {
             mButtonPositive.setEnabled(false);
             mEditTextLayout.setError(getString(R.string.rename_tag_error_spaces));
+        } else if (isTagNameInvalidCommas()) {
+            mButtonPositive.setEnabled(false);
+            mEditTextLayout.setError(getString(R.string.rename_tag_error_commas));
         }
     }
 
@@ -170,7 +173,7 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
     }
 
     private boolean isTagNameValid() {
-        return !isTagNameInvalidSpaces() && !isTagNameInvalidLength() && !isTagNameInvalidEmpty();
+        return !isTagNameInvalidSpaces() && !isTagNameInvalidLength() && !isTagNameInvalidEmpty() && !isTagNameInvalidCommas();
     }
 
     private boolean isTagNameInvalidEmpty() {
@@ -183,6 +186,10 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
 
     private boolean isTagNameInvalidSpaces() {
         return mEditTextTag.getText() != null && mEditTextTag.getText().toString().contains(" ");
+    }
+
+    private boolean isTagNameInvalidCommas() {
+        return mEditTextTag.getText() != null && mEditTextTag.getText().toString().contains(",");
     }
 
     private void showDialogErrorConflict(String canonical, String tagOld) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
@@ -10,6 +10,7 @@ public class SearchTokenizer {
     static public final char SINGLE_QUOTE = '\'';
     static public final char GLOB = '*';
     static public final char COLON = ':';
+    static public final char COMMA = ',';
     static public final char ESCAPE = '\\';
     static public final char HYPHEN = '-';
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SearchTokenizer.java
@@ -10,7 +10,6 @@ public class SearchTokenizer {
     static public final char SINGLE_QUOTE = '\'';
     static public final char GLOB = '*';
     static public final char COLON = ':';
-    static public final char COMMA = ',';
     static public final char ESCAPE = '\\';
     static public final char HYPHEN = '-';
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
@@ -16,11 +16,8 @@ import com.automattic.simplenote.R;
 import com.automattic.simplenote.models.Tag;
 import com.simperium.client.Bucket;
 
-import static com.automattic.simplenote.utils.SearchTokenizer.COMMA;
-import static com.automattic.simplenote.utils.SearchTokenizer.EMPTY;
-import static com.automattic.simplenote.utils.SearchTokenizer.SPACE;
-
 public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTextView implements OnItemClickListener {
+
     private Bucket<Tag> mBucketTag;
     private OnTagAddedListener mTagAddedListener;
     private TextWatcher mTextWatcher = new TextWatcher() {
@@ -39,7 +36,7 @@ public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTex
 
         @Override
         public void onTextChanged(CharSequence s, int start, int before, int count) {
-            if (count >= 1 && (s.charAt(start) == SPACE || s.charAt(start) == COMMA)) {
+            if (count >= 1 && (s.charAt(start) == ' ' || s.charAt(start) == ',')) {
                 saveTagOrShowError(s.toString());
             }
         }
@@ -85,7 +82,7 @@ public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTex
     }
 
     public void notifyTagsChanged() {
-        String lexical = getText().toString().replace(String.valueOf(COMMA), EMPTY).trim();
+        String lexical = getText().toString().replace(',', ' ').trim();
         String canonical = TagUtils.getCanonicalFromLexical(mBucketTag, lexical);
         notifyTagsChanged(canonical);
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagsMultiAutoCompleteTextView.java
@@ -16,6 +16,8 @@ import com.automattic.simplenote.R;
 import com.automattic.simplenote.models.Tag;
 import com.simperium.client.Bucket;
 
+import static com.automattic.simplenote.utils.SearchTokenizer.COMMA;
+import static com.automattic.simplenote.utils.SearchTokenizer.EMPTY;
 import static com.automattic.simplenote.utils.SearchTokenizer.SPACE;
 
 public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTextView implements OnItemClickListener {
@@ -37,7 +39,7 @@ public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTex
 
         @Override
         public void onTextChanged(CharSequence s, int start, int before, int count) {
-            if (count >= 1 && s.charAt(start) == SPACE) {
+            if (count >= 1 && (s.charAt(start) == SPACE || s.charAt(start) == COMMA)) {
                 saveTagOrShowError(s.toString());
             }
         }
@@ -83,7 +85,7 @@ public class TagsMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTex
     }
 
     public void notifyTagsChanged() {
-        String lexical = getText().toString().trim();
+        String lexical = getText().toString().replace(String.valueOf(COMMA), EMPTY).trim();
         String canonical = TagUtils.getCanonicalFromLexical(mBucketTag, lexical);
         notifyTagsChanged(canonical);
     }

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="rename_tag_error_empty">Tags cannot be empty</string>
     <string name="rename_tag_error_length">Tag length too long</string>
     <string name="rename_tag_error_spaces">Tags cannot contain spaces</string>
+    <string name="rename_tag_error_commas">Tags cannot contain commas</string>
     <string name="rename_tag_message">An error occurred renaming the tag. Please, try again. If the problem continues, contact us at %1$s%2$s%3$s%4$s%5$s for help.</string>
     <string name="rename_tag_message_length">The tag length is too long. Please, try again with a shorter name. If the problem continues, contact us at %1$s%2$s%3$s%4$s%5$s for help.</string>
     <string name="tag_name">Tag name</string>
@@ -114,6 +115,7 @@
     <string name="tag_error_exists">Tag already exists</string>
     <string name="tag_error_length">Tag length too long</string>
     <string name="tag_error_spaces">Tags cannot contain spaces</string>
+    <string name="tag_error_commas">Tags cannot contain commas</string>
 
     <!-- Undo -->
     <string name="undo">Undo</string>


### PR DESCRIPTION
Fixes #1299

### Fix

- A comma character can now be used as a delimiter when adding tags from the tag input field within the note editor view.
- Tag name cannot contain commas.

![Peek 2021-02-21 00-21](https://user-images.githubusercontent.com/5927747/108606637-1c072c00-73e1-11eb-8789-f49cec2099d4.gif)

### Test

#### Use comma as a delimiter

1. Go to the note editor screen, either by tapping on an existing note or by tapping on the plus sign that creates a new note
2. Enter some text (without spaces or commas) into the tag input field
3. Then press ',' or the space key
4. Notice that the text that you entered gets added to the note as a tag
5. Repeat 2, 3, and 4

#### Disallow commas when editing tags

1. In the **'Edit Tags'** view tap on a tag in the list
2. In the **'Rename Tag'** dialog, try to enter a tag name with a comma
3. Notice the error 'Tags cannot contain commas'

#### Disallow commas when adding tags

1. In the **'Edit Tags'** view tap on the plus sign that creates a new note
2. In the **'Add Tag'** dialog, try to enter a tag name with a comma
3. Notice the error 'Tags cannot contain commas'

### Review

Only one developer is required to review these changes, but anyone can perform the review.
