### PR TITLE
Fix list of searched tags after leaving and entering the app

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -121,6 +121,9 @@ dependencies {
     // Support for ViewModels and LiveData
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.1'
+    // Support for androidx Fragments
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1"
+
     // Google Play Services
     implementation 'com.google.android.gms:play-services-wearable:17.0.0'
     // Third Party

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -1,6 +1,7 @@
 package com.automattic.simplenote.integration
 
 import android.widget.EditText
+import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
@@ -17,6 +18,7 @@ import com.automattic.simplenote.TagsActivity
 import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.utils.isToast
+import com.automattic.simplenote.utils.withItemCount
 import com.automattic.simplenote.utils.withRecyclerView
 import org.hamcrest.CoreMatchers
 import org.junit.Assert.assertEquals
@@ -26,6 +28,8 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4ClassRunner::class)
 @MediumTest
 class TagsActivityTest : BaseUITest() {
+    private lateinit var activityScenario: ActivityScenario<TagsActivity>
+
     @Test
     fun listTagsShouldShowCompleteListTags() {
         val testData = launchTagsActivityWithTestData()
@@ -52,23 +56,70 @@ class TagsActivityTest : BaseUITest() {
         onView(isAssignableFrom(EditText::class.java)).perform(typeText(firstSearchPhrase))
 
         // All tags starting with tag should be shown
-        testData.tags.filter { it.tag.name.startsWith(firstSearchPhrase) }.forEachIndexed { index, tagAndCounter ->
+        val filteredTagsFirstPhrase = testData.tags.filter { it.tag.name.startsWith(firstSearchPhrase) }
+        filteredTagsFirstPhrase.forEachIndexed { index, tagAndCounter ->
             onView(withRecyclerView(R.id.list).atPositionOnView(index, R.id.tag_name))
-                    .check(matches(withText(tagAndCounter.tag.name)))
+                .check(matches(withText(tagAndCounter.tag.name)))
             onView(withRecyclerView(R.id.list).atPositionOnView(index, R.id.tag_count))
-                    .check(matches(withText(tagAndCounter.counter)))
+                .check(matches(withText(tagAndCounter.counter)))
         }
+
+        onView(withId(R.id.list)).check(withItemCount(filteredTagsFirstPhrase.count()))
 
         // Type in the second search phrase
         onView(isAssignableFrom(EditText::class.java)).perform(replaceText(secondSearchPhrase))
 
         // Jus the tag other should be shown
-        testData.tags.filter { it.tag.name.startsWith(secondSearchPhrase) }.forEachIndexed { index, tagAndCounter ->
+        val filteredTagsSecondPhrase = testData.tags.filter { it.tag.name.startsWith(secondSearchPhrase) }
+        filteredTagsSecondPhrase.forEachIndexed { index, tagAndCounter ->
             onView(withRecyclerView(R.id.list).atPositionOnView(index, R.id.tag_name))
-                    .check(matches(withText(tagAndCounter.tag.name)))
+                .check(matches(withText(tagAndCounter.tag.name)))
             onView(withRecyclerView(R.id.list).atPositionOnView(index, R.id.tag_count))
-                    .check(matches(withText(tagAndCounter.counter)))
+                .check(matches(withText(tagAndCounter.counter)))
         }
+
+        onView(withId(R.id.list)).check(withItemCount(filteredTagsSecondPhrase.count()))
+    }
+
+    @Test
+    fun searchTagsShouldKeepFilteredListAtReenter() {
+        val testData = launchTagsActivityWithTestData()
+
+        val firstSearchPhrase = "tag"
+
+        // Activate search bar
+        onView(withId(R.id.menu_search)).perform(click())
+
+        // Type in the first search phrase
+        onView(isAssignableFrom(EditText::class.java)).perform(typeText(firstSearchPhrase))
+
+        // All tags starting with tag should be shown
+        val filteredTags = testData.tags.filter { it.tag.name.startsWith(firstSearchPhrase) }
+        filteredTags.forEachIndexed { index, tagAndCounter ->
+            onView(withRecyclerView(R.id.list).atPositionOnView(index, R.id.tag_name))
+                .check(matches(withText(tagAndCounter.tag.name)))
+            onView(withRecyclerView(R.id.list).atPositionOnView(index, R.id.tag_count))
+                .check(matches(withText(tagAndCounter.counter)))
+        }
+
+        onView(withId(R.id.list)).check(withItemCount(filteredTags.count()))
+
+
+        // Change the state of the activity to CREATED which calls onPause and onStop
+        activityScenario.moveToState(Lifecycle.State.CREATED)
+
+        // Change the state of the activity to RESUMED
+        activityScenario.moveToState(Lifecycle.State.RESUMED)
+
+        // All tags starting with tag should be shown when activity becomes RESUMED again
+        filteredTags.forEachIndexed { index, tagAndCounter ->
+            onView(withRecyclerView(R.id.list).atPositionOnView(index, R.id.tag_name))
+                .check(matches(withText(tagAndCounter.tag.name)))
+            onView(withRecyclerView(R.id.list).atPositionOnView(index, R.id.tag_count))
+                .check(matches(withText(tagAndCounter.counter)))
+        }
+
+        onView(withId(R.id.list)).check(withItemCount(filteredTags.count()))
     }
 
     @Test
@@ -215,7 +266,7 @@ class TagsActivityTest : BaseUITest() {
         assertEquals(tagsBucket.count(), 4)
         assertEquals(notesBucket.count(), 3)
 
-        ActivityScenario.launch(TagsActivity::class.java)
+        activityScenario = ActivityScenario.launch(TagsActivity::class.java)
 
         return TestData(tags, notes)
     }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagsActivityTest.kt
@@ -145,7 +145,7 @@ class TagsActivityTest : BaseUITest() {
         launchTagsActivityWithTestData()
 
         onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_name))
-                .perform(click())
+            .perform(click())
 
         val renameTagTitle = getResourceString(R.string.rename_tag)
         onView(withText(renameTagTitle)).check(matches(isDisplayed()))
@@ -158,9 +158,9 @@ class TagsActivityTest : BaseUITest() {
         // Check data is displayed
         testData.tags.forEachIndexed { index, tagAndCounter ->
             onView(withRecyclerView(R.id.list).atPositionOnView(index, R.id.tag_name))
-                    .check(matches(withText(tagAndCounter.tag.name)))
+                .check(matches(withText(tagAndCounter.tag.name)))
             onView(withRecyclerView(R.id.list).atPositionOnView(index, R.id.tag_count))
-                    .check(matches(withText(tagAndCounter.counter)))
+                .check(matches(withText(tagAndCounter.counter)))
         }
 
         // Delete tag other
@@ -168,7 +168,7 @@ class TagsActivityTest : BaseUITest() {
         testData.tags.forEachIndexed { index, tagAndCounter ->
             if (tagAndCounter.tag.name == tagToDelete) {
                 onView(withRecyclerView(R.id.list).atPositionOnView(index, R.id.tag_trash))
-                        .perform(click())
+                    .perform(click())
             }
         }
 
@@ -185,7 +185,7 @@ class TagsActivityTest : BaseUITest() {
         testData.tags.forEachIndexed { index, tagAndCounter ->
             if (tagAndCounter.tag.name == tagToDelete) {
                 onView(withRecyclerView(R.id.list).atPositionOnView(index, R.id.tag_trash))
-                        .perform(click())
+                    .perform(click())
 
 
                 onView(withText(deleteTagTitle)).check(matches(isDisplayed()))
@@ -205,7 +205,7 @@ class TagsActivityTest : BaseUITest() {
         testData.tags.forEachIndexed { index, tagAndCounter ->
             if (tagAndCounter.tag.name == tagToDelete) {
                 onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.tag_trash))
-                        .perform(click())
+                    .perform(click())
 
                 onView(withText(deleteTagTitle)).check(matches(isDisplayed()))
                 onView(withText(confirmDeleteTagMessage)).check(matches(isDisplayed()))
@@ -236,16 +236,16 @@ class TagsActivityTest : BaseUITest() {
 
         ActivityScenario.launch(TagsActivity::class.java)
 
-        onView(withId(R.id.list)).
-            perform(scrollToPosition<RecyclerView.ViewHolder>(49))
+        onView(withId(R.id.list))
+            .perform(scrollToPosition<RecyclerView.ViewHolder>(49))
 
         onView(withRecyclerView(R.id.list).atPositionOnView(49, R.id.tag_name))
-                .perform(click())
+            .perform(click())
 
         val renameTagTitle = getResourceString(R.string.rename_tag)
         onView(withText(renameTagTitle)).check(matches(isDisplayed()))
         onView(CoreMatchers.allOf(withText("tag50"), isDescendantOfA(withId(R.id.input_tag_name))))
-                .check(matches(isDisplayed()))
+            .check(matches(isDisplayed()))
 
         assertEquals(tagsBucket.count(), 50)
     }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/EspressoUtils.kt
@@ -4,8 +4,12 @@ import android.content.res.Resources
 import android.view.View
 import android.view.WindowManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.Root
+import androidx.test.espresso.ViewAssertion
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import com.google.android.material.textfield.TextInputLayout
+import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
@@ -99,4 +103,23 @@ fun isToast(): Matcher<Root> {
 
         }
     }
+}
+
+class RecyclerViewItemCountAssertion(private val matcher: Matcher<Int>) : ViewAssertion {
+    override fun check(view: View?, noViewFoundException: NoMatchingViewException?) {
+        if (noViewFoundException != null) {
+            throw noViewFoundException
+        }
+        val recyclerView = view as RecyclerView
+        val adapter = recyclerView.adapter
+        assertThat(adapter!!.itemCount, matcher)
+    }
+}
+
+fun withItemCount(expectedCount: Int): RecyclerViewItemCountAssertion {
+    return withItemCount(`is`(expectedCount))
+}
+
+fun withItemCount(matcher: Matcher<Int>): RecyclerViewItemCountAssertion {
+    return RecyclerViewItemCountAssertion(matcher)
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -90,6 +90,8 @@ public class TagsActivity extends ThemedAppCompatActivity {
         setupViews();
 
         setObservers();
+
+        viewModel.start();
     }
 
     private void setupViews() {
@@ -258,14 +260,14 @@ public class TagsActivity extends ThemedAppCompatActivity {
         super.onResume();
         disableScreenshotsIfLocked(this);
 
-        viewModel.start();
+        viewModel.startListeningTagChanges();
     }
 
     @Override
     public void onPause() {
         super.onPause();
 
-        viewModel.pause();
+        viewModel.stopListeningTagChanges();
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -28,7 +28,9 @@ class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
             val tagItems = tagsRepository.allTags()
             _uiState.value = UiState(tagItems)
         }
+    }
 
+    fun startListeningTagChanges() {
         jobTagsFlow = viewModelScope.launch {
             tagsRepository.tagsChanged().collect {
                 val searchQuery = _uiState.value?.searchQuery
@@ -66,7 +68,7 @@ class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
         }
     }
 
-    fun pause() {
+    fun stopListeningTagChanges() {
         // When the job for tagsFlow is cancelled, the awaitClose block is called
         // This remove the listeners for the tags bucket
         jobTagsFlow?.cancel()

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
@@ -70,6 +70,7 @@ class TagsViewModelTest {
         }
 
         viewModel.start()
+        viewModel.startListeningTagChanges()
 
         assertEquals(viewModel.uiState.value?.tagItems, tagItems)
         assertEquals(viewModel.uiState.value?.searchUpdate, false)
@@ -100,12 +101,13 @@ class TagsViewModelTest {
         }
 
         viewModel.start()
+        viewModel.startListeningTagChanges()
 
         assertEquals(viewModel.uiState.value?.tagItems, tagItems)
         assertEquals(viewModel.uiState.value?.searchUpdate, false)
         assertNull(viewModel.uiState.value?.searchQuery)
 
-        viewModel.pause()
+        viewModel.stopListeningTagChanges()
 
         variableTagItems.add(TagItem(Tag("tag6"), 3))
         fakeTagsRepository.stub {


### PR DESCRIPTION
Fixes #1413 

### Fix

The previous implementation of the method `start()` setup the initial `UiState` with all tags and empty search terms. It also starts listening to tag changes from the tag's bucket. The `start()` method was called in `onResume`, thus if the user leaves the app and comes back (the activity is restarted), the `start()` method was called every time, cleaning the `UiState` to its initial state. This created a problem when the user searched tags and left the app and come back because the search term stayed in the search bar but showed the complete list of tags (the expected behavior is to show the filtered list of tags).

This PR separates the setup of the initial `UiState` (method `start()`) and start listening to tag changes (method `startListeningTagChanges()`). The method `start()` is now called in the `onCreate()` callback to avoid cleaning the `UiState `when the user returns an activity (activity is restarted).

### Test

1. Open the menu
2. Tap on Edit (Tags)
3. Tap on the Search icon (lens icon)
4. Introduce a search term that filters the list of tags
5. Tap on the home button
6. Enter Simplenote again
7. The list of search tags should be filtered

### Review

This PR will be reviewed by @ParaskP7

### Release
These changes do not require release notes.

