### PR TITLE
Refactor Tag#renameTo to support renaming unassigned tags

### DIFF
--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TagUtilsTest.java
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TagUtilsTest.java
@@ -1,0 +1,48 @@
+package com.automattic.simplenote.utils;
+
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
+
+import com.automattic.simplenote.models.Note;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class TagUtilsTest extends TestCase {
+
+    @Test
+    public void testRenameTagInNote() {
+        Note note = new Note("key");
+        note.setTags(tagList("one", "two", "three"));
+
+        TagUtils.renameTagInNote(note, "one", "four");
+        assertThat(note.getTags(), is(tagList("four", "two", "three")));
+
+        TagUtils.renameTagInNote(note, "two", "Two");
+        assertThat(note.getTags(), is(tagList("four", "Two", "three")));
+
+        TagUtils.renameTagInNote(note, "three", "four");
+        assertThat(note.getTags(), is(tagList("four", "Two")));
+
+        TagUtils.renameTagInNote(note, "four", "two");
+        assertThat(note.getTags(), is(tagList("Two")));
+    }
+
+    private List<String> tagList(String... tags) {
+        List<String> tagArray = new ArrayList<>(tags.length);
+        Collections.addAll(tagArray, tags);
+        return tagArray;
+    }
+
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagUtils.java
@@ -2,6 +2,7 @@ package com.automattic.simplenote.utils;
 
 import android.util.Log;
 
+import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObjectMissingException;
@@ -11,6 +12,9 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 
 public class TagUtils {
@@ -165,4 +169,42 @@ public class TagUtils {
             .replace(".", "%2E")
             .replace("_", "%5F");
     }
+
+    /**
+     * Rename a tag in a note, given the name of the tag to be renamed and the new tag name.
+     * @param tagOld The tag to be renamed.
+     * @param tagNew The tag to replace the old tag.
+     * @param note The note object to be modified.
+     */
+    public static void renameTagInNote(Note note, String tagOld, String tagNew) {
+        List<String> tags = note.getTags();
+
+        List<String> tagHashList = new ArrayList<>();
+        for (String tag : tags) {
+            tagHashList.add(TagUtils.hashTag(tag));
+        }
+
+        String tagOldHash = TagUtils.hashTag(tagOld);
+        String tagNewHash = TagUtils.hashTag(tagNew);
+        boolean isOldHashEqualNew = tagOldHash.equals(tagNewHash);
+
+        ListIterator<String> iterator = tags.listIterator();
+        while (iterator.hasNext()) {
+            String tag = iterator.next();
+
+            if (tag.equals(tagOld)) {
+                // Remove old tag
+                iterator.remove();
+
+                if (isOldHashEqualNew || !tagHashList.contains(tagNewHash)) {
+                    // Add new tag
+                    iterator.add(tagNew);
+                }
+            }
+
+        }
+
+        note.setTags(tags);
+    }
+
 }


### PR DESCRIPTION
### Fix

Fixes https://github.com/Automattic/simplenote-android/issues/1319

This refactors `Tag#renameTo` to support renaming unassigned tags, as the current implementation does not work for unassigned tags.

### Test

1. Open the navigation drawer.
2. Tap the **Edit** button in the header named '**Tags**' to open the tag editor.
2. Add a new tag.
3. Rename it.
4. Note that it is being renamed.
5. Rename it to a lexical variation.
6. Note that it is being renamed to the lexical variation.


### Review

Only one developer is required to review these changes, but anyone can perform the review.