### PR TITLE
UI Tests for TagDialogFragment

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -79,6 +79,9 @@ dependencies {
         exclude group: 'androidx', module: 'support-annotations'
         exclude module: 'recyclerview-v7'
     }
+    // Infrastructure to test fragments
+    debugImplementation "androidx.fragment:fragment-testing:1.3.3"
+
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -50,6 +50,15 @@ android {
         // Espresso tests
         animationsDisabled = true
     }
+
+    // Target Java8 to avoid use certain Kotlin's features
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
 }
 
 buildscript {

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -26,9 +26,11 @@ open class BaseUITest {
 
         tagsBucket = application.tagsBucket as TestBucket<Tag>
         tagsBucket.clear()
+        tagsBucket.newObjectShouldFail = false
 
         notesBucket = application.notesBucket as TestBucket<Note>
         notesBucket.clear()
+        notesBucket.newObjectShouldFail = false
     }
 
     @After

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -41,6 +41,11 @@ open class BaseUITest {
         return targetContext.resources.getString(id)
     }
 
+    protected fun getResourceStringWithArgs(id: Int, vararg args: Any): String {
+        val targetContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
+        return targetContext.resources.getString(id, *args)
+    }
+
     protected fun getRandomString(len: Int): String {
         val random = SecureRandom()
         val bytes = ByteArray(len)

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -3,6 +3,7 @@ package com.automattic.simplenote
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
+import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.utils.TagUtils
 import com.automattic.simplenote.utils.TestBucket
@@ -14,6 +15,7 @@ open class BaseUITest {
     private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
     private lateinit var application: SimplenoteTest
     protected lateinit var tagsBucket: TestBucket<Tag>
+    protected lateinit var notesBucket: TestBucket<Note>
 
     @Before
     fun setup() {
@@ -23,6 +25,8 @@ open class BaseUITest {
 
         tagsBucket = application.tagsBucket as TestBucket<Tag>
         tagsBucket.clear()
+
+        notesBucket = application.notesBucket as TestBucket<Note>
     }
 
     @After
@@ -47,5 +51,10 @@ open class BaseUITest {
 
     protected fun createTag(tagName: String) {
         TagUtils.createTagIfMissing(tagsBucket, tagName)
+    }
+
+    protected fun getTag(tagName: String): Tag {
+        val hashName = TagUtils.hashTag(tagName)
+        return tagsBucket.getObject(hashName)
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -28,6 +28,7 @@ open class BaseUITest {
         tagsBucket.clear()
 
         notesBucket = application.notesBucket as TestBucket<Note>
+        notesBucket.clear()
     }
 
     @After

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -54,6 +54,14 @@ open class BaseUITest {
         TagUtils.createTagIfMissing(tagsBucket, tagName)
     }
 
+    protected fun createNote(content: String, tags: List<String>): Note {
+        val note = notesBucket.newObject(content.hashCode().toString())
+        note.content = content
+        note.tags = tags
+
+        return note
+    }
+
     protected fun getTag(tagName: String): Tag? {
         val hashName = TagUtils.hashTag(tagName)
         return try {

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -14,7 +14,7 @@ import java.security.SecureRandom
 
 open class BaseUITest {
     private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
-    private lateinit var application: SimplenoteTest
+    protected lateinit var application: SimplenoteTest
     protected lateinit var tagsBucket: TestBucket<Tag>
     protected lateinit var notesBucket: TestBucket<Note>
 

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -7,6 +7,7 @@ import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.utils.TagUtils
 import com.automattic.simplenote.utils.TestBucket
+import com.simperium.client.BucketObjectMissingException
 import org.junit.After
 import org.junit.Before
 import java.security.SecureRandom
@@ -53,8 +54,12 @@ open class BaseUITest {
         TagUtils.createTagIfMissing(tagsBucket, tagName)
     }
 
-    protected fun getTag(tagName: String): Tag {
+    protected fun getTag(tagName: String): Tag? {
         val hashName = TagUtils.hashTag(tagName)
-        return tagsBucket.getObject(hashName)
+        return try {
+            tagsBucket.getObject(hashName)
+        } catch (b: BucketObjectMissingException) {
+            null
+        }
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -95,8 +95,9 @@ class TagDialogFragmentTest : BaseUITest() {
 
         onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
 
+        val tagWithSpace = "tag 3"
         onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name))))
-                .perform(ViewActions.replaceText("tag 3"))
+                .perform(ViewActions.replaceText(tagWithSpace))
 
         val tagWithSpaceMessage = getResourceString(R.string.tag_error_spaces)
         onView(withId(R.id.input_tag_name)).check(matches(hasTextInputLayoutErrorText(tagWithSpaceMessage)))
@@ -123,8 +124,9 @@ class TagDialogFragmentTest : BaseUITest() {
 
         onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
 
+        val emptyTag = ""
         onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name))))
-                .perform(ViewActions.replaceText(""))
+                .perform(ViewActions.replaceText(emptyTag))
 
         val tagEmpty = getResourceString(R.string.tag_error_empty)
         onView(withId(R.id.input_tag_name)).check(matches(hasTextInputLayoutErrorText(tagEmpty)))

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -1,6 +1,5 @@
 package com.automattic.simplenote.integration
 
-import androidx.fragment.app.testing.FragmentScenario
 import androidx.fragment.app.testing.launchFragment
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
@@ -36,6 +35,9 @@ class TagDialogFragmentTest : BaseUITest() {
 
         launchFragment("tag1")
 
+        val renameTagTitle = getResourceString(R.string.rename_tag)
+        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
+
         onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
         onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name))))
                 .perform(ViewActions.replaceText("tag5"))
@@ -63,6 +65,9 @@ class TagDialogFragmentTest : BaseUITest() {
         assertEquals(notesBucket.count(), 1)
 
         launchFragment("tag1")
+
+        val renameTagTitle = getResourceString(R.string.rename_tag)
+        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
 
         onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
 
@@ -93,6 +98,9 @@ class TagDialogFragmentTest : BaseUITest() {
 
         launchFragment("tag10")
 
+        val renameTagTitle = getResourceString(R.string.rename_tag)
+        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
+
         onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
 
         val tagWithSpace = "tag 3"
@@ -121,6 +129,9 @@ class TagDialogFragmentTest : BaseUITest() {
         assertEquals(notesBucket.count(), 1)
 
         launchFragment("tag10")
+
+        val renameTagTitle = getResourceString(R.string.rename_tag)
+        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
 
         onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
 
@@ -154,6 +165,9 @@ class TagDialogFragmentTest : BaseUITest() {
         assertEquals(notesBucket.count(), 3)
 
         launchFragment("tag2")
+
+        val renameTagTitle = getResourceString(R.string.rename_tag)
+        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
 
         onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
 
@@ -195,6 +209,9 @@ class TagDialogFragmentTest : BaseUITest() {
 
         launchFragment("tag2")
 
+        val renameTagTitle = getResourceString(R.string.rename_tag)
+        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
+
         onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
 
         onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name))))
@@ -204,6 +221,9 @@ class TagDialogFragmentTest : BaseUITest() {
 
         val saveText = getResourceString(R.string.save)
         onView(withText(saveText)).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
+
+        val titleMergeDialog = getResourceString(R.string.dialog_tag_conflict_title)
+        onView(withText(titleMergeDialog)).check(matches(isDisplayed()))
 
         val canonical = TagUtils.getCanonicalFromLexical(tagsBucket, "tag3")
         val mergeMessage = getResourceStringWithArgs(R.string.dialog_tag_conflict_message, canonical, "tag2", canonical)
@@ -243,6 +263,9 @@ class TagDialogFragmentTest : BaseUITest() {
 
         launchFragment("tag2")
 
+        val renameTagTitle = getResourceString(R.string.rename_tag)
+        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
+
         onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
 
         onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name))))
@@ -252,6 +275,9 @@ class TagDialogFragmentTest : BaseUITest() {
 
         val saveText = getResourceString(R.string.save)
         onView(withText(saveText)).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
+
+        val titleMergeDialog = getResourceString(R.string.dialog_tag_conflict_title)
+        onView(withText(titleMergeDialog)).check(matches(isDisplayed()))
 
         val canonical = TagUtils.getCanonicalFromLexical(tagsBucket, "tag1")
         val mergeMessage = getResourceStringWithArgs(R.string.dialog_tag_conflict_message, canonical, "tag2", canonical)
@@ -283,6 +309,9 @@ class TagDialogFragmentTest : BaseUITest() {
         assertEquals(notesBucket.count(), 1)
 
         launchFragment("tag1")
+
+        val renameTagTitle = getResourceString(R.string.rename_tag)
+        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
 
         onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
         onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name))))

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -1,0 +1,12 @@
+package com.automattic.simplenote.integration
+
+import androidx.test.filters.MediumTest
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.automattic.simplenote.BaseUITest
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+@MediumTest
+class TagDialogFragmentTest : BaseUITest() {
+
+}

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -25,7 +25,7 @@ class TagDialogFragmentTest : BaseUITest() {
     fun editTagWithValidName() {
         createTag("tag1")
         // To edit tags, tags should belong a note
-        createNote("Hello World", listOf("tag1"))
+        val note = createNote("Hello World", listOf("tag1"))
 
         assertEquals(tagsBucket.count(), 1)
         assertEquals(notesBucket.count(), 1)
@@ -46,6 +46,7 @@ class TagDialogFragmentTest : BaseUITest() {
         assertNull(tag1)
         assertNotNull(tag5)
         assertEquals(tagsBucket.count(), 1)
+        assertEquals(note.tags, listOf("tag5"))
     }
 
     private fun launchFragment(tagName: String) {

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -145,8 +145,8 @@ class TagDialogFragmentTest : BaseUITest() {
         createTag("tag3")
         // To edit tags, tags should belong a note
         val note1 = createNote("Hello1", listOf("tag1", "tag2"))
-        val note2 = createNote("Hello1", listOf("tag2", "tag3"))
-        val note3 = createNote("Hello1", listOf("tag1", "tag3"))
+        val note2 = createNote("Hello2", listOf("tag2", "tag3"))
+        val note3 = createNote("Hello3", listOf("tag1", "tag3"))
 
         assertEquals(tagsBucket.count(), 3)
         assertEquals(notesBucket.count(), 3)
@@ -185,8 +185,8 @@ class TagDialogFragmentTest : BaseUITest() {
         createTag("tag3")
         // To edit tags, tags should belong a note
         val note1 = createNote("Hello1", listOf("tag1", "tag2"))
-        val note2 = createNote("Hello1", listOf("tag2", "tag3"))
-        val note3 = createNote("Hello1", listOf("tag1", "tag3"))
+        val note2 = createNote("Hello2", listOf("tag2", "tag3"))
+        val note3 = createNote("Hello3", listOf("tag1", "tag3"))
 
         assertEquals(tagsBucket.count(), 3)
         assertEquals(notesBucket.count(), 3)
@@ -233,8 +233,8 @@ class TagDialogFragmentTest : BaseUITest() {
         createTag("tag3")
         // To edit tags, tags should belong a note
         val note1 = createNote("Hello1", listOf("tag1", "tag2"))
-        val note2 = createNote("Hello1", listOf("tag2", "tag3"))
-        val note3 = createNote("Hello1", listOf("tag1", "tag3"))
+        val note2 = createNote("Hello2", listOf("tag2", "tag3"))
+        val note3 = createNote("Hello3", listOf("tag1", "tag3"))
 
         assertEquals(tagsBucket.count(), 3)
         assertEquals(notesBucket.count(), 3)

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -1,12 +1,33 @@
 package com.automattic.simplenote.integration
 
+import androidx.fragment.app.testing.launchFragment
 import androidx.test.filters.MediumTest
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.automattic.simplenote.BaseUITest
+import com.automattic.simplenote.R
+import com.automattic.simplenote.TagDialogFragment
+import org.junit.Assert
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4ClassRunner::class)
 @MediumTest
 class TagDialogFragmentTest : BaseUITest() {
 
+    private fun launchFragment(tagName: String) {
+        val scenario = launchFragment(null, R.style.Base_Theme_Simplestyle) {
+            val tag = getTag(tagName)
+            TagDialogFragment(
+                    tag,
+                    notesBucket,
+                    tagsBucket
+            )
+        }
+
+        // Validates the dialog is shown
+        scenario.onFragment { fragment ->
+            Assert.assertNotNull(fragment.dialog)
+            Assert.assertEquals(true, fragment.requireDialog().isShowing)
+            fragment.parentFragmentManager.executePendingTransactions()
+        }
+    }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -304,7 +304,7 @@ class TagDialogFragmentTest : BaseUITest() {
         assertEquals(note.tags, listOf("tag1"))
     }
 
-    private fun launchFragment(tagName: String): FragmentScenario<TagDialogFragment> {
+    private fun launchFragment(tagName: String) {
         val scenario = launchFragment(null, R.style.Base_Theme_Simplestyle) {
             val tag = getTag(tagName)
             TagDialogFragment(
@@ -320,7 +320,5 @@ class TagDialogFragmentTest : BaseUITest() {
             assertEquals(true, fragment.requireDialog().isShowing)
             fragment.parentFragmentManager.executePendingTransactions()
         }
-
-        return scenario
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -109,6 +109,34 @@ class TagDialogFragmentTest : BaseUITest() {
         assertEquals(note.tags, listOf("tag10"))
     }
 
+    @Test
+    fun editTagWithEmpty() {
+        createTag("tag10")
+        // To edit tags, tags should belong a note
+        val note = createNote("Hello World", listOf("tag10"))
+
+        assertEquals(tagsBucket.count(), 1)
+        assertEquals(notesBucket.count(), 1)
+
+        launchFragment("tag10")
+
+        onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+
+        onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .perform(ViewActions.replaceText(""))
+
+        val tagEmpty = getResourceString(R.string.tag_error_empty)
+        onView(withId(R.id.input_tag_name)).check(matches(hasTextInputLayoutErrorText(tagEmpty)))
+
+        val saveText = getResourceString(R.string.save)
+        onView(withText(saveText)).inRoot(isDialog()).check(matches(not(isEnabled())))
+        val cancelText = getResourceString(R.string.cancel)
+        onView(withText(cancelText)).inRoot(isDialog()).perform(click())
+
+        assertEquals(tagsBucket.count(), 1)
+        assertEquals(note.tags, listOf("tag10"))
+    }
+
     private fun launchFragment(tagName: String): FragmentScenario<TagDialogFragment> {
         val scenario = launchFragment(null, R.style.Base_Theme_Simplestyle) {
             val tag = getTag(tagName)

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -24,7 +24,11 @@ class TagDialogFragmentTest : BaseUITest() {
     @Test
     fun editTagWithValidName() {
         createTag("tag1")
+        // To edit tags, tags should belong a note
+        createNote("Hello World", listOf("tag1"))
+
         assertEquals(tagsBucket.count(), 1)
+        assertEquals(notesBucket.count(), 1)
 
         launchFragment("tag1")
 

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -137,6 +137,46 @@ class TagDialogFragmentTest : BaseUITest() {
         assertEquals(note.tags, listOf("tag10"))
     }
 
+    @Test
+    fun editTagInMultipleNotes() {
+        createTag("tag1")
+        createTag("tag2")
+        createTag("tag3")
+        // To edit tags, tags should belong a note
+        val note1 = createNote("Hello1", listOf("tag1", "tag2"))
+        val note2 = createNote("Hello1", listOf("tag2", "tag3"))
+        val note3 = createNote("Hello1", listOf("tag1", "tag3"))
+
+        assertEquals(tagsBucket.count(), 3)
+        assertEquals(notesBucket.count(), 3)
+
+        launchFragment("tag2")
+
+        onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+
+        onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .perform(ViewActions.replaceText("tag10"))
+
+        onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+
+        val saveText = getResourceString(R.string.save)
+        onView(withText(saveText)).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
+
+        val tag1 = getTag("tag1")
+        val tag2 = getTag("tag2")
+        val tag3 = getTag("tag3")
+        val tag10 = getTag("tag10")
+
+        assertNull(tag2)
+        assertNotNull(tag1)
+        assertNotNull(tag3)
+        assertNotNull(tag10)
+
+        assertEquals(note1.tags, listOf("tag1", "tag10"))
+        assertEquals(note2.tags, listOf("tag3", "tag10"))
+        assertEquals(note3.tags, listOf("tag1", "tag3"))
+    }
+
     private fun launchFragment(tagName: String): FragmentScenario<TagDialogFragment> {
         val scenario = launchFragment(null, R.style.Base_Theme_Simplestyle) {
             val tag = getTag(tagName)

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -1,17 +1,48 @@
 package com.automattic.simplenote.integration
 
 import androidx.fragment.app.testing.launchFragment
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.filters.MediumTest
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.automattic.simplenote.BaseUITest
 import com.automattic.simplenote.R
 import com.automattic.simplenote.TagDialogFragment
-import org.junit.Assert
+import org.hamcrest.CoreMatchers.allOf
+import org.junit.Assert.*
+import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4ClassRunner::class)
 @MediumTest
 class TagDialogFragmentTest : BaseUITest() {
+
+    @Test
+    fun editTagWithValidName() {
+        createTag("tag1")
+        assertEquals(tagsBucket.count(), 1)
+
+        launchFragment("tag1")
+
+        onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .perform(ViewActions.replaceText("tag5"))
+        onView(allOf(withText("tag5"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+
+        val saveText = getResourceString(R.string.save)
+        onView(withText(saveText)).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
+
+        val tag1 = getTag("tag1")
+        val tag5 = getTag("tag5")
+
+        assertNull(tag1)
+        assertNotNull(tag5)
+        assertEquals(tagsBucket.count(), 1)
+    }
 
     private fun launchFragment(tagName: String) {
         val scenario = launchFragment(null, R.style.Base_Theme_Simplestyle) {
@@ -25,8 +56,8 @@ class TagDialogFragmentTest : BaseUITest() {
 
         // Validates the dialog is shown
         scenario.onFragment { fragment ->
-            Assert.assertNotNull(fragment.dialog)
-            Assert.assertEquals(true, fragment.requireDialog().isShowing)
+            assertNotNull(fragment.dialog)
+            assertEquals(true, fragment.requireDialog().isShowing)
             fragment.parentFragmentManager.executePendingTransactions()
         }
     }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -271,6 +271,39 @@ class TagDialogFragmentTest : BaseUITest() {
         assertEquals(note3.tags, listOf("tag1", "tag3"))
     }
 
+    @Test
+    fun editTagFails() {
+        createTag("tag1")
+        // To edit tags, tags should belong a note
+        val note = createNote("Hello World", listOf("tag1"))
+
+        assertEquals(tagsBucket.count(), 1)
+        assertEquals(notesBucket.count(), 1)
+
+        launchFragment("tag1")
+
+        onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .perform(ViewActions.replaceText("tag5"))
+        onView(allOf(withText("tag5"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+
+        tagsBucket.newObjectShouldFail = true
+
+        val saveText = getResourceString(R.string.save)
+        onView(withText(saveText)).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
+
+        val okText = getResourceString(android.R.string.ok)
+        onView(withText(okText)).check(matches(isDisplayed())).perform(click())
+
+        val tag1 = getTag("tag1")
+        val tag5 = getTag("tag5")
+
+        assertNotNull(tag1)
+        assertNull(tag5)
+        assertEquals(tagsBucket.count(), 1)
+        assertEquals(note.tags, listOf("tag1"))
+    }
+
     private fun launchFragment(tagName: String): FragmentScenario<TagDialogFragment> {
         val scenario = launchFragment(null, R.style.Base_Theme_Simplestyle) {
             val tag = getTag(tagName)

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -36,15 +36,21 @@ class TagDialogFragmentTest : BaseUITest() {
         launchFragment("tag1")
 
         val renameTagTitle = getResourceString(R.string.rename_tag)
-        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
+        onView(withText(renameTagTitle))
+                .check(matches(isDisplayed()))
 
-        onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
         onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name))))
                 .perform(ViewActions.replaceText("tag5"))
-        onView(allOf(withText("tag5"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag5"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
 
         val saveText = getResourceString(R.string.save)
-        onView(withText(saveText)).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
+        onView(withText(saveText))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+                .perform(click())
 
         val tag1 = getTag("tag1")
         val tag5 = getTag("tag5")
@@ -69,19 +75,25 @@ class TagDialogFragmentTest : BaseUITest() {
         val renameTagTitle = getResourceString(R.string.rename_tag)
         onView(withText(renameTagTitle)).check(matches(isDisplayed()))
 
-        onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
 
         val longName = getRandomString(258)
         onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name))))
                 .perform(ViewActions.replaceText(longName))
 
         val tooLongMessage = getResourceString(R.string.tag_error_length)
-        onView(withId(R.id.input_tag_name)).check(matches(hasTextInputLayoutErrorText(tooLongMessage)))
+        onView(withId(R.id.input_tag_name))
+                .check(matches(hasTextInputLayoutErrorText(tooLongMessage)))
 
         val saveText = getResourceString(R.string.save)
-        onView(withText(saveText)).inRoot(isDialog()).check(matches(not(isEnabled())))
+        onView(withText(saveText))
+                .inRoot(isDialog())
+                .check(matches(not(isEnabled())))
         val cancelText = getResourceString(R.string.cancel)
-        onView(withText(cancelText)).inRoot(isDialog()).perform(click())
+        onView(withText(cancelText))
+                .inRoot(isDialog())
+                .perform(click())
 
         assertEquals(tagsBucket.count(), 1)
         assertEquals(note.tags, listOf("tag1"))
@@ -99,21 +111,28 @@ class TagDialogFragmentTest : BaseUITest() {
         launchFragment("tag10")
 
         val renameTagTitle = getResourceString(R.string.rename_tag)
-        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
+        onView(withText(renameTagTitle))
+                .check(matches(isDisplayed()))
 
-        onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
 
         val tagWithSpace = "tag 3"
         onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name))))
                 .perform(ViewActions.replaceText(tagWithSpace))
 
         val tagWithSpaceMessage = getResourceString(R.string.tag_error_spaces)
-        onView(withId(R.id.input_tag_name)).check(matches(hasTextInputLayoutErrorText(tagWithSpaceMessage)))
+        onView(withId(R.id.input_tag_name))
+                .check(matches(hasTextInputLayoutErrorText(tagWithSpaceMessage)))
 
         val saveText = getResourceString(R.string.save)
-        onView(withText(saveText)).inRoot(isDialog()).check(matches(not(isEnabled())))
+        onView(withText(saveText))
+                .inRoot(isDialog())
+                .check(matches(not(isEnabled())))
         val cancelText = getResourceString(R.string.cancel)
-        onView(withText(cancelText)).inRoot(isDialog()).perform(click())
+        onView(withText(cancelText))
+                .inRoot(isDialog())
+                .perform(click())
 
         assertEquals(tagsBucket.count(), 1)
         assertEquals(note.tags, listOf("tag10"))
@@ -133,19 +152,25 @@ class TagDialogFragmentTest : BaseUITest() {
         val renameTagTitle = getResourceString(R.string.rename_tag)
         onView(withText(renameTagTitle)).check(matches(isDisplayed()))
 
-        onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
 
         val emptyTag = ""
         onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name))))
                 .perform(ViewActions.replaceText(emptyTag))
 
         val tagEmpty = getResourceString(R.string.tag_error_empty)
-        onView(withId(R.id.input_tag_name)).check(matches(hasTextInputLayoutErrorText(tagEmpty)))
+        onView(withId(R.id.input_tag_name))
+                .check(matches(hasTextInputLayoutErrorText(tagEmpty)))
 
         val saveText = getResourceString(R.string.save)
-        onView(withText(saveText)).inRoot(isDialog()).check(matches(not(isEnabled())))
+        onView(withText(saveText))
+                .inRoot(isDialog())
+                .check(matches(not(isEnabled())))
         val cancelText = getResourceString(R.string.cancel)
-        onView(withText(cancelText)).inRoot(isDialog()).perform(click())
+        onView(withText(cancelText))
+                .inRoot(isDialog())
+                .perform(click())
 
         assertEquals(tagsBucket.count(), 1)
         assertEquals(note.tags, listOf("tag10"))
@@ -169,15 +194,20 @@ class TagDialogFragmentTest : BaseUITest() {
         val renameTagTitle = getResourceString(R.string.rename_tag)
         onView(withText(renameTagTitle)).check(matches(isDisplayed()))
 
-        onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
 
         onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name))))
                 .perform(ViewActions.replaceText("tag10"))
 
-        onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag10"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
 
         val saveText = getResourceString(R.string.save)
-        onView(withText(saveText)).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
+        onView(withText(saveText))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+                .perform(click())
 
         val tag1 = getTag("tag1")
         val tag2 = getTag("tag2")
@@ -210,30 +240,39 @@ class TagDialogFragmentTest : BaseUITest() {
         launchFragment("tag2")
 
         val renameTagTitle = getResourceString(R.string.rename_tag)
-        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
+        onView(withText(renameTagTitle))
+                .check(matches(isDisplayed()))
 
-        onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
 
         onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name))))
                 .perform(ViewActions.replaceText("tag3"))
 
-        onView(allOf(withText("tag3"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag3"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
 
         val saveText = getResourceString(R.string.save)
-        onView(withText(saveText)).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
+        onView(withText(saveText))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+                .perform(click())
 
         val titleMergeDialog = getResourceString(R.string.dialog_tag_conflict_title)
         onView(withText(titleMergeDialog)).check(matches(isDisplayed()))
 
         val canonical = TagUtils.getCanonicalFromLexical(tagsBucket, "tag3")
         val mergeMessage = getResourceStringWithArgs(R.string.dialog_tag_conflict_message, canonical, "tag2", canonical)
-        onView(withId(R.id.message)).check(matches(withText(mergeMessage)))
+        onView(withId(R.id.message))
+                .check(matches(withText(mergeMessage)))
 
         val backText = getResourceString(R.string.back)
         onView(withText(backText)).perform(click())
 
         val cancelText = getResourceString(R.string.cancel)
-        onView(withText(cancelText)).inRoot(isDialog()).perform(click())
+        onView(withText(cancelText))
+                .inRoot(isDialog())
+                .perform(click())
 
         val tag1 = getTag("tag1")
         val tag2 = getTag("tag2")
@@ -266,25 +305,31 @@ class TagDialogFragmentTest : BaseUITest() {
         val renameTagTitle = getResourceString(R.string.rename_tag)
         onView(withText(renameTagTitle)).check(matches(isDisplayed()))
 
-        onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
 
         onView(allOf(withText("tag2"), isDescendantOfA(withId(R.id.input_tag_name))))
                 .perform(ViewActions.replaceText("tag1"))
 
-        onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
 
         val saveText = getResourceString(R.string.save)
-        onView(withText(saveText)).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
+        onView(withText(saveText)).inRoot(isDialog()).check(matches(isDisplayed()))
+                .perform(click())
 
         val titleMergeDialog = getResourceString(R.string.dialog_tag_conflict_title)
-        onView(withText(titleMergeDialog)).check(matches(isDisplayed()))
+        onView(withText(titleMergeDialog))
+                .check(matches(isDisplayed()))
 
         val canonical = TagUtils.getCanonicalFromLexical(tagsBucket, "tag1")
         val mergeMessage = getResourceStringWithArgs(R.string.dialog_tag_conflict_message, canonical, "tag2", canonical)
-        onView(withId(R.id.message)).check(matches(withText(mergeMessage)))
+        onView(withId(R.id.message))
+                .check(matches(withText(mergeMessage)))
 
         val mergeText = getResourceString(R.string.dialog_tag_conflict_button_positive)
-        onView(withText(mergeText)).perform(click())
+        onView(withText(mergeText))
+                .perform(click())
 
         val tag1 = getTag("tag1")
         val tag2 = getTag("tag2")
@@ -313,18 +358,25 @@ class TagDialogFragmentTest : BaseUITest() {
         val renameTagTitle = getResourceString(R.string.rename_tag)
         onView(withText(renameTagTitle)).check(matches(isDisplayed()))
 
-        onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
         onView(allOf(withText("tag1"), isDescendantOfA(withId(R.id.input_tag_name))))
                 .perform(ViewActions.replaceText("tag5"))
-        onView(allOf(withText("tag5"), isDescendantOfA(withId(R.id.input_tag_name)))).check(matches(isDisplayed()))
+        onView(allOf(withText("tag5"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
 
         tagsBucket.newObjectShouldFail = true
 
         val saveText = getResourceString(R.string.save)
-        onView(withText(saveText)).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
+        onView(withText(saveText))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+                .perform(click())
 
         val okText = getResourceString(android.R.string.ok)
-        onView(withText(okText)).check(matches(isDisplayed())).perform(click())
+        onView(withText(okText))
+                .check(matches(isDisplayed()))
+                .perform(click())
 
         val tag1 = getTag("tag1")
         val tag5 = getTag("tag5")

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
@@ -7,8 +7,13 @@ import com.simperium.client.*
 abstract class TestBucket<T : BucketObject>(name: String) : Bucket<T>(null, name, null, null, null, null) {
     // Store objects in memory
     private val objects: MutableList<T> = mutableListOf()
+    var newObjectShouldFail = false
 
     override fun newObject(key: String?): T {
+        if (newObjectShouldFail) {
+            throw BucketObjectNameInvalid(key)
+        }
+
         val o = build(key)
         o.bucket = this
 

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
@@ -1,5 +1,7 @@
 package com.automattic.simplenote.utils
 
+import android.database.AbstractCursor
+import android.database.CharArrayBuffer
 import com.simperium.client.Bucket
 import com.simperium.client.BucketObjectMissingException
 import com.simperium.client.Syncable
@@ -39,7 +41,81 @@ abstract class TestBucket<T : Syncable>(name: String) : Bucket<T>(null, name, nu
         }
     }
 
+    override fun allObjects(): ObjectCursor<T> {
+        return TestObjectCursor(objects)
+    }
+
+    override fun reset() {
+        clear()
+    }
+
     fun clear() {
         objects.clear()
     }
+}
+
+class TestObjectCursor<T : Syncable>(private val objects: MutableList<T>) : AbstractCursor(), Bucket.ObjectCursor<T> {
+    private val columns = arrayOf("simperiumKey", "object")
+
+    override fun getCount(): Int {
+        return objects.size
+    }
+
+
+    override fun getColumnNames(): Array<String> {
+        return columns
+    }
+
+    override fun getColumnCount(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getBlob(columnIndex: Int): ByteArray {
+        throw RuntimeException("not implemented")
+    }
+
+    override fun getString(columnIndex: Int): String {
+        throw RuntimeException("not implemented")
+    }
+
+    override fun copyStringToBuffer(columnIndex: Int, buffer: CharArrayBuffer?) {
+        throw RuntimeException("not implemented")
+    }
+
+    override fun getShort(columnIndex: Int): Short {
+        throw RuntimeException("not implemented")
+    }
+
+    override fun getInt(columnIndex: Int): Int {
+        throw RuntimeException("not implemented")
+    }
+
+    override fun getLong(columnIndex: Int): Long {
+        throw RuntimeException("not implemented")
+    }
+
+    override fun getFloat(columnIndex: Int): Float {
+        throw RuntimeException("not implemented")
+    }
+
+    override fun getDouble(columnIndex: Int): Double {
+        throw RuntimeException("not implemented")
+    }
+
+    override fun getType(columnIndex: Int): Int {
+        throw RuntimeException("not implemented")
+    }
+
+    override fun isNull(column: Int): Boolean {
+        throw RuntimeException("not implemented")
+    }
+
+    override fun getSimperiumKey(): String {
+        return objects[position].simperiumKey
+    }
+
+    override fun getObject(): T {
+        return objects[position]
+    }
+
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
@@ -80,7 +80,7 @@ class TestObjectCursor<T : BucketObject>(private val objects: MutableList<T>) : 
     }
 
     override fun getColumnCount(): Int {
-        TODO("Not yet implemented")
+        return columns.size
     }
 
     override fun getBlob(columnIndex: Int): ByteArray {

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
@@ -32,7 +32,17 @@ abstract class TestBucket<T : Syncable>(name: String) : Bucket<T>(null, name, nu
     }
 
     override fun sync(`object`: T?) {
-        // Do not do anything
+        `object`?.let { o ->
+            o.bucket = this
+            // Find object by Simperium key
+            val index = objects.indexOfFirst { it.simperiumKey == o.simperiumKey }
+            if (index < 0) { // If object does not exists, add it
+                objects.add(o)
+            } else {
+                // If object exists, replace it
+                objects.set(index, o)
+            }
+        }
     }
 
     override fun remove(`object`: T?) {


### PR DESCRIPTION
Fixes #1364

### Fix
This PR adds UI tests for the activity `TagDialogFragment`. The tests are described in #1364. 

### Test
This PR adds UI tests and espresso utilities functions to tests scenarios of editing tags. 

1. Run `TagDialogFragmentTest` inside `androidTest`. It requires to run an on emulator or physical device. 

### Review
This PR will be reviewed by @ParaskP7. 

### Release
These changes do not require release notes.
