### PR TITLE
Remove a duplicate buildscript section in wear's build.gradle

### DIFF
--- a/Wear/build.gradle
+++ b/Wear/build.gradle
@@ -27,13 +27,6 @@ android {
     }
 }
 
-buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
-}
-
 dependencies {
     compileOnly 'androidx.wear:wear:1.0.0'
 


### PR DESCRIPTION
In b25d4030 the buildscript {} section was duplicated, probably by mistake.

### Fix
Remove a duplicate section in wear's `build.gradle`

### Test
Nothing to test

### Review

Please run the CI to ensure that nothing breaks.


### Release

These changes do not require release notes.
