### PR TITLE
Check translation progress during final release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
     colored2 (3.1.2)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     declarative (0.0.20)
     declarative-option (0.1.0)
     diffy (3.4.0)
@@ -103,7 +103,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (1.0.1)
+    fastlane-plugin-wpmreleasetoolkit (1.2.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -260,7 +260,7 @@ PLATFORMS
 DEPENDENCIES
   bigdecimal (~> 1.4)
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 1.0)
+  fastlane-plugin-wpmreleasetoolkit (~> 1.2)
   nokogiri
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (1.2.0)
+    fastlane-plugin-wpmreleasetoolkit (1.3.1)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -117,7 +117,7 @@ GEM
       rake (~> 12.3)
       rake-compiler (~> 1.0)
     gh_inspector (1.1.3)
-    git (1.8.1)
+    git (1.9.1)
       rchardet (~> 1.8)
     google-api-client (0.38.0)
       addressable (~> 2.5, >= 2.5.1)
@@ -189,7 +189,7 @@ GEM
     octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.11.5)
+    oj (3.12.0)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)
@@ -260,7 +260,7 @@ PLATFORMS
 DEPENDENCIES
   bigdecimal (~> 1.4)
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 1.2)
+  fastlane-plugin-wpmreleasetoolkit (~> 1.3.1)
   nokogiri
 
 BUNDLED WITH

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -179,10 +179,18 @@ SUPPORTED_LOCALES = [
   lane :finalize_release do | options |
     android_finalize_prechecks(options)
     configure_apply(force: is_ci)
+
     hotfix = android_current_branch_is_hotfix
-    android_update_metadata(options) unless hotfix
-    android_bump_version_final_release() unless hotfix
-    version = android_get_release_version() unless hotfix
+    unless hotfix 
+      check_translation_progress(
+        glotpress_url: 'https://translate.wordpress.com/projects/simplenote/android/',
+        abort_on_violations: false
+      )
+      android_update_metadata(options) 
+      android_bump_version_final_release() 
+    end
+
+    version = android_get_release_version() 
     download_metadata_strings(version: version["name"], build_number: version["code"]) unless hotfix
     android_tag_build(tag_alpha: false)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -182,10 +182,18 @@ SUPPORTED_LOCALES = [
 
     hotfix = android_current_branch_is_hotfix
     unless hotfix 
+      UI.message('Checking app strings translation status...')
       check_translation_progress(
         glotpress_url: 'https://translate.wordpress.com/projects/simplenote/android/',
         abort_on_violations: false
       )
+
+      UI.message("Checking release notes strings translation status...")
+      check_translation_progress(
+        glotpress_url: 'https://translate.wordpress.com/projects/simplenote/android/release-notes/',
+        abort_on_violations: false
+      )
+
       android_update_metadata(options) 
       android_bump_version_final_release() 
     end

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.2'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.3.1'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.2'


### PR DESCRIPTION
This PR adds a step to the `finalize_release` lane to check the current state of the translation.
If some of the languages which are expected to be fully translated at release time are below 100%, the lane outputs the current state of the translation and asks confirmation to the user before continuing.

```
### Example:

[15:53:43]: ----------------------------------------
[15:53:43]: --- Step: check_translation_progress ---
[15:53:43]: ----------------------------------------
[15:53:43]: Checking translations status...
[15:53:44]: > Getting translation status for ar
[15:53:44]: Language ar is 99% translated.
[15:53:44]: > Getting translation status for de
[15:53:44]: Language de is 97% translated.
[15:53:44]: > Getting translation status for es
[15:53:44]: Language es is 100% translated.
[15:53:44]: > Getting translation status for fr
[15:53:44]: Language fr is 96% translated.
[15:53:44]: > Getting translation status for he
[15:53:44]: Language he is 97% translated.
[15:53:44]: > Getting translation status for id
[15:53:44]: Language id is 96% translated.
[15:53:44]: > Getting translation status for it
[15:53:44]: Language it is 97% translated.
[15:53:44]: > Getting translation status for ja
[15:53:44]: Language ja is 99% translated.
[15:53:44]: > Getting translation status for ko
[15:53:44]: Language ko is 97% translated.
[15:53:44]: > Getting translation status for nl
[15:53:44]: Language nl is 100% translated.
[15:53:44]: > Getting translation status for pt-br
[15:53:44]: Language pt-br is 98% translated.
[15:53:44]: > Getting translation status for ru
[15:53:44]: Language ru is 100% translated.
[15:53:44]: > Getting translation status for sv
[15:53:44]: Language sv is 100% translated.
[15:53:44]: > Getting translation status for tr
[15:53:44]: Language tr is 99% translated.
[15:53:44]: > Getting translation status for zh-cn
[15:53:44]: Language zh-cn is 100% translated.
[15:53:44]: > Getting translation status for zh-tw
[15:53:44]: Language zh-tw is 97% translated.
[15:53:44]: The translations for the following languages are below the 100% threshold:
 - ar is at 99%.
 - de is at 97%.
 - fr is at 96%.
 - he is at 97%.
 - id is at 96%.
 - it is at 97%.
 - ja is at 99%.
 - ko is at 97%.
 - pt-br is at 98%.
 - tr is at 99%.
 - zh-tw is at 97%.
Do you want to continue? (y/n)
```

bundle exec fastlane run check_translation_progress glotpress_url:'https://translate.wordpress.com/projects/simplenote/android/' abort_on_violations:false and it's been tested when introduced in the release-toolkit.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
