### PR TITLE
Add TagDialogViewModel to restructure UI and orchestration logic in TagDialogFragment

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/AddTagActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AddTagActivity.java
@@ -17,6 +17,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.automattic.simplenote.databinding.ActivityTagAddBinding;
+import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
@@ -39,7 +40,8 @@ public class AddTagActivity extends AppCompatActivity implements TextWatcher {
         ActivityTagAddBinding binding = ActivityTagAddBinding.inflate(getLayoutInflater());
 
         Bucket<Tag> mBucketTag = ((Simplenote) getApplication()).getTagsBucket();
-        ViewModelFactory viewModelFactory = new ViewModelFactory(mBucketTag, this, null);
+        Bucket<Note> mNoteTag = ((Simplenote) getApplication()).getNotesBucket();
+        ViewModelFactory viewModelFactory = new ViewModelFactory(mBucketTag, mNoteTag, this, null);
         ViewModelProvider viewModelProvider = new ViewModelProvider(this, viewModelFactory);
         viewModel = viewModelProvider.get(AddTagViewModel.class);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
@@ -126,10 +126,7 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
                 dismiss();
             } else if (event instanceof TagDialogEvent.ShowErrorEvent) {
                 Context context = requireContext();
-                DialogUtils.showDialogWithEmail(
-                        context,
-                        context.getString(R.string.rename_tag_message)
-                );
+                DialogUtils.showDialogWithEmail(context, context.getString(R.string.rename_tag_message));
             } else if (event instanceof TagDialogEvent.ConflictEvent) {
                 TagDialogEvent.ConflictEvent conflictEvent = (TagDialogEvent.ConflictEvent) event;
                 showDialogErrorConflict(conflictEvent.getCanonicalTagName(), conflictEvent.getOldTagName());

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
@@ -23,10 +23,7 @@ import androidx.lifecycle.ViewModelProvider;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
 import com.automattic.simplenote.utils.DialogUtils;
-import com.automattic.simplenote.viewmodels.CloseEvent;
-import com.automattic.simplenote.viewmodels.ConflictEvent;
-import com.automattic.simplenote.viewmodels.FinishEvent;
-import com.automattic.simplenote.viewmodels.ShowErrorEvent;
+import com.automattic.simplenote.viewmodels.TagDialogEvent;
 import com.automattic.simplenote.viewmodels.TagDialogViewModel;
 import com.automattic.simplenote.viewmodels.ViewModelFactory;
 import com.google.android.material.textfield.TextInputEditText;
@@ -125,16 +122,16 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
         });
 
         viewModel.getEvent().observe(this, event -> {
-            if (event instanceof CloseEvent || event instanceof FinishEvent) {
+            if (event instanceof TagDialogEvent.CloseEvent || event instanceof TagDialogEvent.FinishEvent) {
                 dismiss();
-            } else if (event instanceof ShowErrorEvent) {
+            } else if (event instanceof TagDialogEvent.ShowErrorEvent) {
                 Context context = requireContext();
                 DialogUtils.showDialogWithEmail(
                         context,
                         context.getString(R.string.rename_tag_message)
                 );
-            } else if (event instanceof ConflictEvent) {
-                ConflictEvent conflictEvent = (ConflictEvent) event;
+            } else if (event instanceof TagDialogEvent.ConflictEvent) {
+                TagDialogEvent.ConflictEvent conflictEvent = (TagDialogEvent.ConflictEvent) event;
                 showDialogErrorConflict(conflictEvent.getCanonicalTagName(), conflictEvent.getOldTagName());
             }
         });

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
@@ -63,8 +63,6 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
         ViewModelFactory viewModelFactory = new ViewModelFactory(mBucketTag, mBucketNote, this, null);
         ViewModelProvider viewModelProvider = new ViewModelProvider(this, viewModelFactory);
         viewModel = viewModelProvider.get(TagDialogViewModel.class);
-
-        viewModel.start(mTag);
     }
 
     @Override
@@ -142,6 +140,7 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
 
         // Set observers when views are available
         setObservers();
+        viewModel.start(mTag);
 
         showDialogRenameTag();
         mEditTextTag.setText(mTag.getName());

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
@@ -146,6 +146,7 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
         mButtonNeutral = mDialogEditTag.getButton(DialogInterface.BUTTON_NEUTRAL);
         mButtonPositive = mDialogEditTag.getButton(DialogInterface.BUTTON_POSITIVE);
 
