### PR TITLE
Add TagsViewModel to restructure UI and orchestration logic in TagsActivity

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -95,6 +95,8 @@ dependencies {
     // Infrastructure to test fragments
     debugImplementation "androidx.fragment:fragment-testing:1.3.3"
     testImplementation "androidx.arch.core:core-testing:2.1.0"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.3"
+    testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"
 
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -284,7 +284,7 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
     @Override
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         if (resultCode == RESULT_OK && requestCode == REQUEST_ADD_TAG) {
-            refreshTags();
+            viewModel.updateOnResult();
         }
 
         super.onActivityResult(requestCode, resultCode, data);

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -132,6 +132,8 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
                 }
 
                 Toast.makeText(TagsActivity.this, getString(R.string.add_tag), Toast.LENGTH_SHORT).show();
+            } else if (event instanceof TagsEvent.FinishEvent) {
+                finish();
             }
         });
     }
@@ -294,7 +296,7 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            finish();
+            viewModel.close();
             return true;
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -42,6 +42,7 @@ import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
 import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.viewmodels.AddTagViewModel;
+import com.automattic.simplenote.viewmodels.TagsEvent;
 import com.automattic.simplenote.viewmodels.TagsViewModel;
 import com.automattic.simplenote.viewmodels.ViewModelFactory;
 import com.automattic.simplenote.widgets.EmptyViewRecyclerView;
@@ -107,18 +108,8 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
         mTagsList.setEmptyView(emptyView);
 
         mButtonAdd = findViewById(R.id.button_add);
-        mButtonAdd.setOnClickListener(
-            new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    Intent intent = new Intent(TagsActivity.this, AddTagActivity.class);
-                    intent.putExtra(MorphSetup.EXTRA_SHARED_ELEMENT_COLOR_END, ThemeUtils.getColorFromAttribute(TagsActivity.this, R.attr.drawerBackgroundColor));
-                    intent.putExtra(MorphSetup.EXTRA_SHARED_ELEMENT_COLOR_START, ThemeUtils.getColorFromAttribute(TagsActivity.this, R.attr.fabColor));
-                    ActivityOptions options = ActivityOptions.makeSceneTransitionAnimation(TagsActivity.this, mButtonAdd, "shared_button");
-                    startActivityForResult(intent, REQUEST_ADD_TAG, options.toBundle());
-                }
-            }
-        );
+        mButtonAdd.setOnClickListener(v -> viewModel.addTag());
+
         mButtonAdd.setOnLongClickListener(
             new View.OnLongClickListener() {
                 @Override
@@ -133,7 +124,21 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
             }
         );
 
+        setObservers();
+
         refreshTags();
+    }
+
+    private void setObservers() {
+        viewModel.getEvent().observe(this, event -> {
+            if (event instanceof TagsEvent.AddTagEvent) {
+                Intent intent = new Intent(TagsActivity.this, AddTagActivity.class);
+                intent.putExtra(MorphSetup.EXTRA_SHARED_ELEMENT_COLOR_END, ThemeUtils.getColorFromAttribute(TagsActivity.this, R.attr.drawerBackgroundColor));
+                intent.putExtra(MorphSetup.EXTRA_SHARED_ELEMENT_COLOR_START, ThemeUtils.getColorFromAttribute(TagsActivity.this, R.attr.fabColor));
+                ActivityOptions options = ActivityOptions.makeSceneTransitionAnimation(TagsActivity.this, mButtonAdd, "shared_button");
+                startActivityForResult(intent, REQUEST_ADD_TAG, options.toBundle());
+            }
+        });
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -138,13 +138,14 @@ public class TagsActivity extends ThemedAppCompatActivity {
 
     private void setObservers() {
         viewModel.getUiState().observe(this, uiState ->
-            tagItemAdapter.submitList(uiState.getTagItems(), () -> {
-                if (uiState.getSearchUpdate()) {
-                    mTagsList.scrollToPosition(0);
-                    boolean isSearching = uiState.getSearchQuery() != null;
-                    checkEmptyList(isSearching);
-            }
-        }));
+                tagItemAdapter.submitList(uiState.getTagItems(), () -> {
+                    if (uiState.getSearchUpdate()) {
+                        mTagsList.scrollToPosition(0);
+                        boolean isSearching = uiState.getSearchQuery() != null;
+                        checkEmptyList(isSearching);
+                    }
+                })
+        );
 
         // Observe different events such as clicks on add tags, edit tags and delete tags
         viewModel.getEvent().observe(this, event -> {

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -41,7 +41,6 @@ import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
 import com.automattic.simplenote.utils.ThemeUtils;
-import com.automattic.simplenote.viewmodels.AddTagViewModel;
 import com.automattic.simplenote.viewmodels.TagsEvent;
 import com.automattic.simplenote.viewmodels.TagsViewModel;
 import com.automattic.simplenote.viewmodels.ViewModelFactory;
@@ -108,21 +107,11 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
         mTagsList.setEmptyView(emptyView);
 
         mButtonAdd = findViewById(R.id.button_add);
-        mButtonAdd.setOnClickListener(v -> viewModel.addTag());
-
-        mButtonAdd.setOnLongClickListener(
-            new View.OnLongClickListener() {
-                @Override
-                public boolean onLongClick(View v) {
-                    if (v.isHapticFeedbackEnabled()) {
-                        v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
-                    }
-
-                    Toast.makeText(TagsActivity.this, getString(R.string.add_tag), Toast.LENGTH_SHORT).show();
-                    return true;
-                }
-            }
-        );
+        mButtonAdd.setOnClickListener(v -> viewModel.clickAddTag());
+        mButtonAdd.setOnLongClickListener(v -> {
+            viewModel.longClickAddTag();
+            return true;
+        });
 
         setObservers();
 
@@ -137,6 +126,12 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
                 intent.putExtra(MorphSetup.EXTRA_SHARED_ELEMENT_COLOR_START, ThemeUtils.getColorFromAttribute(TagsActivity.this, R.attr.fabColor));
                 ActivityOptions options = ActivityOptions.makeSceneTransitionAnimation(TagsActivity.this, mButtonAdd, "shared_button");
                 startActivityForResult(intent, REQUEST_ADD_TAG, options.toBundle());
+            } else if (event instanceof TagsEvent.LongAddTagEvent) {
+                if (mButtonAdd.isHapticFeedbackEnabled()) {
+                    mButtonAdd.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+                }
+
+                Toast.makeText(TagsActivity.this, getString(R.string.add_tag), Toast.LENGTH_SHORT).show();
             }
         });
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -194,9 +194,8 @@ public class TagsActivity extends ThemedAppCompatActivity {
     }
 
     private void showTagDialogFragment(TagsEvent.EditTagEvent event) {
-        TagsEvent.EditTagEvent editTagEvent = event;
         TagDialogFragment dialog = new TagDialogFragment(
-                editTagEvent.getTagItem().getTag(),
+                event.getTagItem().getTag(),
                 mNotesBucket,
                 mTagsBucket
         );

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -20,6 +20,7 @@ import android.widget.Toast;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.appcompat.widget.SearchView;
@@ -156,7 +157,7 @@ public class TagsActivity extends ThemedAppCompatActivity {
             mButtonAdd.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
         }
 
-        Toast.makeText(TagsActivity.this, getString(R.string.add_tag), Toast.LENGTH_SHORT).show();
+        toast(R.string.add_tag);
     }
 
     private void showLongDeleteToast(TagsEvent.LongDeleteTagEvent event) {
@@ -165,7 +166,11 @@ public class TagsActivity extends ThemedAppCompatActivity {
             v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
         }
 
-        Toast.makeText(TagsActivity.this, getString(R.string.delete_tag), Toast.LENGTH_SHORT).show();
+        toast(R.string.delete_tag);
+    }
+
+    private void toast(@StringRes int resId) {
+        Toast.makeText(TagsActivity.this, getString(resId), Toast.LENGTH_SHORT).show();
     }
 
     private void showDeleteDialog(TagsEvent.DeleteTagEvent event) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -98,15 +98,11 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
                     return Unit.INSTANCE;
                 },
                 (TagItem tagItem) -> {
-                    viewModel.longClickEditTag(tagItem);
-                    return Unit.INSTANCE;
-                },
-                (TagItem tagItem) -> {
                     viewModel.clickDeleteTag(tagItem);
                     return Unit.INSTANCE;
                 },
