### PR TITLE
Add wildcard ignore for .configure-files folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ google-upload-credentials.json
 
 # Eclipse
 .settings/
+
+# All secrets should be stored under .configure-files
+# Everything without a .enc extension is ignored
+.configure-files/*
+!.configure-files/*.enc


### PR DESCRIPTION
### Fix
Makes sure that all the non-encrypted files in the `.configure-files` folder are ignored, for future proofing.

### Test

Add a file the folder and verify it doesn't appear in the `git status` output.

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.