### PR TITLE
UI Tests AddTagActivity

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'io.sentry.android.gradle'
+apply plugin: 'kotlin-android'
 
 android {
     buildToolsVersion '29.0.2'
@@ -37,6 +38,12 @@ android {
         targetSdkVersion 29
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+    }
+
+    // Avoid duplicate annotations dependencies
+    configurations {
+        cleanedAnnotations
+        compile.exclude group: 'org.jetbrains' , module:'annotations'
     }
 
     lintOptions {
@@ -84,6 +91,10 @@ dependencies {
     implementation 'com.simperium.android:simperium:0.10.0'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.2'
+
+    // Kotlin and KTX
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     // Google Support
     implementation 'androidx.appcompat:appcompat:1.1.0'

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -72,10 +72,10 @@ buildscript {
 dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.8.47'
-    androidTestImplementation 'androidx.test:core:1.0.0'
+    androidTestImplementation 'androidx.test:core:1.2.0'
     androidTestImplementation 'androidx.annotation:annotation:1.0.0'
-    androidTestImplementation 'androidx.test:runner:1.1.0'
-    androidTestImplementation 'androidx.test:rules:1.1.0'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0'
     androidTestImplementation('androidx.test.espresso:espresso-contrib:3.1.0') {

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -72,10 +72,10 @@ buildscript {
 dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.8.47'
-    androidTestImplementation 'androidx.test:core:1.2.0'
+    androidTestImplementation 'androidx.test:core:1.3.0'
     androidTestImplementation 'androidx.annotation:annotation:1.0.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0'
     androidTestImplementation('androidx.test.espresso:espresso-contrib:3.1.0') {

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -92,8 +92,7 @@ dependencies {
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.2'
 
-    // Kotlin and KTX
-    implementation 'androidx.core:core-ktx:1.3.2'
+    // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     // Google Support

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     androidTestImplementation 'androidx.annotation:annotation:1.0.0'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0'
     androidTestImplementation('androidx.test.espresso:espresso-contrib:3.1.0') {
@@ -91,7 +92,7 @@ dependencies {
     implementation 'com.simperium.android:simperium:0.10.0'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.2'
-    
+
     // Google Support
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.1.0-beta01'

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -40,12 +40,6 @@ android {
         testInstrumentationRunner 'com.automattic.simplenote.SimplenoteAppRunner'
     }
 
-    // Avoid duplicate annotations dependencies
-    configurations {
-        cleanedAnnotations
-        compile.exclude group: 'org.jetbrains' , module:'annotations'
-    }
-
     lintOptions {
         checkReleaseBuilds false
     }
@@ -89,9 +83,11 @@ dependencies {
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
     implementation 'com.simperium.android:simperium:0.10.0'
-    implementation 'com.automattic:tracks:1.2'
+    implementation('com.automattic:tracks:1.2') {
+        exclude group: "org.jetbrains", module: "annotations-java5"
+    }
     implementation 'org.wordpress:passcodelock:2.0.2'
-    
+
     // Google Support
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.1.0-beta01'

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -37,7 +37,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 29
 
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunner 'com.automattic.simplenote.SimplenoteAppRunner'
     }
 
     // Avoid duplicate annotations dependencies

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -91,10 +91,7 @@ dependencies {
     implementation 'com.simperium.android:simperium:0.10.0'
     implementation 'com.automattic:tracks:1.2'
     implementation 'org.wordpress:passcodelock:2.0.2'
-
-    // Kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-
+    
     // Google Support
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.1.0-beta01'

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -24,7 +24,7 @@ open class BaseUITest {
         tagsBucket.clear()
     }
 
-    protected fun getResourceString(id: Int): String? {
+    protected fun getResourceString(id: Int): String {
         val targetContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
         return targetContext.resources.getString(id)
     }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -1,11 +1,43 @@
 package com.automattic.simplenote
 
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
+import com.automattic.simplenote.models.Tag
+import com.automattic.simplenote.utils.TagUtils
+import com.automattic.simplenote.utils.TestBucket
+import org.junit.Before
+import java.security.SecureRandom
 
 open class BaseUITest {
+    private val charPool : List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+    private lateinit var application: SimplenoteTest
+    protected lateinit var tagsBucket: TestBucket<Tag>
+
+    @Before
+    fun setup() {
+        application = ApplicationProvider.getApplicationContext() as SimplenoteTest
+        tagsBucket = application.tagsBucket as TestBucket<Tag>
+        tagsBucket.clear()
+    }
+
     protected fun getResourceString(id: Int): String? {
         val targetContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
         return targetContext.resources.getString(id)
+    }
+
+    protected fun getRandomString(len: Int): String {
+        val random = SecureRandom()
+        val bytes = ByteArray(len)
+        random.nextBytes(bytes)
+
+        return (bytes.indices)
+                .map {
+                    charPool[random.nextInt(charPool.size)]
+                }.joinToString("")
+    }
+
+    protected fun createTag(tagName: String) {
+        TagUtils.createTagIfMissing(tagsBucket, tagName)
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -1,0 +1,11 @@
+package com.automattic.simplenote
+
+import android.content.Context
+import androidx.test.platform.app.InstrumentationRegistry
+
+open class BaseUITest {
+    protected fun getResourceString(id: Int): String? {
+        val targetContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
+        return targetContext.resources.getString(id)
+    }
+}

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -18,7 +18,7 @@ open class BaseUITest {
     fun setup() {
         application = ApplicationProvider.getApplicationContext() as SimplenoteTest
         // Make sure to use TestBucket buckets in UI tests
-        application.useDefaultBucketImpl = false
+        application.useTestBucket = true
 
         tagsBucket = application.tagsBucket as TestBucket<Tag>
         tagsBucket.clear()

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -17,6 +17,9 @@ open class BaseUITest {
     @Before
     fun setup() {
         application = ApplicationProvider.getApplicationContext() as SimplenoteTest
+        // Make sure to use TestBucket buckets in UI tests
+        application.useDefaultBucketImpl = false
+
         tagsBucket = application.tagsBucket as TestBucket<Tag>
         tagsBucket.clear()
     }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -10,7 +10,7 @@ import org.junit.Before
 import java.security.SecureRandom
 
 open class BaseUITest {
-    private val charPool : List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+    private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
     private lateinit var application: SimplenoteTest
     protected lateinit var tagsBucket: TestBucket<Tag>
 
@@ -35,9 +35,8 @@ open class BaseUITest {
         random.nextBytes(bytes)
 
         return (bytes.indices)
-                .map {
-                    charPool[random.nextInt(charPool.size)]
-                }.joinToString("")
+                .map { charPool[random.nextInt(charPool.size)] }
+                .joinToString("")
     }
 
     protected fun createTag(tagName: String) {

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/SimplenoteAppRunner.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/SimplenoteAppRunner.kt
@@ -1,0 +1,12 @@
+package com.automattic.simplenote
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+
+class SimplenoteAppRunner : AndroidJUnitRunner() {
+    @Throws(InstantiationException::class, IllegalAccessException::class, ClassNotFoundException::class)
+    override fun newApplication(cl: ClassLoader, className: String, context: Context): Application {
+        return super.newApplication(cl, SimplenoteTest::class.java.name, context)
+    }
+}

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/SimplenoteAppRunner.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/SimplenoteAppRunner.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import androidx.test.runner.AndroidJUnitRunner
 
 class SimplenoteAppRunner : AndroidJUnitRunner() {
-    @Throws(InstantiationException::class, IllegalAccessException::class, ClassNotFoundException::class)
     override fun newApplication(cl: ClassLoader, className: String, context: Context): Application {
         return super.newApplication(cl, SimplenoteTest::class.java.name, context)
     }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/SimplenoteTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/SimplenoteTest.kt
@@ -6,8 +6,7 @@ import com.automattic.simplenote.utils.TestBucket
 import com.simperium.client.Bucket
 
 class SimplenoteTest : Simplenote() {
-    // Decides whether use the default bucket implementation or our own TestBucket
-    var useDefaultBucketImpl = true
+    var useTestBucket = false // Decides whether to use the test bucket implementation or the default.
 
     private val tagsBucket = object : TestBucket<Tag>("tags") {
         override fun build(key: String?): Tag {
@@ -21,19 +20,8 @@ class SimplenoteTest : Simplenote() {
         }
     }
 
-    override fun getTagsBucket(): Bucket<Tag> {
-        if (useDefaultBucketImpl) {
-            return super.getTagsBucket()
-        }
+    override fun getTagsBucket(): Bucket<Tag> = if (useTestBucket) tagsBucket else super.getTagsBucket()
 
-        return tagsBucket
-    }
-
-    override fun getNotesBucket(): Bucket<Note> {
-        if (useDefaultBucketImpl) {
-            return super.getNotesBucket()
-        }
-
-        return notesBucket
-    }
+    override fun getNotesBucket(): Bucket<Note> = if (useTestBucket) notesBucket else super.getNotesBucket()
 }
+

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/SimplenoteTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/SimplenoteTest.kt
@@ -6,6 +6,9 @@ import com.automattic.simplenote.utils.TestBucket
 import com.simperium.client.Bucket
 
 class SimplenoteTest : Simplenote() {
+    // Decides whether use the default bucket implementation or our own TestBucket
+    var useDefaultBucketImpl = true
+
     private val tagsBucket = object : TestBucket<Tag>("tags") {
         override fun build(key: String?): Tag {
             return Tag(key)
@@ -19,10 +22,18 @@ class SimplenoteTest : Simplenote() {
     }
 
     override fun getTagsBucket(): Bucket<Tag> {
+        if (useDefaultBucketImpl) {
+            return super.getTagsBucket()
+        }
+
         return tagsBucket
     }
 
     override fun getNotesBucket(): Bucket<Note> {
+        if (useDefaultBucketImpl) {
+            return super.getNotesBucket()
+        }
+
         return notesBucket
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/SimplenoteTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/SimplenoteTest.kt
@@ -1,0 +1,17 @@
+package com.automattic.simplenote
+
+import com.automattic.simplenote.models.Tag
+import com.automattic.simplenote.utils.TestBucket
+import com.simperium.client.Bucket
+
+class SimplenoteTest : Simplenote() {
+    private val tagsBucket = object : TestBucket<Tag>("tags") {
+        override fun build(key: String?): Tag {
+            return Tag(key)
+        }
+    }
+
+    override fun getTagsBucket(): Bucket<Tag> {
+        return tagsBucket
+    }
+}

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/SimplenoteTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/SimplenoteTest.kt
@@ -1,5 +1,6 @@
 package com.automattic.simplenote
 
+import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.utils.TestBucket
 import com.simperium.client.Bucket
@@ -11,7 +12,17 @@ class SimplenoteTest : Simplenote() {
         }
     }
 
+    private val notesBucket = object : TestBucket<Note>("notes") {
+        override fun build(key: String?): Note {
+            return Note(key)
+        }
+    }
+
     override fun getTagsBucket(): Bucket<Tag> {
         return tagsBucket
+    }
+
+    override fun getNotesBucket(): Bucket<Note> {
+        return notesBucket
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
@@ -9,7 +9,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.ActivityResultMatchers.hasResultCode
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.filters.MediumTest
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.automattic.simplenote.AddTagActivity
 import com.automattic.simplenote.BaseUITest
 import com.automattic.simplenote.R
@@ -19,7 +19,7 @@ import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
+@RunWith(AndroidJUnit4ClassRunner::class)
 @MediumTest
 class AddTagActivityTest : BaseUITest() {
 

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
@@ -72,7 +72,7 @@ class AddTagActivityTest : BaseUITest() {
 
         val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
 
-        onView(withId(R.id.tag_input)).perform(replaceText("tag 1"))
+        onView(withId(R.id.tag_input)).perform(replaceText("tag 3"))
         onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
 
         val spaceMessage = getResourceString(R.string.tag_error_spaces)

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
@@ -46,7 +46,7 @@ class AddActivityTest : BaseUITest() {
         onView(withId(R.id.tag_input)).perform(replaceText("tag1"))
         onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
 
-        val existsMessage = getResourceString(R.string.tag_error_exists) ?: ""
+        val existsMessage = getResourceString(R.string.tag_error_exists)
         onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(existsMessage)))
 
         Assert.assertEquals(tagsBucket.count(), 1)
@@ -60,7 +60,7 @@ class AddActivityTest : BaseUITest() {
         onView(withId(R.id.tag_input)).perform(replaceText(newTag))
         onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
 
-        val tooLongMessage = getResourceString(R.string.tag_error_length) ?: ""
+        val tooLongMessage = getResourceString(R.string.tag_error_length)
         onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(tooLongMessage)))
 
         Assert.assertEquals(tagsBucket.count(), 0)
@@ -75,7 +75,7 @@ class AddActivityTest : BaseUITest() {
         onView(withId(R.id.tag_input)).perform(replaceText("tag 1"))
         onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
 
-        val spaceMessage = getResourceString(R.string.tag_error_spaces) ?: ""
+        val spaceMessage = getResourceString(R.string.tag_error_spaces)
         onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(spaceMessage)))
         onView(withId(R.id.button_negative)).perform(click())
         assertThat(activityScenario.result, hasResultCode(Activity.RESULT_CANCELED))
@@ -95,7 +95,7 @@ class AddActivityTest : BaseUITest() {
         onView(withId(R.id.tag_input)).perform(replaceText(""))
         onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
 
-        val spaceMessage = getResourceString(R.string.tag_error_empty) ?: ""
+        val spaceMessage = getResourceString(R.string.tag_error_empty)
         onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(spaceMessage)))
         onView(withId(R.id.button_negative)).perform(click())
         assertThat(activityScenario.result, hasResultCode(Activity.RESULT_CANCELED))

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
@@ -1,0 +1,87 @@
+package com.automattic.simplenote.integration
+
+import android.content.Context
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.filters.MediumTest
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import com.automattic.simplenote.AddTagActivity
+import com.automattic.simplenote.BaseUITest
+import com.automattic.simplenote.R
+import com.automattic.simplenote.SimplenoteTest
+import com.automattic.simplenote.models.Tag
+import com.automattic.simplenote.utils.TagUtils
+import com.automattic.simplenote.utils.TestBucket
+import com.automattic.simplenote.utils.hasTextInputLayoutErrorText
+import org.hamcrest.CoreMatchers.not
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@MediumTest
+class AddActivityTest : BaseUITest() {
+    private lateinit var application: SimplenoteTest
+    private lateinit var tagsBucket: TestBucket<Tag>
+
+    @Before
+    fun setup() {
+        application = getApplicationContext() as SimplenoteTest
+        tagsBucket = application.tagsBucket as TestBucket<Tag>
+        tagsBucket.clear()
+    }
+
+    @Test
+    fun addNewValidTag() {
+        Assert.assertEquals(tagsBucket.count(), 0)
+
+        ActivityScenario.launch(AddTagActivity::class.java)
+
+        onView(withId(R.id.tag_input)).perform(replaceText("tag1"))
+        onView(withId(R.id.button_positive)).check(matches(isEnabled()))
+        onView(withId(R.id.button_positive)).perform(click())
+
+        Assert.assertEquals(tagsBucket.count(), 1)
+    }
+
+    @Test
+    fun addTagAlreadyExists() {
+        TagUtils.createTagIfMissing(tagsBucket, "tag1")
+        Assert.assertEquals(tagsBucket.count(), 1)
+
+        ActivityScenario.launch(AddTagActivity::class.java)
+
+        onView(withId(R.id.tag_input)).perform(replaceText("tag1"))
+        onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
+
+        val existsMessage = getResourceString(R.string.tag_error_exists) ?: ""
+        onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(existsMessage)))
+
+        Assert.assertEquals(tagsBucket.count(), 1)
+    }
+
+    @Test
+    fun addTagTooLong() {
+        TagUtils.createTagIfMissing(tagsBucket, "tag1")
+        Assert.assertEquals(tagsBucket.count(), 1)
+
+        ActivityScenario.launch(AddTagActivity::class.java)
+
+        val newTag =
+        onView(withId(R.id.tag_input)).perform(replaceText("tag1"))
+        onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
+
+        val existsMessage = getResourceString(R.string.tag_error_exists) ?: ""
+        onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(existsMessage)))
+
+        Assert.assertEquals(tagsBucket.count(), 1)
+    }
+}

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
@@ -15,7 +15,7 @@ import com.automattic.simplenote.BaseUITest
 import com.automattic.simplenote.R
 import com.automattic.simplenote.utils.hasTextInputLayoutErrorText
 import org.hamcrest.CoreMatchers.not
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -25,7 +25,7 @@ class AddTagActivityTest : BaseUITest() {
 
     @Test
     fun addNewValidTag() {
-        Assert.assertEquals(tagsBucket.count(), 0)
+        assertEquals(tagsBucket.count(), 0)
 
         ActivityScenario.launch(AddTagActivity::class.java)
 
@@ -33,13 +33,13 @@ class AddTagActivityTest : BaseUITest() {
         onView(withId(R.id.button_positive)).check(matches(isEnabled()))
         onView(withId(R.id.button_positive)).perform(click())
 
-        Assert.assertEquals(tagsBucket.count(), 1)
+        assertEquals(tagsBucket.count(), 1)
     }
 
     @Test
     fun addTagAlreadyExists() {
         createTag("tag1")
-        Assert.assertEquals(tagsBucket.count(), 1)
+        assertEquals(tagsBucket.count(), 1)
 
         ActivityScenario.launch(AddTagActivity::class.java)
 
@@ -49,7 +49,7 @@ class AddTagActivityTest : BaseUITest() {
         val existsMessage = getResourceString(R.string.tag_error_exists)
         onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(existsMessage)))
 
-        Assert.assertEquals(tagsBucket.count(), 1)
+        assertEquals(tagsBucket.count(), 1)
     }
 
     @Test
@@ -63,12 +63,12 @@ class AddTagActivityTest : BaseUITest() {
         val tooLongMessage = getResourceString(R.string.tag_error_length)
         onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(tooLongMessage)))
 
-        Assert.assertEquals(tagsBucket.count(), 0)
+        assertEquals(tagsBucket.count(), 0)
     }
 
     @Test
     fun addTagWithSpace() {
-        Assert.assertEquals(tagsBucket.count(), 0)
+        assertEquals(tagsBucket.count(), 0)
 
         val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
 
@@ -80,12 +80,12 @@ class AddTagActivityTest : BaseUITest() {
         onView(withId(R.id.button_negative)).perform(click())
         assertThat(activityScenario.result, hasResultCode(Activity.RESULT_CANCELED))
 
-        Assert.assertEquals(tagsBucket.count(), 0)
+        assertEquals(tagsBucket.count(), 0)
     }
 
     @Test
     fun addTagEmpty() {
-        Assert.assertEquals(tagsBucket.count(), 0)
+        assertEquals(tagsBucket.count(), 0)
 
         val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
 
@@ -101,12 +101,12 @@ class AddTagActivityTest : BaseUITest() {
         assertThat(activityScenario.result, hasResultCode(Activity.RESULT_CANCELED))
 
 
-        Assert.assertEquals(tagsBucket.count(), 0)
+        assertEquals(tagsBucket.count(), 0)
     }
 
     @Test
     fun addTagCancel() {
-        Assert.assertEquals(tagsBucket.count(), 0)
+        assertEquals(tagsBucket.count(), 0)
 
         val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
 
@@ -116,13 +116,13 @@ class AddTagActivityTest : BaseUITest() {
 
         assertThat(activityScenario.result, hasResultCode(Activity.RESULT_CANCELED))
 
-        Assert.assertEquals(tagsBucket.count(), 0)
+        assertEquals(tagsBucket.count(), 0)
     }
 
     @Test
     fun addSecondValidTag() {
         createTag("tag5")
-        Assert.assertEquals(tagsBucket.count(), 1)
+        assertEquals(tagsBucket.count(), 1)
 
         val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
 
@@ -131,6 +131,6 @@ class AddTagActivityTest : BaseUITest() {
         onView(withId(R.id.button_positive)).perform(click())
         assertThat(activityScenario.result, hasResultCode(Activity.RESULT_OK))
 
-        Assert.assertEquals(tagsBucket.count(), 2)
+        assertEquals(tagsBucket.count(), 2)
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
@@ -110,7 +110,7 @@ class AddTagActivityTest : BaseUITest() {
 
         val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
 
-        onView(withId(R.id.tag_input)).perform(replaceText("tag1"))
+        onView(withId(R.id.tag_input)).perform(replaceText("tag"))
         onView(withId(R.id.button_positive)).check(matches(isEnabled()))
         onView(withId(R.id.button_negative)).perform(click())
 

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
@@ -1,43 +1,27 @@
 package com.automattic.simplenote.integration
 
-import android.content.Context
+import android.app.Activity
 import androidx.test.core.app.ActivityScenario
-import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.isEnabled
-import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.contrib.ActivityResultMatchers.hasResultCode
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.filters.MediumTest
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.AndroidJUnit4
 import com.automattic.simplenote.AddTagActivity
 import com.automattic.simplenote.BaseUITest
 import com.automattic.simplenote.R
-import com.automattic.simplenote.SimplenoteTest
-import com.automattic.simplenote.models.Tag
-import com.automattic.simplenote.utils.TagUtils
-import com.automattic.simplenote.utils.TestBucket
 import com.automattic.simplenote.utils.hasTextInputLayoutErrorText
 import org.hamcrest.CoreMatchers.not
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @MediumTest
 class AddActivityTest : BaseUITest() {
-    private lateinit var application: SimplenoteTest
-    private lateinit var tagsBucket: TestBucket<Tag>
-
-    @Before
-    fun setup() {
-        application = getApplicationContext() as SimplenoteTest
-        tagsBucket = application.tagsBucket as TestBucket<Tag>
-        tagsBucket.clear()
-    }
 
     @Test
     fun addNewValidTag() {
@@ -54,7 +38,7 @@ class AddActivityTest : BaseUITest() {
 
     @Test
     fun addTagAlreadyExists() {
-        TagUtils.createTagIfMissing(tagsBucket, "tag1")
+        createTag("tag1")
         Assert.assertEquals(tagsBucket.count(), 1)
 
         ActivityScenario.launch(AddTagActivity::class.java)
@@ -70,18 +54,83 @@ class AddActivityTest : BaseUITest() {
 
     @Test
     fun addTagTooLong() {
-        TagUtils.createTagIfMissing(tagsBucket, "tag1")
-        Assert.assertEquals(tagsBucket.count(), 1)
-
         ActivityScenario.launch(AddTagActivity::class.java)
 
-        val newTag =
-        onView(withId(R.id.tag_input)).perform(replaceText("tag1"))
+        val newTag = getRandomString(257)
+        onView(withId(R.id.tag_input)).perform(replaceText(newTag))
         onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
 
-        val existsMessage = getResourceString(R.string.tag_error_exists) ?: ""
-        onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(existsMessage)))
+        val tooLongMessage = getResourceString(R.string.tag_error_length) ?: ""
+        onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(tooLongMessage)))
 
+        Assert.assertEquals(tagsBucket.count(), 0)
+    }
+
+    @Test
+    fun addTagWithSpace() {
+        Assert.assertEquals(tagsBucket.count(), 0)
+
+        val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
+
+        onView(withId(R.id.tag_input)).perform(replaceText("tag 1"))
+        onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
+
+        val spaceMessage = getResourceString(R.string.tag_error_spaces) ?: ""
+        onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(spaceMessage)))
+        onView(withId(R.id.button_negative)).perform(click())
+        assertThat(activityScenario.result, hasResultCode(Activity.RESULT_CANCELED))
+
+        Assert.assertEquals(tagsBucket.count(), 0)
+    }
+
+    @Test
+    fun addTagEmpty() {
+        Assert.assertEquals(tagsBucket.count(), 0)
+
+        val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
+
+        onView(withId(R.id.tag_input)).perform(replaceText("tag1"))
+        onView(withId(R.id.button_positive)).check(matches(isEnabled()))
+
+        onView(withId(R.id.tag_input)).perform(replaceText(""))
+        onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
+
+        val spaceMessage = getResourceString(R.string.tag_error_empty) ?: ""
+        onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(spaceMessage)))
+        onView(withId(R.id.button_negative)).perform(click())
+        assertThat(activityScenario.result, hasResultCode(Activity.RESULT_CANCELED))
+
+
+        Assert.assertEquals(tagsBucket.count(), 0)
+    }
+
+    @Test
+    fun addTagCancel() {
+        Assert.assertEquals(tagsBucket.count(), 0)
+
+        val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
+
+        onView(withId(R.id.tag_input)).perform(replaceText("tag1"))
+        onView(withId(R.id.button_positive)).check(matches(isEnabled()))
+        onView(withId(R.id.button_negative)).perform(click())
+
+        assertThat(activityScenario.result, hasResultCode(Activity.RESULT_CANCELED))
+
+        Assert.assertEquals(tagsBucket.count(), 0)
+    }
+
+    @Test
+    fun addSecondValidTag() {
+        createTag("tag5")
         Assert.assertEquals(tagsBucket.count(), 1)
+
+        val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
+
+        onView(withId(R.id.tag_input)).perform(replaceText("tag6"))
+        onView(withId(R.id.button_positive)).check(matches(isEnabled()))
+        onView(withId(R.id.button_positive)).perform(click())
+        assertThat(activityScenario.result, hasResultCode(Activity.RESULT_OK))
+
+        Assert.assertEquals(tagsBucket.count(), 2)
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @MediumTest
-class AddActivityTest : BaseUITest() {
+class AddTagActivityTest : BaseUITest() {
 
     @Test
     fun addNewValidTag() {

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
@@ -14,9 +14,9 @@ fun hasTextInputLayoutErrorText(expectedErrorText: String): Matcher<View> {
             }
 
             val error = view.error ?: return false
-            val hint = error.toString()
+            val errorStr = error.toString()
 
-            return expectedErrorText == hint;
+            return expectedErrorText == errorStr
         }
 
         override fun describeTo(description: Description) {

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
@@ -1,0 +1,44 @@
+package com.automattic.simplenote.utils
+
+import android.view.View
+import com.google.android.material.textfield.TextInputLayout
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
+
+fun hasTextInputLayoutHintText(expectedErrorText: String): Matcher<View> {
+    return object : TypeSafeMatcher<View>() {
+        override fun matchesSafely(view: View): Boolean {
+            if (view !is TextInputLayout) {
+                return false
+            }
+
+            val error = (view as TextInputLayout).hint ?: return false
+            val hint = error.toString()
+
+            return expectedErrorText == hint;
+        }
+        override fun describeTo(description: Description) {
+
+        }
+    }
+}
+
+fun hasTextInputLayoutErrorText(expectedErrorText: String): Matcher<View> {
+    return object : TypeSafeMatcher<View>() {
+        override fun matchesSafely(view: View): Boolean {
+            if (view !is TextInputLayout) {
+                return false
+            }
+
+            val error = (view as TextInputLayout).error ?: return false
+            val hint = error.toString()
+
+            return expectedErrorText == hint;
+        }
+
+        override fun describeTo(description: Description) {
+
+        }
+    }
+}

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
@@ -13,7 +13,7 @@ fun hasTextInputLayoutErrorText(expectedErrorText: String): Matcher<View> {
                 return false
             }
 
-            val error = (view as TextInputLayout).error ?: return false
+            val error = view.error ?: return false
             val hint = error.toString()
 
             return expectedErrorText == hint;

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
@@ -6,24 +6,6 @@ import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
 
-fun hasTextInputLayoutHintText(expectedErrorText: String): Matcher<View> {
-    return object : TypeSafeMatcher<View>() {
-        override fun matchesSafely(view: View): Boolean {
-            if (view !is TextInputLayout) {
-                return false
-            }
-
-            val error = (view as TextInputLayout).hint ?: return false
-            val hint = error.toString()
-
-            return expectedErrorText == hint;
-        }
-        override fun describeTo(description: Description) {
-
-        }
-    }
-}
-
 fun hasTextInputLayoutErrorText(expectedErrorText: String): Matcher<View> {
     return object : TypeSafeMatcher<View>() {
         override fun matchesSafely(view: View): Boolean {

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
@@ -1,0 +1,52 @@
+package com.automattic.simplenote.utils
+
+import com.simperium.client.Bucket
+import com.simperium.client.BucketObjectMissingException
+import com.simperium.client.Syncable
+
+abstract class TestBucket<T : Syncable>(name: String) : Bucket<T>(
+        null,
+        name,
+        null,
+        null,
+        null,
+        null) {
+
+    // Store objects in memory
+    private val objects: MutableList<T> = mutableListOf()
+
+    override fun newObject(key: String?): T {
+        val o = build(key)
+        o.bucket = this
+
+        objects.add(o)
+
+        return o
+    }
+
+    abstract fun build(key: String?): T
+
+    override fun count(): Int {
+        return objects.size
+    }
+
+    override fun getObject(uuid: String?): T {
+        return uuid?.let {
+            objects.find { it.simperiumKey == uuid }
+        } ?: throw BucketObjectMissingException()
+    }
+
+    override fun sync(`object`: T?) {
+        // Do not do anything
+    }
+
+    override fun remove(`object`: T?) {
+        `object`?.let {
+            objects.remove(it)
+        }
+    }
+
+    fun clear() {
+        objects.clear()
+    }
+}

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
@@ -4,14 +4,7 @@ import com.simperium.client.Bucket
 import com.simperium.client.BucketObjectMissingException
 import com.simperium.client.Syncable
 
-abstract class TestBucket<T : Syncable>(name: String) : Bucket<T>(
-        null,
-        name,
-        null,
-        null,
-        null,
-        null) {
-
+abstract class TestBucket<T : Syncable>(name: String) : Bucket<T>(null, name, null, null, null, null) {
     // Store objects in memory
     private val objects: MutableList<T> = mutableListOf()
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    ext.kotlin_version = '1.4.31'
+
     repositories {
         google()
         jcenter()
@@ -7,6 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 


### PR DESCRIPTION
Fixes #1363

### Fix
This PR adds UI tests for the activity `AddTagActivity`. The tests are described in #1363. 

### Test
This PR adds UI tests and espresso utilities functions to tests scenarios of adding a new tag. 

1. Run `AddActivityTest` inside `androidTest`. It requires to run an on emulator or physical device. 

### Review
This PR is part of a trial project guided by @ParaskP7. 

### Release
These changes do not require release notes.

This PR depends on #1376. 