-                (TagItem tagItem) -> {
-                    viewModel.longClickDeleteTag(tagItem);
+                (View view) -> {
+                    viewModel.longClickDeleteTag(view);
                     return Unit.INSTANCE;
                 }
         );
@@ -164,6 +160,33 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
                 Toast.makeText(TagsActivity.this, getString(R.string.add_tag), Toast.LENGTH_SHORT).show();
             } else if (event instanceof TagsEvent.FinishEvent) {
                 finish();
+            } else if (event instanceof TagsEvent.EditTagEvent) {
+                TagsEvent.EditTagEvent editTagEvent = (TagsEvent.EditTagEvent) event;
+                TagDialogFragment dialog = new TagDialogFragment(
+                        editTagEvent.getTagItem().getTag(),
+                        mNotesBucket,
+                        mTagsBucket
+                );
+                dialog.show(getSupportFragmentManager().beginTransaction(), DIALOG_TAG);
+            } else if (event instanceof TagsEvent.DeleteTagEvent) {
+                TagsEvent.DeleteTagEvent deleteTagEvent = (TagsEvent.DeleteTagEvent) event;
+                AlertDialog.Builder alert = new AlertDialog.Builder(new ContextThemeWrapper(TagsActivity.this, R.style.Dialog));
+                alert.setTitle(R.string.delete_tag);
+                alert.setMessage(getString(R.string.confirm_delete_tag));
+                alert.setNegativeButton(R.string.no, null);
+                alert.setPositiveButton(
+                        R.string.yes,
+                        (dialog, whichButton) -> viewModel.deleteTag(deleteTagEvent.getTagItem())
+                );
+                alert.show();
+            } else if (event instanceof TagsEvent.LongDeleteTagEvent) {
+                TagsEvent.LongDeleteTagEvent longDeleteTagEvent = (TagsEvent.LongDeleteTagEvent) event;
+                View v = longDeleteTagEvent.getView();
+                if (v.isHapticFeedbackEnabled()) {
+                    v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+                }
+
+                Toast.makeText(TagsActivity.this, getString(R.string.delete_tag), Toast.LENGTH_SHORT).show();
             }
         });
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -132,7 +132,6 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
         });
 
         setObservers();
-        viewModel.start();
 
         refreshTags();
     }
@@ -272,20 +271,14 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
         super.onResume();
         disableScreenshotsIfLocked(this);
 
