### PR TITLE
Fixed NPE when try to search after scrolling a note

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.19
 -----
 * Added support to import notes [https://github.com/Automattic/simplenote-android/pull/1333]
+* Fixed crash when searching notes in tablets [https://github.com/Automattic/simplenote-android/pull/1425]
 
 2.18
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -577,6 +577,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
                         new View.OnScrollChangeListener() {
                             @Override
                             public void onScrollChange(View v, int scrollX, int scrollY, int oldScrollX, int oldScrollY) {
+                                if (mNote == null) {
+                                    return;
+                                }
                                 mPreferences.edit().putInt(mNote.getSimperiumKey(), scrollY).apply();
                             }
                         }


### PR DESCRIPTION
Fixes #1424

### Fix
When a user tries to scroll and then tab on the search button, the note reference in NoteEditorFragment can become `null`. In these cases, we just add a check to void updating the scroll preference for a note. This avoids a crash.

| Before Fix      |
| ----------- |
| ![20210727_160259](https://user-images.githubusercontent.com/195721/127227271-a180255b-a49e-44aa-b915-a573cd985859.gif)    |

| After Fix      |
| ----------- |
| ![20210727_183055](https://user-images.githubusercontent.com/195721/127240680-c6f4811b-ad94-47c4-94bf-b015cb61a336.gif) |

### Test

1. Go to landscape mode on the table
2. Tap on one of your notes. Be careful to select a long note which can be scrolled down
3. Tap to scroll down and before it finishes scrolling down, tap on the search button (top right corner)

### Review

Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in a04c473af79efd40920083990fb46d52d78cd5ae with:
> Fixed crash when searching notes in tablets

