### PR TITLE
UI Tests for AddTagActivity

### DIFF
--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -1,0 +1,45 @@
+package com.automattic.simplenote
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.platform.app.InstrumentationRegistry
+import com.automattic.simplenote.models.Tag
+import com.automattic.simplenote.utils.TagUtils
+import com.automattic.simplenote.utils.TestBucket
+import org.junit.Before
+import java.security.SecureRandom
+
+open class BaseUITest {
+    private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+    private lateinit var application: SimplenoteTest
+    protected lateinit var tagsBucket: TestBucket<Tag>
+
+    @Before
+    fun setup() {
+        application = ApplicationProvider.getApplicationContext() as SimplenoteTest
+        // Make sure to use TestBucket buckets in UI tests
+        application.useTestBucket = true
+
+        tagsBucket = application.tagsBucket as TestBucket<Tag>
+        tagsBucket.clear()
+    }
+
+    protected fun getResourceString(id: Int): String {
+        val targetContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
+        return targetContext.resources.getString(id)
+    }
+
+    protected fun getRandomString(len: Int): String {
+        val random = SecureRandom()
+        val bytes = ByteArray(len)
+        random.nextBytes(bytes)
+
+        return (bytes.indices)
+                .map { charPool[random.nextInt(charPool.size)] }
+                .joinToString("")
+    }
+
+    protected fun createTag(tagName: String) {
+        TagUtils.createTagIfMissing(tagsBucket, tagName)
+    }
+}

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/AddTagActivityTest.kt
@@ -1,0 +1,136 @@
+package com.automattic.simplenote.integration
+
+import android.app.Activity
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.ActivityResultMatchers.hasResultCode
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.filters.MediumTest
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.automattic.simplenote.AddTagActivity
+import com.automattic.simplenote.BaseUITest
+import com.automattic.simplenote.R
+import com.automattic.simplenote.utils.hasTextInputLayoutErrorText
+import org.hamcrest.CoreMatchers.not
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+@MediumTest
+class AddTagActivityTest : BaseUITest() {
+
+    @Test
+    fun addNewValidTag() {
+        assertEquals(tagsBucket.count(), 0)
+
+        ActivityScenario.launch(AddTagActivity::class.java)
+
+        onView(withId(R.id.tag_input)).perform(replaceText("tag1"))
+        onView(withId(R.id.button_positive)).check(matches(isEnabled()))
+        onView(withId(R.id.button_positive)).perform(click())
+
+        assertEquals(tagsBucket.count(), 1)
+    }
+
+    @Test
+    fun addTagAlreadyExists() {
+        createTag("tag1")
+        assertEquals(tagsBucket.count(), 1)
+
+        ActivityScenario.launch(AddTagActivity::class.java)
+
+        onView(withId(R.id.tag_input)).perform(replaceText("tag1"))
+        onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
+
+        val existsMessage = getResourceString(R.string.tag_error_exists)
+        onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(existsMessage)))
+
+        assertEquals(tagsBucket.count(), 1)
+    }
+
+    @Test
+    fun addTagTooLong() {
+        ActivityScenario.launch(AddTagActivity::class.java)
+
+        val newTag = getRandomString(257)
+        onView(withId(R.id.tag_input)).perform(replaceText(newTag))
+        onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
+
+        val tooLongMessage = getResourceString(R.string.tag_error_length)
+        onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(tooLongMessage)))
+
+        assertEquals(tagsBucket.count(), 0)
+    }
+
+    @Test
+    fun addTagWithSpace() {
+        assertEquals(tagsBucket.count(), 0)
+
+        val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
+
+        onView(withId(R.id.tag_input)).perform(replaceText("tag 3"))
+        onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
+
+        val spaceMessage = getResourceString(R.string.tag_error_spaces)
+        onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(spaceMessage)))
+        onView(withId(R.id.button_negative)).perform(click())
+        assertThat(activityScenario.result, hasResultCode(Activity.RESULT_CANCELED))
+
+        assertEquals(tagsBucket.count(), 0)
+    }
+
+    @Test
+    fun addTagEmpty() {
+        assertEquals(tagsBucket.count(), 0)
+
+        val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
+
+        onView(withId(R.id.tag_input)).perform(replaceText("tag1"))
+        onView(withId(R.id.button_positive)).check(matches(isEnabled()))
+
+        onView(withId(R.id.tag_input)).perform(replaceText(""))
+        onView(withId(R.id.button_positive)).check(matches(not(isEnabled())))
+
+        val spaceMessage = getResourceString(R.string.tag_error_empty)
+        onView(withId(R.id.tag_layout)).check(matches(hasTextInputLayoutErrorText(spaceMessage)))
+        onView(withId(R.id.button_negative)).perform(click())
+        assertThat(activityScenario.result, hasResultCode(Activity.RESULT_CANCELED))
+
+
+        assertEquals(tagsBucket.count(), 0)
+    }
+
+    @Test
+    fun addTagCancel() {
+        assertEquals(tagsBucket.count(), 0)
+
+        val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
+
+        onView(withId(R.id.tag_input)).perform(replaceText("tag"))
+        onView(withId(R.id.button_positive)).check(matches(isEnabled()))
+        onView(withId(R.id.button_negative)).perform(click())
+
+        assertThat(activityScenario.result, hasResultCode(Activity.RESULT_CANCELED))
+
+        assertEquals(tagsBucket.count(), 0)
+    }
+
+    @Test
+    fun addSecondValidTag() {
+        createTag("tag5")
+        assertEquals(tagsBucket.count(), 1)
+
+        val activityScenario = ActivityScenario.launch(AddTagActivity::class.java)
+
+        onView(withId(R.id.tag_input)).perform(replaceText("tag6"))
+        onView(withId(R.id.button_positive)).check(matches(isEnabled()))
+        onView(withId(R.id.button_positive)).perform(click())
+        assertThat(activityScenario.result, hasResultCode(Activity.RESULT_OK))
+
+        assertEquals(tagsBucket.count(), 2)
+    }
+}

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
@@ -1,0 +1,26 @@
+package com.automattic.simplenote.utils
+
+import android.view.View
+import com.google.android.material.textfield.TextInputLayout
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
+
+fun hasTextInputLayoutErrorText(expectedErrorText: String): Matcher<View> {
+    return object : TypeSafeMatcher<View>() {
+        override fun matchesSafely(view: View): Boolean {
+            if (view !is TextInputLayout) {
+                return false
+            }
+
+            val error = view.error ?: return false
+            val errorStr = error.toString()
+
+            return expectedErrorText == errorStr
+        }
+
+        override fun describeTo(description: Description) {
+
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1363

### Fix
This PR adds UI tests for the activity `AddTagActivity` and it is based on a previous PR #1378. The tests are described in #1363. 

### Test
This PR adds UI tests and espresso utilities functions to tests scenarios of adding a new tag. 

1. Run `AddActivityTest` inside `androidTest`. It requires to run an on emulator or physical device. 

### Review
This PR will be reviewed by @ParaskP7. 

### Release
These changes do not require release notes.
