### PR TITLE
Cleanup of instrumented tests BaseUITest's useTestBucket

### DIFF
--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -6,6 +6,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.utils.TagUtils
 import com.automattic.simplenote.utils.TestBucket
+import org.junit.After
 import org.junit.Before
 import java.security.SecureRandom
 
@@ -22,6 +23,11 @@ open class BaseUITest {
 
         tagsBucket = application.tagsBucket as TestBucket<Tag>
         tagsBucket.clear()
+    }
+
+    @After
+    fun cleanup() {
+        application.useTestBucket = false
     }
 
     protected fun getResourceString(id: Int): String {


### PR DESCRIPTION
Fixes #1381 

### Fix
When running tests that extend BaseUITest set the application field `useTestBucket` to true. This PR cleanups `useTestBucket` (set the variable to `false`) after every test. 

### Test

1. Go to the console
2. Run `./gradlew connectedAndroidTest
3. The tests that fail should not be related to implementation of Bucket's `reset()` method. 


### Review
This PR will be reviewed by @ParaskP7. 

### Release
These changes do not require release notes.
