### PR TITLE
Updates the release toolkit version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 48f500bd9212f13d2bf71220c89a8794cdd46e03
-  tag: 0.13.0
+  revision: 3ed0fb146be68d47e7b49f7fd1d82ca6fe05c892
+  branch: release/0.17.2
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.13.0)
+    fastlane-plugin-wpmreleasetoolkit (0.17.2)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -21,7 +21,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
-    activesupport (5.2.4.4)
+    activesupport (5.2.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -54,7 +54,7 @@ GEM
     colored2 (3.1.2)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     declarative (0.0.20)
     declarative-option (0.1.0)
     diffy (3.4.0)
@@ -164,7 +164,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.8.7)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.5.1)
@@ -176,7 +176,7 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.0)
     mini_portile2 (2.5.0)
-    minitest (5.14.3)
+    minitest (5.14.4)
     multi_json (1.15.0)
     multipart-post (2.0.0)
     nanaimo (0.3.0)
@@ -184,10 +184,10 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    octokit (4.20.0)
+    octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.11.0)
+    oj (3.11.5)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 3ed0fb146be68d47e7b49f7fd1d82ca6fe05c892
-  branch: release/0.17.2
+  revision: ce59a5e7b4fa75f6bb694bcfa333f85175294c3c
+  tag: 0.18.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.17.2)
+    fastlane-plugin-wpmreleasetoolkit (0.18.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -175,7 +175,6 @@ SUPPORTED_LOCALES = [
   # bundle exec fastlane download_translations
   #####################################################################################
   lane :download_translations do |options|
-    # Adapt the GP project URL and lint_task as needed if testing a project other than WordPress
     android_download_translations(
       res_dir: File.join(ENV['PROJECT_NAME'], 'src', 'main', 'res'),
       glotpress_url: 'https://translate.wordpress.com/projects/simplenote/android/',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,22 +25,22 @@ ENV["PROJECT_NAME"]="Simplenote"
 ENV["validate_translations"]="buildRelease"
 
 SUPPORTED_LOCALES = [
-  { glotpress: "ar", google_play: "ar",  promo_config: {}},
-  { glotpress: "de", google_play: "de-DE",  promo_config: {} },
-  { glotpress: "es", google_play: "es-ES",  promo_config: {} },
-  { glotpress: "fr", google_play: "fr-FR",  promo_config: {} },
-  { glotpress: "he", google_play: "iw-IL",  promo_config: {} },
-  { glotpress: "id", google_play: "id",  promo_config: {} },
-  { glotpress: "it", google_play: "it-IT",  promo_config: {} },
-  { glotpress: "ja", google_play: "ja-JP",  promo_config: {} },
-  { glotpress: "ko", google_play: "ko-KR",  promo_config: {} },
-  { glotpress: "nl", google_play: "nl-NL",  promo_config: {} },
-  { glotpress: "pt-br", google_play: "pt-BR",  promo_config: {} },
-  { glotpress: "ru", google_play: "ru-RU",  promo_config: {} },
-  { glotpress: "sv", google_play: "sv-SE",  promo_config: {} },
-  { glotpress: "tr", google_play: "tr-TR",  promo_config: {} },
-  { glotpress: "zh-cn", google_play: "zh-CN",  promo_config: {} },
-  { glotpress: "zh-tw", google_play: "zh-TW",  promo_config: {} },
+  { glotpress: "ar", android: "ar", google_play: "ar",  promo_config: {}},
+  { glotpress: "de", android: "de", google_play: "de-DE",  promo_config: {} },
+  { glotpress: "es", android: "es", google_play: "es-ES",  promo_config: {} },
+  { glotpress: "fr", android: "fr", google_play: "fr-FR",  promo_config: {} },
+  { glotpress: "he", android: "he", google_play: "iw-IL",  promo_config: {} },
+  { glotpress: "id", android: "id", google_play: "id",  promo_config: {} },
+  { glotpress: "it", android: "it", google_play: "it-IT",  promo_config: {} },
+  { glotpress: "ja", android: "ja", google_play: "ja-JP",  promo_config: {} },
+  { glotpress: "ko", android: "ko", google_play: "ko-KR",  promo_config: {} },
+  { glotpress: "nl", android: "nl", google_play: "nl-NL",  promo_config: {} },
+  { glotpress: "pt-br", android: "pt-rBR", google_play: "pt-BR",  promo_config: {} },
+  { glotpress: "ru", android: "ru", google_play: "ru-RU",  promo_config: {} },
+  { glotpress: "sv", android: "sv", google_play: "sv-SE",  promo_config: {} },
+  { glotpress: "tr", android: "tr", google_play: "tr-TR",  promo_config: {} },
+  { glotpress: "zh-cn", android: "zh-rCN", google_play: "zh-CN",  promo_config: {} },
+  { glotpress: "zh-tw", android: "zh-rTW", google_play: "zh-TW",  promo_config: {} },
 ].freeze
 
 ########################################################################
@@ -65,6 +65,10 @@ SUPPORTED_LOCALES = [
 
     android_bump_version_release()
     new_version = android_get_app_version()
+
+    # need to get prs list before version update to frozen tag
+    get_prs_list(repository:GHHELPER_REPO, milestone:new_version, report_path:"#{File.expand_path('~')}/simplenoteandroid_prs_list_#{old_version}_#{new_version}.txt")
+
     extract_release_notes_for_version(version: new_version,
       release_notes_file_path:"#{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt",
       extracted_notes_file_path:release_notes_path)
@@ -75,7 +79,6 @@ SUPPORTED_LOCALES = [
     update_strings_for_translation_automation()
 
     android_tag_build()
-    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/simplenoteandroid_prs_list_#{old_version}_#{new_version}.txt")
   end
 
   #####################################################################################
@@ -277,7 +280,7 @@ SUPPORTED_LOCALES = [
 ########################################################################
   desc "Get a list of pull request from `start_tag` to the current state"
   lane :get_pullrequests_list do | options |
-    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{options[:start_tag]}", report_path:"#{File.expand_path('~')}/simplenoteandroid_prs_list.txt")
+    get_prs_list(repository:GHHELPER_REPO, milestone:"#{options[:milestone]}", report_path:"#{File.expand_path('~')}/simplenoteandroid_prs_list.txt")
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -200,12 +200,7 @@ SUPPORTED_LOCALES = [
     android_finalize_prechecks(options)
     configure_apply(force: is_ci)
     hotfix = android_current_branch_is_hotfix
-    android_download_translations(
-      res_dir: File.join(ENV['PROJECT_NAME'], 'src', 'main', 'res'),
-      glotpress_url: 'https://translate.wordpress.com/projects/simplenote/android/',
-      locales: SUPPORTED_LOCALES,
-      lint_task: 'lintRelease'
-    ) unless hotfix
+    download_translations(options) unless hotfix
     android_bump_version_final_release() unless hotfix
     version = android_get_release_version() unless hotfix
     download_metadata_strings(version: version["name"], build_number: version["code"]) unless hotfix

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -167,6 +167,24 @@ SUPPORTED_LOCALES = [
   end
 
   #####################################################################################
+  # download_translations
+  # -----------------------------------------------------------------------------------
+  # This lane download the string translations from GlotPress
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane download_translations
+  #####################################################################################
+  lane :download_translations do |options|
+    # Adapt the GP project URL and lint_task as needed if testing a project other than WordPress
+    android_download_translations(
+      res_dir: File.join(ENV['PROJECT_NAME'], 'src', 'main', 'res'),
+      glotpress_url: 'https://translate.wordpress.com/projects/simplenote/android/',
+      locales: SUPPORTED_LOCALES,
+      lint_task: 'lintRelease'
+    )
+  end
+
+  #####################################################################################
   # finalize_release
   # -----------------------------------------------------------------------------------
   # This lane finalize a release: updates store metadata and runs the release checks
@@ -183,7 +201,12 @@ SUPPORTED_LOCALES = [
     android_finalize_prechecks(options)
     configure_apply(force: is_ci)
     hotfix = android_current_branch_is_hotfix
-    android_update_metadata(options) unless hotfix
+    android_download_translations(
+      res_dir: File.join(ENV['PROJECT_NAME'], 'src', 'main', 'res'),
+      glotpress_url: 'https://translate.wordpress.com/projects/simplenote/android/',
+      locales: SUPPORTED_LOCALES,
+      lint_task: 'lintRelease'
+    ) unless hotfix
     android_bump_version_final_release() unless hotfix
     version = android_get_release_version() unless hotfix
     download_metadata_strings(version: version["name"], build_number: version["code"]) unless hotfix

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'release/0.17.2'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.18.0'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.13.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'release/0.17.2'


### PR DESCRIPTION
This is a big version jump. The changes specifically addressed in this PR include

* Updates to the `get_prs_list` callsite 
* Changes to use the new action to download translations from GlotPress.

To test: Create a temporary branch and run `bundle exec fastlane download_translations` this should download the translations from GlotPress, verify that this works as expected. 