-        mTagsBucket.addOnNetworkChangeListener(this);
-        mTagsBucket.addOnSaveObjectListener(this);
-        mTagsBucket.addOnDeleteObjectListener(this);
-        AppLog.add(AppLog.Type.SYNC, "Added tag bucket listener (TagsActivity)");
+        viewModel.start();
     }
 
     @Override
     public void onPause() {
         super.onPause();
 
-        mTagsBucket.removeOnNetworkChangeListener(this);
-        mTagsBucket.removeOnSaveObjectListener(this);
-        mTagsBucket.removeOnDeleteObjectListener(this);
-        AppLog.add(AppLog.Type.SYNC, "Removed tag bucket listener (TagsActivity)");
+        viewModel.pause();
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -1,20 +1,17 @@
 package com.automattic.simplenote;
 
+import static com.automattic.simplenote.TagDialogFragment.DIALOG_TAG;
+import static com.automattic.simplenote.utils.DisplayUtils.disableScreenshotsIfLocked;
+
 import android.app.ActivityOptions;
-import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
-import android.database.Cursor;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.SpannableString;
 import android.view.HapticFeedbackConstants;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -22,7 +19,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.DrawableRes;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.view.ContextThemeWrapper;
@@ -30,14 +26,10 @@ import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 
-import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
 import com.automattic.simplenote.models.TagItem;
-import com.automattic.simplenote.utils.AppLog;
-import com.automattic.simplenote.utils.BaseCursorAdapter;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
@@ -49,18 +41,8 @@ import com.automattic.simplenote.viewmodels.ViewModelFactory;
 import com.automattic.simplenote.widgets.EmptyViewRecyclerView;
 import com.automattic.simplenote.widgets.MorphSetup;
 import com.simperium.client.Bucket;
-import com.simperium.client.Query;
-
-import java.lang.ref.SoftReference;
-import java.util.List;
-import java.util.Set;
 
 import kotlin.Unit;
-
-import static com.automattic.simplenote.TagDialogFragment.DIALOG_TAG;
-import static com.automattic.simplenote.models.Note.TAGS_PROPERTY;
-import static com.automattic.simplenote.models.Tag.NAME_PROPERTY;
-import static com.automattic.simplenote.utils.DisplayUtils.disableScreenshotsIfLocked;
 
 public class TagsActivity extends ThemedAppCompatActivity {
     private static final int REQUEST_ADD_TAG = 9000;
@@ -125,7 +107,7 @@ public class TagsActivity extends ThemedAppCompatActivity {
         View emptyView = findViewById(R.id.empty);
         mEmptyViewImage = emptyView.findViewById(R.id.image);
         mEmptyViewText = emptyView.findViewById(R.id.text);
-        checkEmptyList(false);
+        setLabelEmptyTagList();
         mTagsList.setEmptyView(emptyView);
 
         mButtonAdd = findViewById(R.id.button_add);
@@ -142,7 +124,11 @@ public class TagsActivity extends ThemedAppCompatActivity {
                     if (uiState.getSearchUpdate()) {
                         mTagsList.scrollToPosition(0);
                         boolean isSearching = uiState.getSearchQuery() != null;
-                        checkEmptyList(isSearching);
+                        if (isSearching) {
+                            setLabelEmptyTagListSearchResults();
+                        } else {
+                            setLabelEmptyTagList();
+                        }
                     }
                 })
         );
@@ -286,19 +272,20 @@ public class TagsActivity extends ThemedAppCompatActivity {
         super.onActivityResult(requestCode, resultCode, data);
     }
 
-    public void checkEmptyList(boolean isSearching) {
-        if (isSearching) {
-            if (DisplayUtils.isLandscape(TagsActivity.this) && !DisplayUtils.isLargeScreen(TagsActivity.this)) {
-                setEmptyListImage(-1);
-            } else {
-                setEmptyListImage(R.drawable.ic_search_24dp);
-            }
+    private void setLabelEmptyTagList() {
+        setEmptyListImage(R.drawable.ic_tag_24dp);
+        setEmptyListMessage(getString(R.string.empty_tags));
+    }
 
-            setEmptyListMessage(getString(R.string.empty_tags_search));
+    private void setLabelEmptyTagListSearchResults() {
+        if (DisplayUtils.isLandscape(TagsActivity.this) &&
+                !DisplayUtils.isLargeScreen(TagsActivity.this)) {
+            setEmptyListImage(-1);
         } else {
-            setEmptyListImage(R.drawable.ic_tag_24dp);
-            setEmptyListMessage(getString(R.string.empty_tags));
+            setEmptyListImage(R.drawable.ic_search_24dp);
         }
+
+        setEmptyListMessage(getString(R.string.empty_tags_search));
     }
 
     private void setEmptyListImage(@DrawableRes int image) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -28,6 +28,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -40,6 +41,9 @@ import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
 import com.automattic.simplenote.utils.ThemeUtils;
+import com.automattic.simplenote.viewmodels.AddTagViewModel;
+import com.automattic.simplenote.viewmodels.TagsViewModel;
+import com.automattic.simplenote.viewmodels.ViewModelFactory;
 import com.automattic.simplenote.widgets.EmptyViewRecyclerView;
 import com.automattic.simplenote.widgets.MorphSetup;
 import com.simperium.client.Bucket;
@@ -68,10 +72,20 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
     private TextView mEmptyViewText;
     private boolean mIsSearching;
 
+    private TagsViewModel viewModel;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_tags);
+
+        Simplenote application = (Simplenote) getApplication();
+        mTagsBucket = application.getTagsBucket();
+        mNotesBucket = application.getNotesBucket();
+
+        ViewModelFactory viewModelFactory = new ViewModelFactory(mTagsBucket, mNotesBucket, this, null);
+        ViewModelProvider viewModelProvider = new ViewModelProvider(this, viewModelFactory);
+        viewModel = viewModelProvider.get(TagsViewModel.class);
 
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
@@ -81,10 +95,6 @@ public class TagsActivity extends ThemedAppCompatActivity implements Bucket.List
             getSupportActionBar().setTitle(title);
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
-
-        Simplenote application = (Simplenote) getApplication();
-        mTagsBucket = application.getTagsBucket();
-        mNotesBucket = application.getNotesBucket();
 
         mTagsList = findViewById(R.id.list);
         mTagsAdapter = new TagsAdapter();

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
@@ -449,6 +449,14 @@ public class Note extends BucketObject {
         }
     }
 
+    public void removeTag(String tag) {
+        List<String> tags = getTags();
+        tags.remove(tag);
+
+        setTags(tags);
+        save();
+    }
+
     private boolean hasSystemTag(String tag) {
         if (TextUtils.isEmpty(tag))
             return false;

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Note.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 
 import com.automattic.simplenote.R;
+import com.automattic.simplenote.utils.TagUtils;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObject;
 import com.simperium.client.BucketSchema;
@@ -449,9 +450,11 @@ public class Note extends BucketObject {
         }
     }
 
-    public void removeTag(String tag) {
+    public void removeTag(String tagName) {
         List<String> tags = getTags();
-        tags.remove(tag);
+
+        List<String> tagsMatched = TagUtils.findTagsMatch(tags, tagName);
+        tags.removeAll(tagsMatched);
 
         setTags(tags);
         save();

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/TagItem.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/TagItem.kt
@@ -1,0 +1,3 @@
+package com.automattic.simplenote.models
+
+data class TagItem(val tag: Tag, val noteCount: Int)

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
@@ -74,7 +74,7 @@ class SimperiumTagsRepository(
         return localAllTags()
     }
 
-    fun localAllTags(): List<TagItem> {
+    private fun localAllTags(): List<TagItem> {
         val tagQuery = Tag.all(tagsBucket).reorder().orderByKey().include(Tag.NOTE_COUNT_INDEX_NAME)
         val cursor = tagQuery.execute()
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
@@ -78,21 +78,23 @@ class SimperiumTagsRepository(
     }
 
     @ExperimentalCoroutinesApi
-    override suspend fun tagsChanged(): Flow<Boolean> = callbackFlow {
-        val callbackOnSaveObject = Bucket.OnSaveObjectListener<Tag> { _, _ -> offer(true) }
-        val callbackOnDeleteObject = Bucket.OnDeleteObjectListener<Tag> { _, _ -> offer(true) }
-        val callbackOnNetworkChange = Bucket.OnNetworkChangeListener<Tag> { _, _, _ -> offer(true) }
+    override suspend fun tagsChanged(): Flow<Boolean> = withContext(Dispatchers.IO) {
+        callbackFlow {
+            val callbackOnSaveObject = Bucket.OnSaveObjectListener<Tag> { _, _ -> offer(true) }
+            val callbackOnDeleteObject = Bucket.OnDeleteObjectListener<Tag> { _, _ -> offer(true) }
+            val callbackOnNetworkChange = Bucket.OnNetworkChangeListener<Tag> { _, _, _ -> offer(true) }
 
-        tagsBucket.addOnSaveObjectListener(callbackOnSaveObject)
-        tagsBucket.addOnDeleteObjectListener(callbackOnDeleteObject)
-        tagsBucket.addOnNetworkChangeListener(callbackOnNetworkChange)
-        AppLog.add(AppLog.Type.SYNC, "Added tag bucket listener (TagsActivity)")
+            tagsBucket.addOnSaveObjectListener(callbackOnSaveObject)
+            tagsBucket.addOnDeleteObjectListener(callbackOnDeleteObject)
+            tagsBucket.addOnNetworkChangeListener(callbackOnNetworkChange)
+            AppLog.add(AppLog.Type.SYNC, "Added tag bucket listener (TagsActivity)")
 
-        awaitClose {
-            tagsBucket.removeOnSaveObjectListener(callbackOnSaveObject)
-            tagsBucket.removeOnDeleteObjectListener(callbackOnDeleteObject)
-            tagsBucket.removeOnNetworkChangeListener(callbackOnNetworkChange)
-            AppLog.add(AppLog.Type.SYNC, "Removed tag bucket listener (TagsActivity)")
+            awaitClose {
+                tagsBucket.removeOnSaveObjectListener(callbackOnSaveObject)
+                tagsBucket.removeOnDeleteObjectListener(callbackOnDeleteObject)
+                tagsBucket.removeOnNetworkChangeListener(callbackOnNetworkChange)
+                AppLog.add(AppLog.Type.SYNC, "Removed tag bucket listener (TagsActivity)")
+            }
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
@@ -69,10 +69,7 @@ class SimperiumTagsRepository(
 
         while (cursor.moveToNext()) {
             val note = cursor.getObject()
-            val tags = note.tags
-            tags.remove(tag.name)
-            note.tags = tags
-            note.save()
+            note.removeTag(tag.name)
         }
 
         cursor.close()

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
@@ -58,7 +58,7 @@ class SimperiumTagsRepository(
         }
     }
 
-    override suspend fun deleteTag(tag: Tag) {
+    override suspend fun deleteTag(tag: Tag) = withContext(Dispatchers.IO) {
         deleteTagFromNotes(tag)
         tag.delete()
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
@@ -57,8 +57,8 @@ class SimperiumTagsRepository(
     }
 
     override suspend fun deleteTag(tag: Tag) {
-        tag.delete()
         deleteTagFromNotes(tag)
+        tag.delete()
     }
 
     private fun deleteTagFromNotes(tag: Tag) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/TagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/TagsRepository.kt
@@ -12,4 +12,5 @@ interface TagsRepository {
     fun renameTag(tagName: String, oldTag: Tag): Boolean
     suspend fun allTags(): List<TagItem>
     suspend fun searchTags(query: String): List<TagItem>
+    suspend fun deleteTag(tag: Tag)
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/TagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/TagsRepository.kt
@@ -2,6 +2,7 @@ package com.automattic.simplenote.repositories
 
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.models.TagItem
+import kotlinx.coroutines.flow.Flow
 
 interface TagsRepository {
     fun saveTag(tagName: String): Boolean
@@ -13,4 +14,5 @@ interface TagsRepository {
     suspend fun allTags(): List<TagItem>
     suspend fun searchTags(query: String): List<TagItem>
     suspend fun deleteTag(tag: Tag)
+    suspend fun tagsChanged(): Flow<Boolean>
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/TagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/TagsRepository.kt
@@ -1,6 +1,7 @@
 package com.automattic.simplenote.repositories
 
 import com.automattic.simplenote.models.Tag
+import com.automattic.simplenote.models.TagItem
 
 interface TagsRepository {
     fun saveTag(tagName: String): Boolean
@@ -9,4 +10,6 @@ interface TagsRepository {
     fun isTagConflict(tagName: String, oldTagName: String): Boolean
     fun getCanonicalTagName(tagName: String): String
     fun renameTag(tagName: String, oldTag: Tag): Boolean
+    suspend fun allTags(): List<TagItem>
+    suspend fun searchTags(query: String): List<TagItem>
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagItemAdapter.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagItemAdapter.kt
@@ -1,6 +1,7 @@
 package com.automattic.simplenote.utils
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -10,16 +11,14 @@ import com.automattic.simplenote.models.TagItem
 
 class TagItemAdapter(
         private val onEditClick: (tagItem: TagItem) -> Unit,
-        private val onLongEditClick: (tagItem: TagItem) -> Unit,
         private val onDeleteClick: (tagItem: TagItem) -> Unit,
-        private val onLongDeleteClick: (tagItem: TagItem) -> Unit,
+        private val onLongDeleteClick: (view: View) -> Unit,
 ) : ListAdapter<TagItem, TagItemAdapter.TagItemViewHolder>(DIFF_CALLBACK) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TagItemViewHolder {
         val binding = TagsListRowBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return TagItemViewHolder(
                 binding,
                 onEditClick,
-                onLongEditClick,
                 onDeleteClick,
                 onLongDeleteClick
         )
@@ -33,9 +32,8 @@ class TagItemAdapter(
     class TagItemViewHolder(
             private val binding: TagsListRowBinding,
             private val onEditClick: (tagItem: TagItem) -> Unit,
-            private val onLongEditClick: (tagItem: TagItem) -> Unit,
             private val onDeleteClick: (tagItem: TagItem) -> Unit,
-            private val onLongDeleteClick: (tagItem: TagItem) -> Unit,
+            private val onLongDeleteClick: (view: View) -> Unit,
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(currentTagItem: TagItem) {
             binding.apply {
@@ -45,16 +43,12 @@ class TagItemAdapter(
                     onDeleteClick(currentTagItem)
                 }
                 tagTrash.setOnLongClickListener {
-                    onLongDeleteClick(currentTagItem)
+                    onLongDeleteClick(it)
                     true
                 }
 
                 binding.root.setOnClickListener {
                     onEditClick(currentTagItem)
-                }
-                binding.root.setOnLongClickListener {
-                    onLongEditClick(currentTagItem)
-                    true
                 }
             }
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagItemAdapter.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagItemAdapter.kt
@@ -1,0 +1,76 @@
+package com.automattic.simplenote.utils
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.automattic.simplenote.databinding.TagsListRowBinding
+import com.automattic.simplenote.models.TagItem
+
+class TagItemAdapter(
+        private val onEditClick: (tagItem: TagItem) -> Unit,
+        private val onLongEditClick: (tagItem: TagItem) -> Unit,
+        private val onDeleteClick: (tagItem: TagItem) -> Unit,
+        private val onLongDeleteClick: (tagItem: TagItem) -> Unit,
+) : ListAdapter<TagItem, TagItemAdapter.TagItemViewHolder>(DIFF_CALLBACK) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TagItemViewHolder {
+        val binding = TagsListRowBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return TagItemViewHolder(
+                binding,
+                onEditClick,
+                onLongEditClick,
+                onDeleteClick,
+                onLongDeleteClick
+        )
+    }
+
+    override fun onBindViewHolder(holder: TagItemViewHolder, position: Int) {
+        val currentTagItem = getItem(position)
+        holder.bind(currentTagItem)
+    }
+
+    class TagItemViewHolder(
+            private val binding: TagsListRowBinding,
+            private val onEditClick: (tagItem: TagItem) -> Unit,
+            private val onLongEditClick: (tagItem: TagItem) -> Unit,
+            private val onDeleteClick: (tagItem: TagItem) -> Unit,
+            private val onLongDeleteClick: (tagItem: TagItem) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(currentTagItem: TagItem) {
+            binding.apply {
+                tagName.text = currentTagItem.tag.name
+                tagCount.text = if (currentTagItem.noteCount > 0) currentTagItem.noteCount.toString() else ""
+                tagTrash.setOnClickListener {
+                    onDeleteClick(currentTagItem)
+                }
+                tagTrash.setOnLongClickListener {
+                    onLongDeleteClick(currentTagItem)
+                    true
+                }
+
+                binding.root.setOnClickListener {
+                    onEditClick(currentTagItem)
+                }
+                binding.root.setOnLongClickListener {
+                    onLongEditClick(currentTagItem)
+                    true
+                }
+            }
+        }
+    }
+
+    companion object {
+        val DIFF_CALLBACK = object : DiffUtil.ItemCallback<TagItem>() {
+            override fun areItemsTheSame(oldItem: TagItem, newItem: TagItem): Boolean {
+                return oldItem.tag.simperiumKey == newItem.tag.simperiumKey
+            }
+
+            override fun areContentsTheSame(oldItem: TagItem, newItem: TagItem): Boolean {
+                return oldItem == newItem
+            }
+
+        }
+    }
+
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagUtils.java
@@ -11,6 +11,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 public class TagUtils {
@@ -45,6 +47,29 @@ public class TagUtils {
         if (isTagMissing(bucket, name)) {
             createTag(bucket, name, bucket.count());
         }
+    }
+
+    /**
+     * Find the tags that match the canonical representation of tagSearch
+     *~
+     * @param tags      {@link List<String>} list of tags where tagSearch is going to be matched.
+     * @param tagSearch {@link String} tag to be searched.
+     * @return          {@link List<String>} Sublist of tags that matched tagSearch's canonical
+     *                  representation.
+     */
+    public static List<String> findTagsMatch(List<String> tags, String tagSearch) {
+        List<String> tagsMatched = new ArrayList<>();
+
+        // Get the canonical hash of tag that is searched
+        String tagSearchHash = hashTag(tagSearch);
+        for (String tag : tags) {
+            String tagHash = hashTag(tag);
+            if (tagHash.equals(tagSearchHash)) {
+                tagsMatched.add(tag);
+            }
+        }
+
+        return tagsMatched;
     }
 
     /**

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/TagUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/TagUtils.java
@@ -51,7 +51,7 @@ public class TagUtils {
 
     /**
      * Find the tags that match the canonical representation of tagSearch
-     *~
+     *
      * @param tags      {@link List<String>} list of tags where tagSearch is going to be matched.
      * @param tagSearch {@link String} tag to be searched.
      * @return          {@link List<String>} Sublist of tags that matched tagSearch's canonical

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -22,6 +22,10 @@ class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
         _event.postValue(TagsEvent.LongAddTagEvent)
     }
 
+    fun close() {
+        _event.postValue(TagsEvent.FinishEvent)
+    }
+
     data class UiState(private val tags: List<TagItem>, private val searchQuery: String)
 }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -14,8 +14,12 @@ class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
     private val _event = SingleLiveEvent<TagsEvent>()
     val event: LiveData<TagsEvent> = _event
 
-    fun addTag() {
+    fun clickAddTag() {
         _event.postValue(TagsEvent.AddTagEvent)
+    }
+
+    fun longClickAddTag() {
+        _event.postValue(TagsEvent.LongAddTagEvent)
     }
 
     data class UiState(private val tags: List<TagItem>, private val searchQuery: String)

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -1,0 +1,27 @@
+package com.automattic.simplenote.viewmodels
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.automattic.simplenote.models.Tag
+import com.automattic.simplenote.models.TagItem
+import com.automattic.simplenote.repositories.TagsRepository
+
+class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
+    private val _uiState = MutableLiveData<UiState>()
+    val uiState: LiveData<UiState> = _uiState
+
+    private val _event = SingleLiveEvent<TagsEvent>()
+    val event: LiveData<TagsEvent> = _event
+    
+    data class UiState(private val tags: List<TagItem>, private val searchQuery: String)
+}
+
+sealed class TagsEvent {
+    object AddTagEvent : TagsEvent()
+    object LongAddTagEvent : TagsEvent()
+    object ShowSearch : TagsEvent()
+    object CloseSearch : TagsEvent()
+    object ResultEvent : TagsEvent()
+    data class EditTagEvent(val tag: Tag) : TagsEvent()
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -96,7 +96,7 @@ class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
     }
 
     fun deleteTag(tagItem: TagItem) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             tagsRepository.deleteTag(tagItem.tag)
             AnalyticsTracker.track(
                     AnalyticsTracker.Stat.TAG_MENU_DELETED,

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -3,9 +3,11 @@ package com.automattic.simplenote.viewmodels
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.models.TagItem
 import com.automattic.simplenote.repositories.TagsRepository
+import kotlinx.coroutines.launch
 
 class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
     private val _uiState = MutableLiveData<UiState>()
@@ -13,6 +15,13 @@ class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
 
     private val _event = SingleLiveEvent<TagsEvent>()
     val event: LiveData<TagsEvent> = _event
+
+    fun start() {
+        viewModelScope.launch {
+            val tagItems = tagsRepository.allTags()
+            _uiState.value = UiState(tagItems)
+        }
+    }
 
     fun clickAddTag() {
         _event.postValue(TagsEvent.AddTagEvent)
@@ -26,7 +35,23 @@ class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
         _event.postValue(TagsEvent.FinishEvent)
     }
 
-    data class UiState(private val tags: List<TagItem>, private val searchQuery: String)
+    fun clickEditTag(tagItem: TagItem) {
+
+    }
+
+    fun longClickEditTag(tagItem: TagItem) {
+
+    }
+
+    fun clickDeleteTag(tagItem: TagItem) {
+
+    }
+
+    fun longClickDeleteTag(tagItem: TagItem) {
+
+    }
+
+    data class UiState(val tagItems: List<TagItem>, val searchQuery: String? = null)
 }
 
 sealed class TagsEvent {
@@ -36,5 +61,6 @@ sealed class TagsEvent {
     object CloseSearch : TagsEvent()
     object ResultEvent : TagsEvent()
     object FinishEvent: TagsEvent()
-    data class EditTagEvent(val tag: Tag) : TagsEvent()
+    data class EditTagEvent(val tagItem: TagItem) : TagsEvent()
+    data class DeleteTagEvent(val tagItem: TagItem) : TagsEvent()
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -13,7 +13,11 @@ class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
 
     private val _event = SingleLiveEvent<TagsEvent>()
     val event: LiveData<TagsEvent> = _event
-    
+
+    fun addTag() {
+        _event.postValue(TagsEvent.AddTagEvent)
+    }
+
     data class UiState(private val tags: List<TagItem>, private val searchQuery: String)
 }
 
@@ -23,5 +27,6 @@ sealed class TagsEvent {
     object ShowSearch : TagsEvent()
     object CloseSearch : TagsEvent()
     object ResultEvent : TagsEvent()
+    object FinishEvent: TagsEvent()
     data class EditTagEvent(val tag: Tag) : TagsEvent()
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -68,6 +68,8 @@ class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
     }
 
     fun pause() {
+        // When the job for tagsFlow is cancelled, the awaitClose block is called
+        // This remove the listeners for the tags bucket
         jobTagsFlow?.cancel()
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -1,5 +1,6 @@
 package com.automattic.simplenote.viewmodels
 
+import android.view.View
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -36,18 +37,18 @@ class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
     }
 
     fun clickEditTag(tagItem: TagItem) {
-
-    }
-
-    fun longClickEditTag(tagItem: TagItem) {
-
+        _event.postValue(TagsEvent.EditTagEvent(tagItem))
     }
 
     fun clickDeleteTag(tagItem: TagItem) {
-
+        _event.postValue(TagsEvent.DeleteTagEvent(tagItem))
     }
 
-    fun longClickDeleteTag(tagItem: TagItem) {
+    fun longClickDeleteTag(view: View) {
+        _event.postValue(TagsEvent.LongDeleteTagEvent(view))
+    }
+
+    fun deleteTag(TagItem: TagItem) {
 
     }
 
@@ -63,4 +64,5 @@ sealed class TagsEvent {
     object FinishEvent: TagsEvent()
     data class EditTagEvent(val tagItem: TagItem) : TagsEvent()
     data class DeleteTagEvent(val tagItem: TagItem) : TagsEvent()
+    data class LongDeleteTagEvent(val view: View) : TagsEvent()
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -25,7 +25,7 @@ class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
 
     fun start() {
         viewModelScope.launch {
-            val tagItems = withContext(Dispatchers.IO) { tagsRepository.allTags() }
+            val tagItems = tagsRepository.allTags()
             _uiState.value = UiState(tagItems)
         }
 
@@ -38,10 +38,9 @@ class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
     }
 
     private suspend fun updateUiState(searchQuery: String?, searchUpdate: Boolean = false) {
-        val tagItems = withContext(Dispatchers.IO) {
-            if (searchQuery == null) tagsRepository.allTags()
+        val tagItems = if (searchQuery == null) tagsRepository.allTags()
             else tagsRepository.searchTags(searchQuery)
-        }
+
         _uiState.value = UiState(tagItems, searchUpdate, searchQuery)
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/ViewModelFactory.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/ViewModelFactory.kt
@@ -27,6 +27,8 @@ class ViewModelFactory constructor(
                 AddTagViewModel(SimperiumTagsRepository(tagsBucket, notesBucket))
             isAssignableFrom(TagDialogViewModel::class.java) ->
                 TagDialogViewModel(SimperiumTagsRepository(tagsBucket, notesBucket))
+            isAssignableFrom(TagsViewModel::class.java) ->
+                TagsViewModel(SimperiumTagsRepository(tagsBucket, notesBucket))
             else ->
                 throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
         }

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
@@ -112,10 +112,6 @@ class TagsViewModelTest {
         }
         viewModel.search(searchQuery)
 
-        // Flay tests regarding runBlockingTest. I will include this sleep here for now
-        // while we find the bug in runBlockingTest
-        Thread.sleep(500)
-
         assertEquals(viewModel.uiState.value?.tagItems, filteredList)
         assertEquals(viewModel.uiState.value?.searchUpdate, true)
         assertEquals(viewModel.uiState.value?.searchQuery, "tag2")
@@ -182,10 +178,6 @@ class TagsViewModelTest {
         }
         viewModel.updateOnResult()
 
-        // Flay tests regarding runBlockingTest. I will include this sleep here for now
-        // while we find the bug in runBlockingTest
-        Thread.sleep(500)
-
         assertEquals(viewModel.uiState.value?.tagItems, updatedTags)
         assertEquals(viewModel.uiState.value?.searchUpdate, false)
         assertNull(viewModel.uiState.value?.searchQuery)
@@ -220,10 +212,6 @@ class TagsViewModelTest {
             onBlocking { allTags() }.doReturn(updatedTags)
         }
         viewModel.updateOnResult()
-
-        // Flay tests regarding runBlockingTest. I will include this sleep here for now
-        // while we find the bug in runBlockingTest
-        Thread.sleep(500)
 
         assertEquals(viewModel.uiState.value?.tagItems, updatedTags)
         assertEquals(viewModel.uiState.value?.searchUpdate, false)

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
@@ -1,0 +1,34 @@
+package com.automattic.simplenote.viewmodels
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.automattic.simplenote.models.Tag
+import com.automattic.simplenote.models.TagItem
+import com.automattic.simplenote.repositories.TagsRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Rule
+import org.mockito.Mockito.mock
+
+
+@ExperimentalCoroutinesApi
+class TagsViewModelTest {
+    @get:Rule val rule = InstantTaskExecutorRule()
+
+    private lateinit var viewModel: TagsViewModel
+    private val fakeTagsRepository = mock(TagsRepository::class.java)
+    private val tagItems = mutableListOf<TagItem>()
+
+    @Before
+    fun setup() {
+        viewModel = TagsViewModel(fakeTagsRepository)
+    }
+
+    @Before
+    fun setupTags() {
+        tagItems.add(TagItem(Tag("tag1"), 0))
+        tagItems.add(TagItem(Tag("tag2"), 2))
+        tagItems.add(TagItem(Tag("tag3"), 5))
+        tagItems.add(TagItem(Tag("tag4"), 10))
+        tagItems.add(TagItem(Tag("tag5"), 0))
+    }
+}

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
@@ -1,11 +1,13 @@
 package com.automattic.simplenote.viewmodels
 
+import android.view.View
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.models.TagItem
 import com.automattic.simplenote.repositories.TagsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -13,7 +15,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
 
 
@@ -88,6 +92,129 @@ class TagsViewModelTest {
 
         assertEquals(viewModel.uiState.value?.tagItems, tagItems)
         assertEquals(viewModel.uiState.value?.searchUpdate, true)
+        assertNull(viewModel.uiState.value?.searchQuery)
+    }
+
+    @Test
+    fun searchShouldFilterTags() = runBlockingTest {
+        fakeTagsRepository.stub {
+            onBlocking { allTags() }.doReturn(tagItems)
+        }
+        fakeTagsRepository.stub {
+            onBlocking { tagsChanged() }.doReturn(emptyFlow())
+        }
+        viewModel.start()
+
+        val filteredList = listOf(tagItems[1])
+        val searchQuery = "tag2"
+        fakeTagsRepository.stub {
+            onBlocking { searchTags(any()) }.doReturn(filteredList)
+        }
+        viewModel.search(searchQuery)
+
+        assertEquals(viewModel.uiState.value?.tagItems, filteredList)
+        assertEquals(viewModel.uiState.value?.searchUpdate, true)
+        assertEquals(viewModel.uiState.value?.searchQuery, "tag2")
+    }
+
+    @Test
+    fun afterAddingATagUpdateOnResultShouldUpdateUiState() = runBlockingTest {
+        fakeTagsRepository.stub {
+            onBlocking { allTags() }.doReturn(tagItems)
+        }
+        fakeTagsRepository.stub {
+            onBlocking { tagsChanged() }.doReturn(emptyFlow())
+        }
+        viewModel.start()
+
+        // Add a new tag
+        tagItems.add(TagItem(Tag("tag10"), 2))
+
+        fakeTagsRepository.stub {
+            onBlocking { allTags() }.doReturn(tagItems)
+        }
+
+        viewModel.updateOnResult()
+
+        assertEquals(viewModel.uiState.value?.tagItems, tagItems)
+        assertEquals(viewModel.uiState.value?.searchUpdate, false)
+        assertNull(viewModel.uiState.value?.searchQuery)
+    }
+
+    @Test
+    fun clickEditTagShouldTriggerEventEditTagEvent() {
+
+        viewModel.clickEditTag(tagItems[0])
+
+        assertEquals(viewModel.event.value, TagsEvent.EditTagEvent(tagItems[0]))
+    }
+
+    @Test
+    fun clickDeleteTagOfTagWithNotesShouldTriggerDeleteTagEvent() {
+        viewModel.clickDeleteTag(tagItems[1])
+
+        assertEquals(viewModel.event.value, TagsEvent.DeleteTagEvent(tagItems[1]))
+    }
+
+    @Test
+    fun clickDeleteTagOfTagWithNotesShouldDeleteTagDirectly() = runBlockingTest {
+        fakeTagsRepository.stub {
+            onBlocking { deleteTag(any()) }.doReturn(Unit)
+        }
+
+        fakeTagsRepository.stub {
+            onBlocking { tagsChanged() }.doReturn(flow{ emit(true) })
+        }
+
+        val updatedTags = tagItems.filter { tagItem -> tagItem.tag.name != "tag2" }
+        fakeTagsRepository.stub {
+            onBlocking { allTags() }.doReturn(updatedTags)
+        }
+
+        viewModel.clickDeleteTag(tagItems[1])
+
+        fakeTagsRepository.stub {
+            onBlocking { allTags() }.doReturn(updatedTags)
+        }
+        viewModel.updateOnResult()
+
+        assertEquals(viewModel.uiState.value?.tagItems, updatedTags)
+        assertEquals(viewModel.uiState.value?.searchUpdate, false)
+        assertNull(viewModel.uiState.value?.searchQuery)
+    }
+
+    @Test
+    fun longClickDeleteTagShouldTriggerLongDeleteTagEvent() {
+        val view = mock<View>()
+        viewModel.longClickDeleteTag(view)
+
+        assertEquals(viewModel.event.value, TagsEvent.LongDeleteTagEvent(view))
+    }
+
+    @Test
+    fun deleteTagUpdatesListOfTags() {
+        fakeTagsRepository.stub {
+            onBlocking { deleteTag(any()) }.doReturn(Unit)
+        }
+
+        fakeTagsRepository.stub {
+            onBlocking { tagsChanged() }.doReturn(flow{ emit(true) })
+        }
+
+        val updatedTags = tagItems.filter { tagItem -> tagItem.tag.name != "tag3" }
+        fakeTagsRepository.stub {
+            onBlocking { allTags() }.doReturn(updatedTags)
+        }
+
+        viewModel.deleteTag(tagItems[2])
+
+        fakeTagsRepository.stub {
+            onBlocking { allTags() }.doReturn(updatedTags)
+        }
+        viewModel.updateOnResult()
+
+        assertEquals(viewModel.uiState.value?.tagItems, updatedTags)
+        assertEquals(viewModel.uiState.value?.searchUpdate, false)
         assertNull(viewModel.uiState.value?.searchQuery)
     }
 }

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
@@ -112,6 +112,10 @@ class TagsViewModelTest {
         }
         viewModel.search(searchQuery)
 
+        // Flay tests regarding runBlockingTest. I will include this sleep here for now
+        // while we find the bug in runBlockingTest
+        Thread.sleep(500)
+
         assertEquals(viewModel.uiState.value?.tagItems, filteredList)
         assertEquals(viewModel.uiState.value?.searchUpdate, true)
         assertEquals(viewModel.uiState.value?.searchQuery, "tag2")
@@ -178,6 +182,10 @@ class TagsViewModelTest {
         }
         viewModel.updateOnResult()
 
+        // Flay tests regarding runBlockingTest. I will include this sleep here for now
+        // while we find the bug in runBlockingTest
+        Thread.sleep(500)
+
         assertEquals(viewModel.uiState.value?.tagItems, updatedTags)
         assertEquals(viewModel.uiState.value?.searchUpdate, false)
         assertNull(viewModel.uiState.value?.searchQuery)
@@ -212,6 +220,10 @@ class TagsViewModelTest {
             onBlocking { allTags() }.doReturn(updatedTags)
         }
         viewModel.updateOnResult()
+
+        // Flay tests regarding runBlockingTest. I will include this sleep here for now
+        // while we find the bug in runBlockingTest
+        Thread.sleep(500)
 
         assertEquals(viewModel.uiState.value?.tagItems, updatedTags)
         assertEquals(viewModel.uiState.value?.searchUpdate, false)

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
@@ -155,7 +155,7 @@ class TagsViewModelTest {
     }
 
     @Test
-    fun clickDeleteTagOfTagWithNotesShouldDeleteTagDirectly() = runBlockingTest {
+    fun clickDeleteTagOfTagWithoutNotesShouldDeleteTagDirectly() = runBlockingTest {
         fakeTagsRepository.stub {
             onBlocking { deleteTag(any()) }.doReturn(Unit)
         }
@@ -164,12 +164,12 @@ class TagsViewModelTest {
             onBlocking { tagsChanged() }.doReturn(flow{ emit(true) })
         }
 
-        val updatedTags = tagItems.filter { tagItem -> tagItem.tag.name != "tag2" }
+        val updatedTags = tagItems.filter { tagItem -> tagItem.tag.name != "tag1" }
         fakeTagsRepository.stub {
             onBlocking { allTags() }.doReturn(updatedTags)
         }
 
-        viewModel.clickDeleteTag(tagItems[1])
+        viewModel.clickDeleteTag(tagItems[0])
 
         fakeTagsRepository.stub {
             onBlocking { allTags() }.doReturn(updatedTags)

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
@@ -74,4 +74,20 @@ class TagsViewModelTest {
 
         assertEquals(viewModel.event.value, TagsEvent.FinishEvent)
     }
+
+    @Test
+    fun closeSearchShouldCleanQuery() = runBlockingTest {
+        fakeTagsRepository.stub {
+            onBlocking { allTags() }.doReturn(tagItems)
+        }
+        fakeTagsRepository.stub {
+            onBlocking { tagsChanged() }.doReturn(emptyFlow())
+        }
+        viewModel.start()
+        viewModel.closeSearch()
+
+        assertEquals(viewModel.uiState.value?.tagItems, tagItems)
+        assertEquals(viewModel.uiState.value?.searchUpdate, true)
+        assertNull(viewModel.uiState.value?.searchQuery)
+    }
 }


### PR DESCRIPTION
Fixes #1371

### Fix
This PR restructure the code of `TagsActivity` to use ViewModels (`TagsViewModel`)  in order to decouple data management logic from the view. 

### Test

#### Automatic Tests
1. Run `TagsActivityTest` inside `androidTest`. It requires to run an on emulator or physical device. 
2. Run `TagsViewModelTest` inside `test`

#### Manual Tests
1. Open Simplenote app
2. Tab on left menu
3. Tab on EDIT tags
4. Try deleting tags without and with notes. It should update the list
5. Try tab on tags to open a dialog to update the tag
6. Try tab on + button to add new tags
7. Try searching tags

### Review
This PR will be reviewed by @ParaskP7 .

### Release
These changes do not require release notes.
