### PR TITLE
Opt-out from translation for all strings using resource references

### DIFF
--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -113,10 +113,10 @@
 
     <!-- Tags -->
     <string name="add_tag">Add Tag</string>
-    <string name="dialog_tag_add_button_negative">@android:string/cancel</string>
-    <string name="dialog_tag_add_button_positive">@string/save</string>
-    <string name="dialog_tag_add_hint">@string/tag_name</string>
-    <string name="dialog_tag_add_title">@string/add_tag</string>
+    <string name="dialog_tag_add_button_negative" translatable="false">@android:string/cancel</string>
+    <string name="dialog_tag_add_button_positive" translatable="false">@string/save</string>
+    <string name="dialog_tag_add_hint" translatable="false">@string/tag_name</string>
+    <string name="dialog_tag_add_title" translatable="false">@string/add_tag</string>
     <string name="dialog_tag_error_message">An error occurred adding the tag. Please, try again. If the problem continues, contact us at %1$s%2$s%3$s%4$s%5$s for help.</string>
     <string name="dialog_tag_error_message_email" translatable="false">\u003c\u0061\u0020\u0068\u0072\u0065\u0066\u003d\u0022\u006d\u0061\u0069\u006c\u0074\u006f\u003a\u0073\u0075\u0070\u0070\u006f\u0072\u0074\u0040\u0073\u0069\u006d\u0070\u006c\u0065\u006e\u006f\u0074\u0065\u002e\u0063\u006f\u006d\u0022\u003e\u0073\u0075\u0070\u0070\u006f\u0072\u0074\u0040\u0073\u0069\u006d\u0070\u006c\u0065\u006e\u006f\u0074\u0065\u002e\u0063\u006f\u006d\u003c\u002f\u0061\u003e</string>
     <string name="tag_error_empty">Tags cannot be empty</string>
@@ -385,6 +385,6 @@
     <string name="simperium_hint_email">Email</string>
     <string name="simperium_hint_password">Password</string>
     <string name="simperium_subtitle">The simplest way to keep notes.</string>
-    <string name="simperium_title">@string/app_name</string>
+    <string name="simperium_title" translatable="false">@string/app_name</string>
     <string name="simperium_url">http://simplenote.com</string>
 </resources>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -112,7 +112,6 @@
     <string name="share_analytics_summary">Help us improve Simplenote by sharing usage data with our analytics tool. %1$sLearn more%2$s</string>
 
     <!-- Tags -->
-    <string name="test_dialog_string">@string/save</string>
     <string name="add_tag">Add Tag</string>
     <string name="dialog_tag_add_button_negative" translatable="false">@android:string/cancel</string>
     <string name="dialog_tag_add_button_positive" translatable="false">@string/save</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="share_analytics_summary">Help us improve Simplenote by sharing usage data with our analytics tool. %1$sLearn more%2$s</string>
 
     <!-- Tags -->
+    <string name="test_dialog_string">@string/save</string>
     <string name="add_tag">Add Tag</string>
     <string name="dialog_tag_add_button_negative" translatable="false">@android:string/cancel</string>
     <string name="dialog_tag_add_button_positive" translatable="false">@string/save</string>


### PR DESCRIPTION
### Fix
See https://github.com/Automattic/simplenote-android/commit/d15153fadfdc6945982ee60df4bd723c719fb8c0#r49837835. Thanks @AliSoftware!

### Test
No manual test required.

### Review
Only one developer required to review these changes, but anyone can perform the review.

@ParaskP7, I asked for your review as an Android subject matter expert because of your recent work on the project. Thanks! 🙇‍♂️ 

### Release
These changes do not require release notes.