### PR TITLE
UI Tests for TagsActivity

### DIFF
--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/BaseUITest.kt
@@ -58,8 +58,9 @@ open class BaseUITest {
                 .joinToString("")
     }
 
-    protected fun createTag(tagName: String) {
+    protected fun createTag(tagName: String): Tag {
         TagUtils.createTagIfMissing(tagsBucket, tagName)
+        return tagsBucket.getObject(TagUtils.hashTag(tagName))
     }
 
     protected fun createNote(content: String, tags: List<String>): Note {

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -1,9 +1,11 @@
 package com.automattic.simplenote.integration
 
+import android.widget.EditText
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.filters.MediumTest
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.automattic.simplenote.BaseUITest
@@ -52,6 +54,47 @@ class TagsActivityTest : BaseUITest() {
         onView(withRecyclerView(R.id.list).atPositionOnView(3, R.id.tag_name))
                 .check(matches(withText("other")))
         onView(withRecyclerView(R.id.list).atPositionOnView(3, R.id.tag_count))
+                .check(matches(withText("")))
+    }
+
+    @Test
+    fun searchTagsShouldReturnMatchedTags() {
+        createTag("tag1")
+        createTag("tag2")
+        createTag("tag3")
+        createTag("other")
+        createNote("Hello1", listOf("tag1", "tag2"))
+        createNote("Hello2", listOf("tag2"))
+        createNote("Hello3", listOf("tag1", "tag2", "tag3"))
+
+        Assert.assertEquals(tagsBucket.count(), 4)
+        Assert.assertEquals(notesBucket.count(), 3)
+
+        ActivityScenario.launch(TagsActivity::class.java)
+
+        onView(withId(R.id.menu_search)).perform(click())
+
+        onView(isAssignableFrom(EditText::class.java)).perform(typeText("tag"))
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(0, R.id.tag_name))
+                .check(matches(withText("tag1")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(0, R.id.tag_count))
+                .check(matches(withText("2")))
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_name))
+                .check(matches(withText("tag2")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_count))
+                .check(matches(withText("3")))
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(2, R.id.tag_name))
+                .check(matches(withText("tag3")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(2, R.id.tag_count))
+                .check(matches(withText("1")))
+
+        onView(isAssignableFrom(EditText::class.java)).perform(replaceText("ot"))
+        onView(withRecyclerView(R.id.list).atPositionOnView(0, R.id.tag_name))
+                .check(matches(withText("other")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(0, R.id.tag_count))
                 .check(matches(withText("")))
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -1,7 +1,57 @@
 package com.automattic.simplenote.integration
 
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.filters.MediumTest
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.automattic.simplenote.BaseUITest
+import com.automattic.simplenote.R
+import com.automattic.simplenote.TagsActivity
+import com.automattic.simplenote.utils.withRecyclerView
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4ClassRunner::class)
+@MediumTest
 class TagsActivityTest : BaseUITest() {
 
+    @Test
+    fun listTagsShouldShowCompleteListTags() {
+        createTag("tag1")
+        createTag("tag2")
+        createTag("tag3")
+        createTag("other")
+        // To edit tags, tags should belong a note
+        createNote("Hello1", listOf("tag1", "tag2"))
+        createNote("Hello2", listOf("tag2"))
+        createNote("Hello3", listOf("tag1", "tag2", "tag3"))
+
+        Assert.assertEquals(tagsBucket.count(), 4)
+        Assert.assertEquals(notesBucket.count(), 3)
+
+        ActivityScenario.launch(TagsActivity::class.java)
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(0, R.id.tag_name))
+                .check(matches(withText("tag1")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(0, R.id.tag_count))
+                .check(matches(withText("2")))
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_name))
+                .check(matches(withText("tag2")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_count))
+                .check(matches(withText("3")))
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(2, R.id.tag_name))
+                .check(matches(withText("tag3")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(2, R.id.tag_count))
+                .check(matches(withText("1")))
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(3, R.id.tag_name))
+                .check(matches(withText("other")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(3, R.id.tag_count))
+                .check(matches(withText("")))
+    }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -14,7 +14,7 @@ import com.automattic.simplenote.R
 import com.automattic.simplenote.TagsActivity
 import com.automattic.simplenote.utils.isToast
 import com.automattic.simplenote.utils.withRecyclerView
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -33,8 +33,8 @@ class TagsActivityTest : BaseUITest() {
         createNote("Hello2", listOf("tag2"))
         createNote("Hello3", listOf("tag1", "tag2", "tag3"))
 
-        Assert.assertEquals(tagsBucket.count(), 4)
-        Assert.assertEquals(notesBucket.count(), 3)
+        assertEquals(tagsBucket.count(), 4)
+        assertEquals(notesBucket.count(), 3)
 
         ActivityScenario.launch(TagsActivity::class.java)
 
@@ -69,8 +69,8 @@ class TagsActivityTest : BaseUITest() {
         createNote("Hello2", listOf("tag2"))
         createNote("Hello3", listOf("tag1", "tag2", "tag3"))
 
-        Assert.assertEquals(tagsBucket.count(), 4)
-        Assert.assertEquals(notesBucket.count(), 3)
+        assertEquals(tagsBucket.count(), 4)
+        assertEquals(notesBucket.count(), 3)
 
         ActivityScenario.launch(TagsActivity::class.java)
 
@@ -125,7 +125,7 @@ class TagsActivityTest : BaseUITest() {
         createTag("tag3")
         createTag("other")
 
-        Assert.assertEquals(tagsBucket.count(), 4)
+        assertEquals(tagsBucket.count(), 4)
 
         ActivityScenario.launch(TagsActivity::class.java)
 
@@ -147,8 +147,8 @@ class TagsActivityTest : BaseUITest() {
         val note2 = createNote("Hello2", listOf("tag2"))
         val note3 = createNote("Hello3", listOf("tag1", "tag2", "tag3"))
 
-        Assert.assertEquals(tagsBucket.count(), 4)
-        Assert.assertEquals(notesBucket.count(), 3)
+        assertEquals(tagsBucket.count(), 4)
+        assertEquals(notesBucket.count(), 3)
 
         ActivityScenario.launch(TagsActivity::class.java)
 
@@ -176,11 +176,11 @@ class TagsActivityTest : BaseUITest() {
         onView(withRecyclerView(R.id.list).atPositionOnView(0, R.id.tag_trash))
                 .perform(click())
 
-        Assert.assertEquals(tagsBucket.count(), 3)
-        Assert.assertEquals(notesBucket.count(), 3)
-        Assert.assertEquals(note1.tags, listOf("tag1", "tag2"))
-        Assert.assertEquals(note2.tags, listOf("tag2"))
-        Assert.assertEquals(note3.tags, listOf("tag1", "tag2", "tag3"))
+        assertEquals(tagsBucket.count(), 3)
+        assertEquals(notesBucket.count(), 3)
+        assertEquals(note1.tags, listOf("tag1", "tag2"))
+        assertEquals(note2.tags, listOf("tag2"))
+        assertEquals(note3.tags, listOf("tag1", "tag2", "tag3"))
 
         // Try Delete tag tag2
         onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_trash))
@@ -193,11 +193,11 @@ class TagsActivityTest : BaseUITest() {
         val noText = getResourceString(R.string.no)
         onView(withText(noText)).inRoot(RootMatchers.isDialog()).perform(click())
 
-        Assert.assertEquals(tagsBucket.count(), 3)
-        Assert.assertEquals(notesBucket.count(), 3)
-        Assert.assertEquals(note1.tags, listOf("tag1", "tag2"))
-        Assert.assertEquals(note2.tags, listOf("tag2"))
-        Assert.assertEquals(note3.tags, listOf("tag1", "tag2", "tag3"))
+        assertEquals(tagsBucket.count(), 3)
+        assertEquals(notesBucket.count(), 3)
+        assertEquals(note1.tags, listOf("tag1", "tag2"))
+        assertEquals(note2.tags, listOf("tag2"))
+        assertEquals(note3.tags, listOf("tag1", "tag2", "tag3"))
 
         // Delete tag tag2
         onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_trash))
@@ -211,10 +211,10 @@ class TagsActivityTest : BaseUITest() {
         // Avoid flaky tests with AsyncTask
         Thread.sleep(1000)
 
-        Assert.assertEquals(tagsBucket.count(), 2)
-        Assert.assertEquals(notesBucket.count(), 3)
-        Assert.assertEquals(note1.tags, listOf("tag1"))
-        Assert.assertEquals(note2.tags, listOf<String>())
-        Assert.assertEquals(note3.tags, listOf("tag1", "tag3"))
+        assertEquals(tagsBucket.count(), 2)
+        assertEquals(notesBucket.count(), 3)
+        assertEquals(note1.tags, listOf("tag1"))
+        assertEquals(note2.tags, listOf<String>())
+        assertEquals(note3.tags, listOf("tag1", "tag3"))
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.filters.MediumTest
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
@@ -133,5 +134,87 @@ class TagsActivityTest : BaseUITest() {
 
         val renameTagTitle = getResourceString(R.string.rename_tag)
         onView(withText(renameTagTitle)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun deleteTagsShowRemoveTagsFromNotes() {
+        createTag("other")
+        createTag("tag1")
+        createTag("tag2")
+        createTag("tag3")
+        // To edit tags, tags should belong a note
+        val note1 = createNote("Hello1", listOf("tag1", "tag2"))
+        val note2 = createNote("Hello2", listOf("tag2"))
+        val note3 = createNote("Hello3", listOf("tag1", "tag2", "tag3"))
+
+        Assert.assertEquals(tagsBucket.count(), 4)
+        Assert.assertEquals(notesBucket.count(), 3)
+
+        ActivityScenario.launch(TagsActivity::class.java)
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(0, R.id.tag_name))
+                .check(matches(withText("other")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(0, R.id.tag_count))
+                .check(matches(withText("")))
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_name))
+                .check(matches(withText("tag1")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_count))
+                .check(matches(withText("2")))
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(2, R.id.tag_name))
+                .check(matches(withText("tag2")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(2, R.id.tag_count))
+                .check(matches(withText("3")))
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(3, R.id.tag_name))
+                .check(matches(withText("tag3")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(3, R.id.tag_count))
+                .check(matches(withText("1")))
+
+        // Delete tag other
+        onView(withRecyclerView(R.id.list).atPositionOnView(0, R.id.tag_trash))
+                .perform(click())
+
+        Assert.assertEquals(tagsBucket.count(), 3)
+        Assert.assertEquals(notesBucket.count(), 3)
+        Assert.assertEquals(note1.tags, listOf("tag1", "tag2"))
+        Assert.assertEquals(note2.tags, listOf("tag2"))
+        Assert.assertEquals(note3.tags, listOf("tag1", "tag2", "tag3"))
+
+        // Try Delete tag tag2
+        onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_trash))
+                .perform(click())
+
+        val deleteTagTitle = getResourceString(R.string.delete_tag)
+        val confirmDeleteTagMessage = getResourceString(R.string.confirm_delete_tag)
+        onView(withText(deleteTagTitle)).check(matches(isDisplayed()))
+        onView(withText(confirmDeleteTagMessage)).check(matches(isDisplayed()))
+        val noText = getResourceString(R.string.no)
+        onView(withText(noText)).inRoot(RootMatchers.isDialog()).perform(click())
+
+        Assert.assertEquals(tagsBucket.count(), 3)
+        Assert.assertEquals(notesBucket.count(), 3)
+        Assert.assertEquals(note1.tags, listOf("tag1", "tag2"))
+        Assert.assertEquals(note2.tags, listOf("tag2"))
+        Assert.assertEquals(note3.tags, listOf("tag1", "tag2", "tag3"))
+
+        // Delete tag tag2
+        onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_trash))
+                .perform(click())
+
+        onView(withText(deleteTagTitle)).check(matches(isDisplayed()))
+        onView(withText(confirmDeleteTagMessage)).check(matches(isDisplayed()))
+        val yesText = getResourceString(R.string.yes)
+        onView(withText(yesText)).inRoot(RootMatchers.isDialog()).perform(click())
+
+        // Avoid flaky tests with AsyncTask
+        Thread.sleep(1000)
+
+        Assert.assertEquals(tagsBucket.count(), 2)
+        Assert.assertEquals(notesBucket.count(), 3)
+        Assert.assertEquals(note1.tags, listOf("tag1"))
+        Assert.assertEquals(note2.tags, listOf<String>())
+        Assert.assertEquals(note3.tags, listOf("tag1", "tag3"))
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -116,4 +116,22 @@ class TagsActivityTest : BaseUITest() {
         val addTagTitle = getResourceString(R.string.add_tag)
         onView(withText(addTagTitle)).inRoot(isToast()).check(matches(isDisplayed()))
     }