+        // Set observers when views are available
         setObservers();
 
         showDialogRenameTag();

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
@@ -29,6 +29,11 @@ class SimperiumTagsRepository(
         return TagUtils.isTagMissing(tagsBucket, tagName)
     }
 
+    override fun isTagConflict(tagName: String, oldTagName: String): Boolean {
+        val isRenamingToLexical = TagUtils.hashTag(tagName).equals(TagUtils.hashTag(oldTagName))
+        return !isRenamingToLexical && !isTagMissing(tagName)
+    }
+
     override fun getCanonicalTagName(tagName: String): String {
         return TagUtils.getCanonicalFromLexical(tagsBucket, tagName)
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
@@ -1,11 +1,17 @@
 package com.automattic.simplenote.repositories
 
+import android.util.Log
+import com.automattic.simplenote.Simplenote
+import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.utils.TagUtils
 import com.simperium.client.Bucket
 import com.simperium.client.BucketObjectNameInvalid
 
-class SimperiumTagsRepository(private val tagsBucket: Bucket<Tag>) : TagsRepository {
+class SimperiumTagsRepository(
+        private val tagsBucket: Bucket<Tag>,
+        private val notesBucket: Bucket<Note>
+) : TagsRepository {
     override fun saveTag(tagName: String): Boolean {
         return try {
             TagUtils.createTagIfMissing(tagsBucket, tagName)
@@ -21,5 +27,20 @@ class SimperiumTagsRepository(private val tagsBucket: Bucket<Tag>) : TagsReposit
 
     override fun isTagMissing(tagName: String): Boolean {
         return TagUtils.isTagMissing(tagsBucket, tagName)
+    }
+
+    override fun getCanonicalTagName(tagName: String): String {
+        return TagUtils.getCanonicalFromLexical(tagsBucket, tagName)
+    }
+
+    override fun renameTag(tagName: String, oldTag: Tag): Boolean {
+        return try {
+            val index = if (oldTag.hasIndex()) oldTag.index else tagsBucket.count()
+            oldTag.renameTo(oldTag.name, tagName, index, notesBucket)
+            true
+        } catch (e: BucketObjectNameInvalid) {
+            Log.e(Simplenote.TAG, "Unable to rename tag", e)
+            false
+        }
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/TagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/TagsRepository.kt
@@ -6,6 +6,7 @@ interface TagsRepository {
     fun saveTag(tagName: String): Boolean
     fun isTagValid(tagName: String): Boolean
     fun isTagMissing(tagName: String): Boolean
+    fun isTagConflict(tagName: String, oldTagName: String): Boolean
     fun getCanonicalTagName(tagName: String): String
     fun renameTag(tagName: String, oldTag: Tag): Boolean
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/TagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/TagsRepository.kt
@@ -1,7 +1,11 @@
 package com.automattic.simplenote.repositories
 
+import com.automattic.simplenote.models.Tag
+
 interface TagsRepository {
     fun saveTag(tagName: String): Boolean
     fun isTagValid(tagName: String): Boolean
     fun isTagMissing(tagName: String): Boolean
+    fun getCanonicalTagName(tagName: String): String
+    fun renameTag(tagName: String, oldTag: Tag): Boolean
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
@@ -24,22 +24,29 @@ class TagDialogViewModel(private val tagsRepository: TagsRepository) : ViewModel
     }
 
     fun updateUiState(tagName: String) {
+        // Make sure the UI state exists
+        val currentUiState = _uiState.value
+        if (currentUiState == null) {
+            _event.postValue(ShowErrorEvent)
+            return
+        }
+
         if (tagName.isEmpty()) {
-            _uiState.value = _uiState.value!!.copy(tagName = tagName, errorMsg = R.string.tag_error_empty)
+            _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = R.string.tag_error_empty)
             return
         }
 
         if (tagName.contains(" ")) {
-            _uiState.value = _uiState.value!!.copy(tagName = tagName, errorMsg = R.string.tag_error_spaces)
+            _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = R.string.tag_error_spaces)
             return
         }
 
         if (!tagsRepository.isTagValid(tagName)) {
-            _uiState.value = _uiState.value!!.copy(tagName = tagName, errorMsg = R.string.tag_error_length)
+            _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = R.string.tag_error_length)
             return
         }
 
-        _uiState.value = _uiState.value!!.copy(tagName = tagName, errorMsg = null)
+        _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = null)
     }
 
     fun renameTagIfValid() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
@@ -8,9 +8,7 @@ import com.automattic.simplenote.analytics.AnalyticsTracker
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.repositories.TagsRepository
 
-class TagDialogViewModel(
-        private val tagsRepository: TagsRepository
-) : ViewModel() {
+class TagDialogViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
@@ -20,14 +20,14 @@ class TagDialogViewModel(private val tagsRepository: TagsRepository) : ViewModel
     }
 
     fun close() {
-        _event.postValue(CloseEvent)
+        _event.postValue(TagDialogEvent.CloseEvent)
     }
 
     fun updateUiState(tagName: String) {
         // Make sure the UI state exists
         val currentUiState = _uiState.value
         if (currentUiState == null) {
-            _event.postValue(ShowErrorEvent)
+            _event.postValue(TagDialogEvent.ShowErrorEvent)
             return
         }
 
@@ -53,13 +53,13 @@ class TagDialogViewModel(private val tagsRepository: TagsRepository) : ViewModel
         val currentState = uiState.value
 
         if (currentState == null) {
-            _event.postValue(ShowErrorEvent)
+            _event.postValue(TagDialogEvent.ShowErrorEvent)
             return
         }
 
         // If the tag did not changed, do not anything
         if (currentState.tagName == currentState.oldTag.name) {
-            _event.postValue(FinishEvent)
+            _event.postValue(TagDialogEvent.FinishEvent)
             return
         }
 
@@ -67,7 +67,7 @@ class TagDialogViewModel(private val tagsRepository: TagsRepository) : ViewModel
         if (tagsRepository.isTagConflict(currentState.tagName, currentState.oldTag.name)) {
             // get canonical name
             val canonicalTagName = tagsRepository.getCanonicalTagName(currentState.tagName)
-            _event.postValue(ConflictEvent(canonicalTagName, currentState.oldTag.name))
+            _event.postValue(TagDialogEvent.ConflictEvent(canonicalTagName, currentState.oldTag.name))
             return
         }
 
@@ -78,28 +78,29 @@ class TagDialogViewModel(private val tagsRepository: TagsRepository) : ViewModel
         val currentState = _uiState.value
 
         if (currentState == null) {
-            _event.postValue(ShowErrorEvent)
+            _event.postValue(TagDialogEvent.ShowErrorEvent)
             return
         }
 
         val result = tagsRepository.renameTag(currentState.tagName, currentState.oldTag)
         if (result) {
-            _event.postValue(FinishEvent)
+            _event.postValue(TagDialogEvent.FinishEvent)
             AnalyticsTracker.track(
                     AnalyticsTracker.Stat.TAG_EDITOR_ACCESSED,
                     AnalyticsTracker.CATEGORY_TAG,
                     "tag_alert_edit_box"
             )
         } else {
-            _event.postValue(ShowErrorEvent)
+            _event.postValue(TagDialogEvent.ShowErrorEvent)
         }
     }
 
     data class UiState(val tagName: String, val oldTag: Tag, val errorMsg: Int? = null)
 }
 
-sealed class TagDialogEvent
-object CloseEvent : TagDialogEvent()
-object FinishEvent : TagDialogEvent()
-object ShowErrorEvent : TagDialogEvent()
-data class ConflictEvent(val canonicalTagName: String, val oldTagName: String): TagDialogEvent()
+sealed class TagDialogEvent {
+    object CloseEvent : TagDialogEvent()
+    object FinishEvent : TagDialogEvent()
+    object ShowErrorEvent : TagDialogEvent()
+    data class ConflictEvent(val canonicalTagName: String, val oldTagName: String): TagDialogEvent()
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
@@ -1,0 +1,100 @@
+package com.automattic.simplenote.viewmodels
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.automattic.simplenote.R
+import com.automattic.simplenote.analytics.AnalyticsTracker
+import com.automattic.simplenote.models.Tag
+import com.automattic.simplenote.repositories.TagsRepository
+
+class TagDialogViewModel(
+        private val tagsRepository: TagsRepository
+) : ViewModel() {
+    private val _uiState = MutableLiveData<UiState>()
+    val uiState: LiveData<UiState> = _uiState
+
+    private val _event = SingleLiveEvent<TagDialogEvent>()
+    val event: LiveData<TagDialogEvent> = _event
+
+    fun start(tag: Tag) {
+        _uiState.value = UiState(tag.name, tag)
+    }
+
+    fun close() {
+        _event.postValue(CloseEvent)
+    }
+
+    fun updateUiState(tagName: String) {
+        if (tagName.isEmpty()) {
+            _uiState.value = _uiState.value!!.copy(tagName = tagName, errorMsg = R.string.tag_error_empty)
+            return
+        }
+
+        if (tagName.contains(" ")) {
+            _uiState.value = _uiState.value!!.copy(tagName = tagName, errorMsg = R.string.tag_error_spaces)
+            return
+        }
+
+        if (!tagsRepository.isTagValid(tagName)) {
+            _uiState.value = _uiState.value!!.copy(tagName = tagName, errorMsg = R.string.tag_error_length)
+            return
+        }
+
+        _uiState.value = _uiState.value!!.copy(tagName = tagName, errorMsg = null)
+    }
+
+    fun renameTagIfValid() {
+        val currentState = uiState.value
+
+        if (currentState == null) {
+            _event.postValue(ShowErrorEvent)
+            return
+        }
+
+        // If the tag did not changed, do not anything
+        if (currentState.tagName == currentState.oldTag.name) {
+            _event.postValue(FinishEvent)
+            return
+        }
+
+        // If there is another tag with the same name
+        if (!tagsRepository.isTagMissing(currentState.tagName)) {
+            // get canonical name
+            val canonicalTagName = tagsRepository.getCanonicalTagName(currentState.tagName)
+            _event.postValue(ConflictEvent(canonicalTagName, currentState.oldTag.name))
+            return
+        }
+
+        renameTag()
+    }
+
+    fun renameTag() {
+        val currentState = _uiState.value
+
+        if (currentState == null) {
+            _event.postValue(ShowErrorEvent)
+            return
+        }
+
+        val result = tagsRepository.renameTag(currentState.tagName, currentState.oldTag)
+        if (result) {
+            _event.postValue(FinishEvent)
+            AnalyticsTracker.track(
+                    AnalyticsTracker.Stat.TAG_EDITOR_ACCESSED,
+                    AnalyticsTracker.CATEGORY_TAG,
+                    "tag_alert_edit_box"
+            )
+        } else {
+            _event.postValue(ShowErrorEvent)
+        }
+    }
+
+    data class UiState(val tagName: String, val oldTag: Tag, val errorMsg: Int? = null)
+}
+
+sealed class TagDialogEvent
+object CloseEvent : TagDialogEvent()
+object FinishEvent : TagDialogEvent()
+object ShowErrorEvent : TagDialogEvent()
+data class ConflictEvent(val canonicalTagName: String, val oldTagName: String): TagDialogEvent()

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
@@ -64,7 +64,7 @@ class TagDialogViewModel(private val tagsRepository: TagsRepository) : ViewModel
         }
 
         // If there is another tag with the same name
-        if (!tagsRepository.isTagMissing(currentState.tagName)) {
+        if (tagsRepository.isTagConflict(currentState.tagName, currentState.oldTag.name)) {
             // get canonical name
             val canonicalTagName = tagsRepository.getCanonicalTagName(currentState.tagName)
             _event.postValue(ConflictEvent(canonicalTagName, currentState.oldTag.name))

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/ViewModelFactory.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/ViewModelFactory.kt
@@ -5,12 +5,14 @@ import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.savedstate.SavedStateRegistryOwner
+import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.repositories.SimperiumTagsRepository
 import com.simperium.client.Bucket
 
 class ViewModelFactory constructor(
         private val tagsBucket: Bucket<Tag>,
+        private val notesBucket: Bucket<Note>,
         owner: SavedStateRegistryOwner,
         defaultArgs: Bundle? = null
 ) : AbstractSavedStateViewModelFactory(owner, defaultArgs) {
@@ -22,7 +24,9 @@ class ViewModelFactory constructor(
     ) = with(modelClass) {
         when {
             isAssignableFrom(AddTagViewModel::class.java) ->
-                AddTagViewModel(SimperiumTagsRepository(tagsBucket))
+                AddTagViewModel(SimperiumTagsRepository(tagsBucket, notesBucket))
+            isAssignableFrom(TagDialogViewModel::class.java) ->
+                TagDialogViewModel(SimperiumTagsRepository(tagsBucket, notesBucket))
             else ->
                 throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
         }

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
@@ -1,0 +1,126 @@
+package com.automattic.simplenote.viewmodels
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.automattic.simplenote.R
+import com.automattic.simplenote.models.Tag
+import com.automattic.simplenote.repositories.TagsRepository
+import com.automattic.simplenote.utils.getLocalRandomStringOfLen
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+
+
+class TagDialogViewModelTest {
+    @get:Rule val rule = InstantTaskExecutorRule()
+
+    private lateinit var viewModel: TagDialogViewModel
+    private val fakeTagsRepository = mock(TagsRepository::class.java)
+    private val tagName = "tag1"
+    private lateinit var tag: Tag
+
+    @Before
+    fun setup() {
+        viewModel = TagDialogViewModel(fakeTagsRepository)
+    }
+
+    @Before
+    fun setupInitialTag() {
+        tag = Tag(tagName)
+        tag.name = tagName
+        tag.index = 0
+        viewModel.start(tag)
+    }
+
+    @Test
+    fun startShouldSetupUiState() {
+        assertNull(viewModel.uiState.value?.errorMsg)
+        assertEquals(viewModel.uiState.value!!.tagName, tagName)
+        assertEquals(viewModel.uiState.value!!.oldTag, tag)
+    }
+
+    @Test
+    fun validateEmptyTag() {
+        viewModel.updateUiState("")
+
+        assertEquals(viewModel.uiState.value?.errorMsg, R.string.tag_error_empty)
+    }
+
+    @Test
+    fun validateSpaceTag() {
+        viewModel.updateUiState("tag 5")
+
+        assertEquals(viewModel.uiState.value?.errorMsg, R.string.tag_error_spaces)
+    }
+
+    @Test
+    fun validateTooLongTag() {
+        val randomLongTag = getLocalRandomStringOfLen(279)
+        viewModel.updateUiState(randomLongTag)
+
+        assertEquals(viewModel.uiState.value?.errorMsg, R.string.tag_error_length)
+    }
+
+    @Test
+    fun validateValidTag() {
+        val tagName = "tag2"
+
+        `when`(fakeTagsRepository.isTagValid(tagName)).thenReturn(true)
+        `when`(fakeTagsRepository.isTagMissing(tagName)).thenReturn(true)
+
+        viewModel.updateUiState(tagName)
+
+        assertNull(viewModel.uiState.value?.errorMsg)
+    }
+
+    @Test
+    fun editTagWithSameName() {
+        viewModel.updateUiState(tagName)
+        viewModel.renameTagIfValid()
+
+        assertTrue(viewModel.event.value is FinishEvent)
+    }
+
+    @Test
+    fun editTagWithNewName() {
+        val newTagName = "tag2"
+
+        viewModel.updateUiState(newTagName)
+        `when`(fakeTagsRepository.isTagMissing(newTagName)).thenReturn(true)
+        `when`(fakeTagsRepository.renameTag(newTagName, tag)).thenReturn(true)
+        viewModel.renameTagIfValid()
+
+        assertEquals(viewModel.uiState.value!!.tagName, newTagName)
+        assertTrue(viewModel.event.value is FinishEvent)
+    }
+
+    @Test
+    fun editTagWithConflict() {
+        val newTagName = "tag2"
+
+        viewModel.updateUiState(newTagName)
+        `when`(fakeTagsRepository.isTagMissing(newTagName)).thenReturn(false)
+        `when`(fakeTagsRepository.getCanonicalTagName(newTagName)).thenReturn(newTagName)
+        viewModel.renameTagIfValid()
+
+        assertEquals(viewModel.uiState.value!!.tagName, newTagName)
+        assertTrue(viewModel.event.value is ConflictEvent)
+        assertEquals((viewModel.event.value as ConflictEvent).canonicalTagName, newTagName)
+        assertEquals((viewModel.event.value as ConflictEvent).oldTagName, tagName)
+    }
+
+    @Test
+    fun editTagWithError() {
+        val newTagName = "tag2"
+
+        viewModel.updateUiState(newTagName)
+        `when`(fakeTagsRepository.isTagMissing(newTagName)).thenReturn(true)
+        `when`(fakeTagsRepository.renameTag(newTagName, tag)).thenReturn(false)
+        viewModel.renameTagIfValid()
+
+        assertEquals(viewModel.uiState.value!!.tagName, newTagName)
+        assertTrue(viewModel.event.value is ShowErrorEvent)
+    }
+}

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
@@ -42,6 +42,13 @@ class TagDialogViewModelTest {
     }
 
     @Test
+    fun closeShouldTriggerEventClose() {
+        viewModel.close()
+
+        assertEquals(viewModel.event.value, TagDialogEvent.CloseEvent)
+    }
+
+    @Test
     fun validateEmptyTag() {
         viewModel.updateUiState("")
 
@@ -119,6 +126,30 @@ class TagDialogViewModelTest {
         `when`(fakeTagsRepository.isTagConflict(newTagName, tagName)).thenReturn(false)
         `when`(fakeTagsRepository.renameTag(newTagName, tag)).thenReturn(false)
         viewModel.renameTagIfValid()
+
+        assertEquals(viewModel.uiState.value?.tagName, newTagName)
+        assertTrue(viewModel.event.value is TagDialogEvent.ShowErrorEvent)
+    }
+
+    @Test
+    fun renameTagValid() {
+        val newTagName = "tag2"
+
+        viewModel.updateUiState(newTagName)
+        `when`(fakeTagsRepository.renameTag(newTagName, tag)).thenReturn(true)
+        viewModel.renameTag()
+
+        assertEquals(viewModel.uiState.value?.tagName, newTagName)
+        assertTrue(viewModel.event.value is TagDialogEvent.FinishEvent)
+    }
+
+    @Test
+    fun renameTagError() {
+        val newTagName = "tag2"
+
+        viewModel.updateUiState(newTagName)
+        `when`(fakeTagsRepository.renameTag(newTagName, tag)).thenReturn(false)
+        viewModel.renameTag()
 
         assertEquals(viewModel.uiState.value?.tagName, newTagName)
         assertTrue(viewModel.event.value is TagDialogEvent.ShowErrorEvent)

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
@@ -80,7 +80,7 @@ class TagDialogViewModelTest {
         viewModel.updateUiState(tagName)
         viewModel.renameTagIfValid()
 
-        assertTrue(viewModel.event.value is FinishEvent)
+        assertTrue(viewModel.event.value is TagDialogEvent.FinishEvent)
     }
 
     @Test
@@ -93,7 +93,7 @@ class TagDialogViewModelTest {
         viewModel.renameTagIfValid()
 
         assertEquals(viewModel.uiState.value?.tagName, newTagName)
-        assertTrue(viewModel.event.value is FinishEvent)
+        assertTrue(viewModel.event.value is TagDialogEvent.FinishEvent)
     }
 
     @Test
@@ -106,9 +106,9 @@ class TagDialogViewModelTest {
         viewModel.renameTagIfValid()
 
         assertEquals(viewModel.uiState.value?.tagName, newTagName)
-        assertTrue(viewModel.event.value is ConflictEvent)
-        assertEquals((viewModel.event.value as ConflictEvent).canonicalTagName, newTagName)
-        assertEquals((viewModel.event.value as ConflictEvent).oldTagName, tagName)
+        assertTrue(viewModel.event.value is TagDialogEvent.ConflictEvent)
+        assertEquals((viewModel.event.value as TagDialogEvent.ConflictEvent).canonicalTagName, newTagName)
+        assertEquals((viewModel.event.value as TagDialogEvent.ConflictEvent).oldTagName, tagName)
     }
 
     @Test
@@ -121,6 +121,6 @@ class TagDialogViewModelTest {
         viewModel.renameTagIfValid()
 
         assertEquals(viewModel.uiState.value?.tagName, newTagName)
-        assertTrue(viewModel.event.value is ShowErrorEvent)
+        assertTrue(viewModel.event.value is TagDialogEvent.ShowErrorEvent)
     }
 }

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
@@ -65,12 +65,12 @@ class TagDialogViewModelTest {
 
     @Test
     fun validateValidTag() {
-        val tagName = "tag2"
+        val hewTagName = "tag2"
 
-        `when`(fakeTagsRepository.isTagValid(tagName)).thenReturn(true)
-        `when`(fakeTagsRepository.isTagMissing(tagName)).thenReturn(true)
+        `when`(fakeTagsRepository.isTagValid(hewTagName)).thenReturn(true)
+        `when`(fakeTagsRepository.isTagConflict(hewTagName, tagName)).thenReturn(false)
 
-        viewModel.updateUiState(tagName)
+        viewModel.updateUiState(hewTagName)
 
         assertNull(viewModel.uiState.value?.errorMsg)
     }
@@ -88,11 +88,11 @@ class TagDialogViewModelTest {
         val newTagName = "tag2"
 
         viewModel.updateUiState(newTagName)
-        `when`(fakeTagsRepository.isTagMissing(newTagName)).thenReturn(true)
+        `when`(fakeTagsRepository.isTagConflict(newTagName, tagName)).thenReturn(false)
         `when`(fakeTagsRepository.renameTag(newTagName, tag)).thenReturn(true)
         viewModel.renameTagIfValid()
 
-        assertEquals(viewModel.uiState.value!!.tagName, newTagName)
+        assertEquals(viewModel.uiState.value?.tagName, newTagName)
         assertTrue(viewModel.event.value is FinishEvent)
     }
 
@@ -101,7 +101,7 @@ class TagDialogViewModelTest {
         val newTagName = "tag2"
 
         viewModel.updateUiState(newTagName)
-        `when`(fakeTagsRepository.isTagMissing(newTagName)).thenReturn(false)
+        `when`(fakeTagsRepository.isTagConflict(newTagName, tagName)).thenReturn(true)
         `when`(fakeTagsRepository.getCanonicalTagName(newTagName)).thenReturn(newTagName)
         viewModel.renameTagIfValid()
 
@@ -116,7 +116,7 @@ class TagDialogViewModelTest {
         val newTagName = "tag2"
 
         viewModel.updateUiState(newTagName)
-        `when`(fakeTagsRepository.isTagMissing(newTagName)).thenReturn(true)
+        `when`(fakeTagsRepository.isTagConflict(newTagName, tagName)).thenReturn(false)
         `when`(fakeTagsRepository.renameTag(newTagName, tag)).thenReturn(false)
         viewModel.renameTagIfValid()
 

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
@@ -37,8 +37,8 @@ class TagDialogViewModelTest {
     @Test
     fun startShouldSetupUiState() {
         assertNull(viewModel.uiState.value?.errorMsg)
-        assertEquals(viewModel.uiState.value!!.tagName, tagName)
-        assertEquals(viewModel.uiState.value!!.oldTag, tag)
+        assertEquals(viewModel.uiState.value?.tagName, tagName)
+        assertEquals(viewModel.uiState.value?.oldTag, tag)
     }
 
     @Test
@@ -105,7 +105,7 @@ class TagDialogViewModelTest {
         `when`(fakeTagsRepository.getCanonicalTagName(newTagName)).thenReturn(newTagName)
         viewModel.renameTagIfValid()
 
-        assertEquals(viewModel.uiState.value!!.tagName, newTagName)
+        assertEquals(viewModel.uiState.value?.tagName, newTagName)
         assertTrue(viewModel.event.value is ConflictEvent)
         assertEquals((viewModel.event.value as ConflictEvent).canonicalTagName, newTagName)
         assertEquals((viewModel.event.value as ConflictEvent).oldTagName, tagName)
@@ -120,7 +120,7 @@ class TagDialogViewModelTest {
         `when`(fakeTagsRepository.renameTag(newTagName, tag)).thenReturn(false)
         viewModel.renameTagIfValid()
 
-        assertEquals(viewModel.uiState.value!!.tagName, newTagName)
+        assertEquals(viewModel.uiState.value?.tagName, newTagName)
         assertTrue(viewModel.event.value is ShowErrorEvent)
     }
 }


### PR DESCRIPTION
Fixes #1370 

### Fix
This PR restructure the code of `TagDialogFragment` to use ViewModels (`TagDialogViewModel`)  in order to decouple data management logic from the view. 

### Test

#### Automatic Tests
1. Run `TagDialogFragmentTest` inside `androidTest`. It requires to run an on emulator or physical device. 
2. Run `TagDialogViewModelTest inside `test`

#### Manual Tests
1. Open Simplenote app
2. Tab on left menu
3. Tab on EDIT tags
4. Tab on a tag that have notes associated
5. Try adding valid tags and tags with errors (e.g. tag with spaces, tags that already exists)
6. Try merging tags (rename a tag to a tag that already exists)

### Review
This PR will be reviewed by @ParaskP7 .

### Release
These changes do not require release notes.