+
+    @Test
+    fun clickOnEditTagShouldShowDialog() {
+        createTag("tag1")
+        createTag("tag2")
+        createTag("tag3")
+        createTag("other")
+
+        Assert.assertEquals(tagsBucket.count(), 4)
+
+        ActivityScenario.launch(TagsActivity::class.java)
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_name))
+                .perform(click())
+
+        val renameTagTitle = getResourceString(R.string.rename_tag)
+        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
+    }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -11,6 +11,7 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.automattic.simplenote.BaseUITest
 import com.automattic.simplenote.R
 import com.automattic.simplenote.TagsActivity
+import com.automattic.simplenote.utils.isToast
 import com.automattic.simplenote.utils.withRecyclerView
 import org.junit.Assert
 import org.junit.Test
@@ -105,5 +106,14 @@ class TagsActivityTest : BaseUITest() {
         onView(withId(R.id.button_add)).perform(click())
         val addTagTitle = getResourceString(R.string.add_tag)
         onView(withText(addTagTitle)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun lonTabOnAddTagShouldShowToast() {
+        ActivityScenario.launch(TagsActivity::class.java)
+
+        onView(withId(R.id.button_add)).perform(longClick())
+        val addTagTitle = getResourceString(R.string.add_tag)
+        onView(withText(addTagTitle)).inRoot(isToast()).check(matches(isDisplayed()))
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -26,31 +26,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4ClassRunner::class)
 @MediumTest
 class TagsActivityTest : BaseUITest() {
-
-    inner class TagAndCounter(val tag: Tag, val counter: String)
-    inner class TestData(val tags: List<TagAndCounter>, val notes: List<Note>)
-
-    private fun launchTagsActivityWithTestData(): TestData {
-        val tags = mutableListOf<TagAndCounter>()
-        val notes = mutableListOf<Note>()
-
-        tags.add(TagAndCounter(createTag("tag1"), "2"))
-        tags.add(TagAndCounter(createTag("tag2"), "3"))
-        tags.add(TagAndCounter(createTag("tag3"), "1"))
-        tags.add(TagAndCounter(createTag("other"), ""))
-        // To edit tags, tags should belong a note
-        notes.add(createNote("Hello1", listOf("tag1", "tag2")))
-        notes.add(createNote("Hello2", listOf("tag2")))
-        notes.add(createNote("Hello3", listOf("tag1", "tag2", "tag3")))
-
-        assertEquals(tagsBucket.count(), 4)
-        assertEquals(notesBucket.count(), 3)
-
-        ActivityScenario.launch(TagsActivity::class.java)
-
-        return TestData(tags, notes)
-    }
-
     @Test
     fun listTagsShouldShowCompleteListTags() {
         val testData = launchTagsActivityWithTestData()
@@ -223,4 +198,28 @@ class TagsActivityTest : BaseUITest() {
 
         assertEquals(tagsBucket.count(), 50)
     }
+
+    private fun launchTagsActivityWithTestData(): TestData {
+        val tags = mutableListOf<TagAndCounter>()
+        val notes = mutableListOf<Note>()
+
+        tags.add(TagAndCounter(createTag("tag1"), "2"))
+        tags.add(TagAndCounter(createTag("tag2"), "3"))
+        tags.add(TagAndCounter(createTag("tag3"), "1"))
+        tags.add(TagAndCounter(createTag("other"), ""))
+        // To edit tags, tags should belong a note
+        notes.add(createNote("Hello1", listOf("tag1", "tag2")))
+        notes.add(createNote("Hello2", listOf("tag2")))
+        notes.add(createNote("Hello3", listOf("tag1", "tag2", "tag3")))
+
+        assertEquals(tagsBucket.count(), 4)
+        assertEquals(notesBucket.count(), 3)
+
+        ActivityScenario.launch(TagsActivity::class.java)
+
+        return TestData(tags, notes)
+    }
+
+    inner class TagAndCounter(val tag: Tag, val counter: String)
+    inner class TestData(val tags: List<TagAndCounter>, val notes: List<Note>)
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -1,0 +1,7 @@
+package com.automattic.simplenote.integration
+
+import com.automattic.simplenote.BaseUITest
+
+class TagsActivityTest : BaseUITest() {
+
+}

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -106,7 +106,7 @@ class TagsActivityTest : BaseUITest() {
     }
 
     @Test
-    fun lonTabOnAddTagShouldShowToast() {
+    fun longTabOnAddTagShouldShowToast() {
         ActivityScenario.launch(TagsActivity::class.java)
 
         onView(withId(R.id.button_add)).perform(longClick())

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -1,10 +1,12 @@
 package com.automattic.simplenote.integration
 
 import android.widget.EditText
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.filters.MediumTest
@@ -14,6 +16,7 @@ import com.automattic.simplenote.R
 import com.automattic.simplenote.TagsActivity
 import com.automattic.simplenote.utils.isToast
 import com.automattic.simplenote.utils.withRecyclerView
+import org.hamcrest.CoreMatchers
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -216,5 +219,30 @@ class TagsActivityTest : BaseUITest() {
         assertEquals(note1.tags, listOf("tag1"))
         assertEquals(note2.tags, listOf<String>())
         assertEquals(note3.tags, listOf("tag1", "tag3"))
+    }
+
+    @Test
+    fun scrollTags() {
+        for (i in 1 until 51) {
+            val tagName = "tag${i}"
+            createTag(tagName)
+        }
+
+        assertEquals(tagsBucket.count(), 50)
+
+        ActivityScenario.launch(TagsActivity::class.java)
+
+        onView(withId(R.id.list)).
+            perform(scrollToPosition<RecyclerView.ViewHolder>(49))
+
+        onView(withRecyclerView(R.id.list).atPositionOnView(49, R.id.tag_name))
+                .perform(click())
+
+        val renameTagTitle = getResourceString(R.string.rename_tag)
+        onView(withText(renameTagTitle)).check(matches(isDisplayed()))
+        onView(CoreMatchers.allOf(withText("tag50"), isDescendantOfA(withId(R.id.input_tag_name))))
+                .check(matches(isDisplayed()))
+
+        assertEquals(tagsBucket.count(), 50)
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -97,4 +97,13 @@ class TagsActivityTest : BaseUITest() {
         onView(withRecyclerView(R.id.list).atPositionOnView(0, R.id.tag_count))
                 .check(matches(withText("")))
     }
+
+    @Test
+    fun clickOnAddTagShouldShowDialog() {
+        ActivityScenario.launch(TagsActivity::class.java)
+
+        onView(withId(R.id.button_add)).perform(click())
+        val addTagTitle = getResourceString(R.string.add_tag)
+        onView(withText(addTagTitle)).check(matches(isDisplayed()))
+    }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
@@ -1,10 +1,13 @@
 package com.automattic.simplenote.utils
 
+import android.content.res.Resources
 import android.view.View
+import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.textfield.TextInputLayout
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
+
 
 fun hasTextInputLayoutErrorText(expectedErrorText: String): Matcher<View> {
     return object : TypeSafeMatcher<View>() {
@@ -24,3 +27,51 @@ fun hasTextInputLayoutErrorText(expectedErrorText: String): Matcher<View> {
         }
     }
 }
+
+class RecyclerViewMatcher(private val recyclerViewId: Int) {
+    fun atPositionOnView(position: Int, targetViewId: Int): Matcher<View> {
+        return object : TypeSafeMatcher<View>() {
+            var resources: Resources? = null
+            var childView: View? = null
+
+            override fun describeTo(description: Description) {
+                var idDescription = recyclerViewId.toString()
+                if (this.resources != null) {
+                    idDescription = try {
+                        this.resources!!.getResourceName(recyclerViewId)
+                    } catch (var4: Resources.NotFoundException) {
+                        String.format("%s (resource name not found)",
+                                Integer.valueOf(recyclerViewId)
+                        )
+                    }
+
+                }
+
+                description.appendText("with id: $idDescription")
+            }
+
+            override fun matchesSafely(view: View): Boolean {
+
+                this.resources = view.resources
+
+                if (childView == null) {
+                    val recyclerView = view.rootView.findViewById(recyclerViewId) as RecyclerView
+                    if (recyclerView.id == recyclerViewId) {
+                        childView = recyclerView.findViewHolderForAdapterPosition(position)!!.itemView
+                    } else {
+                        return false
+                    }
+                }
+
+                return if (targetViewId == -1) {
+                    view === childView
+                } else {
+                    val targetView = childView!!.findViewById<View>(targetViewId)
+                    view === targetView
+                }
+            }
+        }
+    }
+}
+
+fun withRecyclerView(recyclerViewId: Int): RecyclerViewMatcher = RecyclerViewMatcher(recyclerViewId)

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
@@ -2,7 +2,9 @@ package com.automattic.simplenote.utils
 
 import android.content.res.Resources
 import android.view.View
+import android.view.WindowManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Root
 import com.google.android.material.textfield.TextInputLayout
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -75,3 +77,26 @@ class RecyclerViewMatcher(private val recyclerViewId: Int) {
 }
 
 fun withRecyclerView(recyclerViewId: Int): RecyclerViewMatcher = RecyclerViewMatcher(recyclerViewId)
+
+fun isToast(): Matcher<Root> {
+    return object : TypeSafeMatcher<Root>() {
+        override fun matchesSafely(root: Root): Boolean {
+            val type = root.windowLayoutParams.get().type
+            // TYPE_APPLICATION_OVERLAY hangs the test
+            if (type == WindowManager.LayoutParams.TYPE_TOAST) {
+                val windowToken = root.decorView.windowToken
+                val appToken = root.decorView.applicationWindowToken
+                if (windowToken === appToken) {
+                    // windowToken == appToken means this window isn't contained by any other windows.
+                    // if it was a window for an activity, it would have TYPE_BASE_APPLICATION.
+                    return true
+                }
+            }
+            return false
+        }
+
+        override fun describeTo(description: Description) {
+
+        }
+    }
+}

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/TestBucket.kt
@@ -155,8 +155,8 @@ class TestQuery<T : BucketObject>(private val objects:  MutableList<T>) : Query<
             when (condition.comparisonType) {
                 ComparisonType.EQUAL_TO -> objects.filter { compare(it.properties.get(condition.key), condition.subject) }
                 ComparisonType.NOT_EQUAL_TO -> objects.filter { !compare(it.properties.get(condition.key), condition.subject) }
-                ComparisonType.LIKE -> objects.filter { it.properties.get(condition.key).toString().contains(condition.subject.toString()) }
-                ComparisonType.NOT_LIKE -> objects.filter { !it.properties.get(condition.key).toString().contains(condition.subject.toString()) }
+                ComparisonType.LIKE -> objects.filter { compareLike(it.properties.get(condition.key), (condition.subject)) }
+                ComparisonType.NOT_LIKE -> objects.filter { !compareLike(it.properties.get(condition.key), (condition.subject.toString())) }
                 else -> currentObjects // The rest of comparison types are not used in the app
             } as MutableList
         })
@@ -174,6 +174,21 @@ class TestQuery<T : BucketObject>(private val objects:  MutableList<T>) : Query<
             return false
         } else {
             return left == right
+        }
+    }
+
+    private fun compareLike(left: Any, right: Any): Boolean {
+        if (left is JSONArray) {
+            for (i in 0 until left.length()) {
+                val o = left.get(i)
+                if (right.toString() == "%%" || o.toString().contains(right.toString())) {
+                    return true
+                }
+            }
+
+            return false
+        } else {
+            return right.toString() == "%%" || left.toString().contains(right.toString().replace("%", ""))
         }
     }
 


### PR DESCRIPTION
Fixes #1365

### Fix
This PR adds UI tests for the activity `TagsActivity`. The tests are described in #1365. 

### Test
This PR adds UI tests and espresso utilities functions to tests scenarios of listing and deleting tags. 

1. Run `TagsActivityTest` inside `androidTest`. It requires to run an on emulator or physical device. 

### Review
This PR will be reviewed by @planarvoid. 

### Release
These changes do not require release notes.
