### PR TITLE
Added Dagger/Hilt for Dependency Injection in Tag related screens and surrounding code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,15 @@ orbs:
 version: 2.1
 jobs:
   Test:
-    executor: 
+    executor:
       name: android/default
       api-version: "29"
     steps:
       - checkout
       - android/restore-gradle-cache
+      - run:
+          name: Configure gradle
+          command: echo $'\norg.gradle.jvmargs=-Xmx3072m -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false' >> gradle.properties
       - run:
           name: Build
           command: ./gradlew --stacktrace assembleDebug assembleRelease
@@ -20,7 +23,7 @@ jobs:
       - android/save-gradle-cache
       - android/save-test-results
   Lint:
-    executor: 
+    executor:
       name: android/default
       api-version: "29"
     steps:

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -38,7 +38,6 @@ android {
         versionCode 138
         minSdkVersion 23
         targetSdkVersion 29
-        multiDexEnabled true
 
         testInstrumentationRunner 'com.automattic.simplenote.SimplenoteAppRunner'
     }

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -38,6 +38,7 @@ android {
         versionCode 138
         minSdkVersion 23
         targetSdkVersion 29
+        multiDexEnabled true
 
         testInstrumentationRunner 'com.automattic.simplenote.SimplenoteAppRunner'
     }
@@ -120,6 +121,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
     implementation 'androidx.work:work-runtime:2.4.0'
     implementation 'androidx.concurrent:concurrent-futures:1.1.0'
+    implementation "androidx.multidex:multidex:2.0.1"
     // Support for ViewModels and LiveData
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.1'
@@ -135,6 +137,7 @@ dependencies {
 
     // Dagger Hilt dependencies
     implementation 'com.google.dagger:hilt-android:2.38'
+    annotationProcessor 'com.google.dagger:hilt-compiler:2.38'
     kapt 'com.google.dagger:hilt-compiler:2.38'
 
     wearApp project(':Wear')

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -96,7 +96,6 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Infrastructure to test fragments
-    debugImplementation "androidx.fragment:fragment-testing:1.3.3"
     testImplementation "androidx.arch.core:core-testing:2.1.0"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.3"
     testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -137,8 +137,8 @@ dependencies {
 
     // Dagger Hilt dependencies
     implementation 'com.google.dagger:hilt-android:2.38'
-    annotationProcessor 'com.google.dagger:hilt-compiler:2.38'
-    kapt 'com.google.dagger:hilt-compiler:2.38'
+    annotationProcessor 'com.google.dagger:hilt-compiler:2.38.1'
+    kapt 'com.google.dagger:hilt-compiler:2.38.1'
 
     wearApp project(':Wear')
 }

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.application'
 apply plugin: 'io.sentry.android.gradle'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
+apply plugin: 'dagger.hilt.android.plugin'
 
 android {
     buildToolsVersion '29.0.2'
@@ -130,6 +132,11 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.12.0'
     implementation 'com.commonsware.cwac:anddown:0.4.0'
     implementation 'net.openid:appauth:0.7.0'
+
+    // Dagger Hilt dependencies
+    implementation 'com.google.dagger:hilt-android:2.38'
+    kapt 'com.google.dagger:hilt-compiler:2.38'
+
     wearApp project(':Wear')
 }
 

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/integration/TagDialogFragmentTest.kt
@@ -1,6 +1,6 @@
 package com.automattic.simplenote.integration
 
-import androidx.fragment.app.testing.launchFragment
+import androidx.fragment.app.DialogFragment
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
@@ -14,6 +14,7 @@ import com.automattic.simplenote.R
 import com.automattic.simplenote.TagDialogFragment
 import com.automattic.simplenote.utils.TagUtils
 import com.automattic.simplenote.utils.hasTextInputLayoutErrorText
+import com.automattic.simplenote.utils.launchDialogFragmentInHiltContainer
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.not
 import org.junit.Assert.*
@@ -388,20 +389,15 @@ class TagDialogFragmentTest : BaseUITest() {
     }
 
     private fun launchFragment(tagName: String) {
-        val scenario = launchFragment(null, R.style.Base_Theme_Simplestyle) {
-            val tag = getTag(tagName)
-            TagDialogFragment(
-                    tag,
-                    notesBucket,
-                    tagsBucket
-            )
+        val activityScenario = launchDialogFragmentInHiltContainer(R.style.Base_Theme_Simplestyle) {
+            TagDialogFragment(getTag(tagName))
         }
 
-        // Validates the dialog is shown
-        scenario.onFragment { fragment ->
+        activityScenario.onActivity {
+            val fragment = it.supportFragmentManager.fragments[0] as DialogFragment
             assertNotNull(fragment.dialog)
             assertEquals(true, fragment.requireDialog().isShowing)
-            fragment.parentFragmentManager.executePendingTransactions()
+            it.supportFragmentManager.executePendingTransactions()
         }
     }
 }

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/HiltUtils.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/HiltUtils.kt
@@ -10,6 +10,8 @@ import com.automattic.simplenote.HiltTestActivity
 import com.automattic.simplenote.R
 
 /**
+ * Source: https://developer.android.com/training/dependency-injection/hilt-testing#launchfragment
+ *
  * launchDialogFragmentInHiltContainer from the androidx.fragment:fragment-testing library
  * is NOT possible to use right now as it uses a hardcoded Activity under the hood
  * (i.e. [EmptyFragmentActivity]) which is not annotated with @AndroidEntryPoint.

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/HiltUtils.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/HiltUtils.kt
@@ -1,0 +1,43 @@
+package com.automattic.simplenote.utils
+
+import android.content.ComponentName
+import android.content.Intent
+import androidx.annotation.StyleRes
+import androidx.fragment.app.DialogFragment
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.automattic.simplenote.HiltTestActivity
+import com.automattic.simplenote.R
+
+/**
+ * launchDialogFragmentInHiltContainer from the androidx.fragment:fragment-testing library
+ * is NOT possible to use right now as it uses a hardcoded Activity under the hood
+ * (i.e. [EmptyFragmentActivity]) which is not annotated with @AndroidEntryPoint.
+ *
+ * As a workaround, use this function that is equivalent. It requires you to add
+ * [HiltTestActivity] in the debug folder and include it in the debug AndroidManifest.xml file
+ * as can be found in this project. This function focus on launching DialogFragment
+ */
+
+inline fun <reified T : DialogFragment> launchDialogFragmentInHiltContainer(
+    @StyleRes themeResId: Int = R.style.FragmentScenarioEmptyFragmentActivityTheme,
+    crossinline instantiate: () -> T
+): ActivityScenario<HiltTestActivity> {
+    val startActivityIntent = Intent.makeMainActivity(
+        ComponentName(
+            ApplicationProvider.getApplicationContext(),
+            HiltTestActivity::class.java
+        )
+    ).putExtra(
+        "androidx.fragment.app.testing.FragmentScenario.EmptyFragmentActivity.THEME_EXTRAS_BUNDLE_KEY",
+        themeResId
+    )
+
+    val activityScenario: ActivityScenario<HiltTestActivity> = ActivityScenario.launch(startActivityIntent)
+    activityScenario.onActivity { activity ->
+        val fragment: DialogFragment = instantiate()
+        fragment.show(activity.supportFragmentManager.beginTransaction(), "dialog_tag")
+    }
+
+    return activityScenario
+}

--- a/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/HiltUtils.kt
+++ b/Simplenote/src/androidTest/java/com/automattic/simplenote/utils/HiltUtils.kt
@@ -20,7 +20,7 @@ import com.automattic.simplenote.R
  */
 
 inline fun <reified T : DialogFragment> launchDialogFragmentInHiltContainer(
-    @StyleRes themeResId: Int = R.style.FragmentScenarioEmptyFragmentActivityTheme,
+    @StyleRes themeResId: Int = R.style.Base_Theme_Simplestyle,
     crossinline instantiate: () -> T
 ): ActivityScenario<HiltTestActivity> {
     val startActivityIntent = Intent.makeMainActivity(

--- a/Simplenote/src/debug/AndroidManifest.xml
+++ b/Simplenote/src/debug/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.automattic.simplenote">
+
+    <application>
+        <activity
+            android:name=".HiltTestActivity"
+            android:exported="false"  />
+    </application>
+
+</manifest>

--- a/Simplenote/src/debug/java/com/automattic/simplenote/HiltTestActivity.kt
+++ b/Simplenote/src/debug/java/com/automattic/simplenote/HiltTestActivity.kt
@@ -1,0 +1,6 @@
+package com.automattic.simplenote
+
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class HiltTestActivity : ThemedAppCompatActivity()

--- a/Simplenote/src/main/java/com/automattic/simplenote/AddTagActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AddTagActivity.java
@@ -30,6 +30,9 @@ import com.simperium.client.Bucket;
 
 import java.util.Objects;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class AddTagActivity extends AppCompatActivity implements TextWatcher {
     private AddTagViewModel viewModel;
 
@@ -39,11 +42,7 @@ public class AddTagActivity extends AppCompatActivity implements TextWatcher {
         super.onCreate(savedInstanceState);
         ActivityTagAddBinding binding = ActivityTagAddBinding.inflate(getLayoutInflater());
 
-        Bucket<Tag> mBucketTag = ((Simplenote) getApplication()).getTagsBucket();
-        Bucket<Note> mNoteTag = ((Simplenote) getApplication()).getNotesBucket();
-        ViewModelFactory viewModelFactory = new ViewModelFactory(mBucketTag, mNoteTag, this, null);
-        ViewModelProvider viewModelProvider = new ViewModelProvider(this, viewModelFactory);
-        viewModel = viewModelProvider.get(AddTagViewModel.class);
+        viewModel = new ViewModelProvider(this).get(AddTagViewModel.class);
 
         setObservers(binding);
         setupLayout(binding);

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -1,5 +1,10 @@
 package com.automattic.simplenote;
 
+import static com.automattic.simplenote.models.Account.KEY_EMAIL_VERIFICATION;
+import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
+import static com.simperium.android.AsyncAuthClient.USER_ACCESS_TOKEN_PREFERENCE;
+import static com.simperium.android.AsyncAuthClient.USER_EMAIL_PREFERENCE;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
@@ -7,7 +12,6 @@ import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
-import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -17,7 +21,6 @@ import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.fragment.app.FragmentManager;
-import androidx.multidex.MultiDexApplication;
 import androidx.work.BackoffPolicy;
 import androidx.work.Constraints;
 import androidx.work.ExistingPeriodicWorkPolicy;
@@ -53,19 +56,13 @@ import org.wordpress.passcodelock.AppLockManager;
 
 import java.util.Calendar;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import dagger.hilt.android.HiltAndroidApp;
 
-import static com.automattic.simplenote.models.Account.KEY_EMAIL_VERIFICATION;
-import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
-import static com.simperium.android.AsyncAuthClient.USER_ACCESS_TOKEN_PREFERENCE;
-import static com.simperium.android.AsyncAuthClient.USER_EMAIL_PREFERENCE;
-
 @HiltAndroidApp
-public class Simplenote extends MultiDexApplication implements HeartbeatListener {
+public class Simplenote extends Application implements HeartbeatListener {
     public static final String DELETED_NOTE_ID = "deletedNoteId";
     public static final String SELECTED_NOTE_ID = "selectedNoteId";
     public static final String SCROLL_POSITION_PREFERENCES = "scroll_position";

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -17,6 +17,7 @@ import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.fragment.app.FragmentManager;
+import androidx.multidex.MultiDexApplication;
 import androidx.work.BackoffPolicy;
 import androidx.work.Constraints;
 import androidx.work.ExistingPeriodicWorkPolicy;
@@ -56,12 +57,15 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import dagger.hilt.android.HiltAndroidApp;
+
 import static com.automattic.simplenote.models.Account.KEY_EMAIL_VERIFICATION;
 import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
 import static com.simperium.android.AsyncAuthClient.USER_ACCESS_TOKEN_PREFERENCE;
 import static com.simperium.android.AsyncAuthClient.USER_EMAIL_PREFERENCE;
 
-public class Simplenote extends Application implements HeartbeatListener {
+@HiltAndroidApp
+public class Simplenote extends MultiDexApplication implements HeartbeatListener {
     public static final String DELETED_NOTE_ID = "deletedNoteId";
     public static final String SELECTED_NOTE_ID = "selectedNoteId";
     public static final String SCROLL_POSITION_PREFERENCES = "scroll_position";

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.java
@@ -20,26 +20,24 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatDialogFragment;
 import androidx.lifecycle.ViewModelProvider;
 
-import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
 import com.automattic.simplenote.utils.DialogUtils;
 import com.automattic.simplenote.viewmodels.TagDialogEvent;
 import com.automattic.simplenote.viewmodels.TagDialogViewModel;
-import com.automattic.simplenote.viewmodels.ViewModelFactory;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
-import com.simperium.client.Bucket;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class TagDialogFragment extends AppCompatDialogFragment implements TextWatcher, OnShowListener {
     public static String DIALOG_TAG = "dialog_tag";
 
     private AlertDialog mDialogEditTag;
-    private Bucket<Note> mBucketNote;
-    private Bucket<Tag> mBucketTag;
     private Button mButtonNegative;
     private Button mButtonNeutral;
     private Button mButtonPositive;
-    private Tag mTag;
+    private final Tag tag;
     private TextInputEditText mEditTextTag;
     private TextInputLayout mEditTextLayout;
     private TextView mMessage;
@@ -50,19 +48,15 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
 
     private TagDialogViewModel viewModel;
 
-    public TagDialogFragment(Tag tag, Bucket<Note> bucketNote, Bucket<Tag> bucketTag) {
-        mTag = tag;
-        mBucketNote = bucketNote;
-        mBucketTag = bucketTag;
+    public TagDialogFragment(Tag tag) {
+        this.tag = tag;
     }
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        ViewModelFactory viewModelFactory = new ViewModelFactory(mBucketTag, mBucketNote, this, null);
-        ViewModelProvider viewModelProvider = new ViewModelProvider(this, viewModelFactory);
-        viewModel = viewModelProvider.get(TagDialogViewModel.class);
+        viewModel = new ViewModelProvider(this).get(TagDialogViewModel.class);
     }
 
     @Override
@@ -140,10 +134,10 @@ public class TagDialogFragment extends AppCompatDialogFragment implements TextWa
 
         // Set observers when views are available
         setObservers();
-        viewModel.start(mTag);
+        viewModel.start(tag);
 
         showDialogRenameTag();
-        mEditTextTag.setText(mTag.getName());
+        mEditTextTag.setText(tag.getName());
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.java
@@ -28,8 +28,6 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 
-import com.automattic.simplenote.models.Note;
-import com.automattic.simplenote.models.Tag;
 import com.automattic.simplenote.models.TagItem;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
@@ -38,13 +36,13 @@ import com.automattic.simplenote.utils.TagItemAdapter;
 import com.automattic.simplenote.utils.ThemeUtils;
 import com.automattic.simplenote.viewmodels.TagsEvent;
 import com.automattic.simplenote.viewmodels.TagsViewModel;
-import com.automattic.simplenote.viewmodels.ViewModelFactory;
 import com.automattic.simplenote.widgets.EmptyViewRecyclerView;
 import com.automattic.simplenote.widgets.MorphSetup;
-import com.simperium.client.Bucket;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import kotlin.Unit;
 
+@AndroidEntryPoint
 public class TagsActivity extends ThemedAppCompatActivity {
     private static final int REQUEST_ADD_TAG = 9000;
 
@@ -56,21 +54,13 @@ public class TagsActivity extends ThemedAppCompatActivity {
 
     private TagsViewModel viewModel;
     private TagItemAdapter tagItemAdapter;
-    Bucket<Tag> mTagsBucket;
-    Bucket<Note> mNotesBucket;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_tags);
 
-        Simplenote application = (Simplenote) getApplication();
-        mTagsBucket = application.getTagsBucket();
-        mNotesBucket = application.getNotesBucket();
-
-        ViewModelFactory viewModelFactory = new ViewModelFactory(mTagsBucket, mNotesBucket, this, null);
-        ViewModelProvider viewModelProvider = new ViewModelProvider(this, viewModelFactory);
-        viewModel = viewModelProvider.get(TagsViewModel.class);
+        viewModel = new ViewModelProvider(this).get(TagsViewModel.class);
 
         tagItemAdapter = new TagItemAdapter(
                 (TagItem tagItem) -> {
@@ -188,11 +178,7 @@ public class TagsActivity extends ThemedAppCompatActivity {
     }
 
     private void showTagDialogFragment(TagsEvent.EditTagEvent event) {
-        TagDialogFragment dialog = new TagDialogFragment(
-                event.getTagItem().getTag(),
-                mNotesBucket,
-                mTagsBucket
-        );
+        TagDialogFragment dialog = new TagDialogFragment(event.getTagItem().getTag());
         dialog.show(getSupportFragmentManager().beginTransaction(), DIALOG_TAG);
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/di/DataModule.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/di/DataModule.kt
@@ -1,0 +1,29 @@
+package com.automattic.simplenote.di
+
+import android.content.Context
+import com.automattic.simplenote.Simplenote
+import com.automattic.simplenote.models.Note
+import com.automattic.simplenote.models.Tag
+import com.automattic.simplenote.repositories.SimperiumTagsRepository
+import com.automattic.simplenote.repositories.TagsRepository
+import com.simperium.client.Bucket
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataModule {
+
+    @Provides
+    fun providesTagsBucket(@ApplicationContext appContext: Context): Bucket<Tag> = (appContext as Simplenote).tagsBucket
+
+    @Provides
+    fun providesNotesBucket(@ApplicationContext appContext: Context): Bucket<Note> = (appContext as Simplenote).notesBucket
+
+    @Provides
+    fun providesTagsRepository(tagsBucket: Bucket<Tag>, notesBucket: Bucket<Note>): TagsRepository =
+        SimperiumTagsRepository(tagsBucket, notesBucket)
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/di/DataModule.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/di/DataModule.kt
@@ -7,6 +7,7 @@ import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.repositories.SimperiumTagsRepository
 import com.automattic.simplenote.repositories.TagsRepository
 import com.simperium.client.Bucket
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,15 +16,15 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object DataModule {
+abstract class DataModule {
+    companion object {
+        @Provides
+        fun providesTagsBucket(@ApplicationContext appContext: Context): Bucket<Tag> = (appContext as Simplenote).tagsBucket
 
-    @Provides
-    fun providesTagsBucket(@ApplicationContext appContext: Context): Bucket<Tag> = (appContext as Simplenote).tagsBucket
+        @Provides
+        fun providesNotesBucket(@ApplicationContext appContext: Context): Bucket<Note> = (appContext as Simplenote).notesBucket
+    }
 
-    @Provides
-    fun providesNotesBucket(@ApplicationContext appContext: Context): Bucket<Note> = (appContext as Simplenote).notesBucket
-
-    @Provides
-    fun providesTagsRepository(tagsBucket: Bucket<Tag>, notesBucket: Bucket<Note>): TagsRepository =
-        SimperiumTagsRepository(tagsBucket, notesBucket)
+    @Binds
+    abstract fun bindsTagsRepository(repository: SimperiumTagsRepository): TagsRepository
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
@@ -17,8 +17,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
-class SimperiumTagsRepository(
+class SimperiumTagsRepository @Inject constructor(
         private val tagsBucket: Bucket<Tag>,
         private val notesBucket: Bucket<Note>
 ) : TagsRepository {

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/AddTagViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/AddTagViewModel.kt
@@ -5,8 +5,11 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.automattic.simplenote.R
 import com.automattic.simplenote.repositories.TagsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class AddTagViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
+@HiltViewModel
+class AddTagViewModel @Inject constructor(private val tagsRepository: TagsRepository) : ViewModel() {
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
@@ -7,8 +7,11 @@ import com.automattic.simplenote.R
 import com.automattic.simplenote.analytics.AnalyticsTracker
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.repositories.TagsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class TagDialogViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
+@HiltViewModel
+class TagDialogViewModel @Inject constructor(private val tagsRepository: TagsRepository) : ViewModel() {
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -8,13 +8,14 @@ import androidx.lifecycle.viewModelScope
 import com.automattic.simplenote.analytics.AnalyticsTracker
 import com.automattic.simplenote.models.TagItem
 import com.automattic.simplenote.repositories.TagsRepository
-import kotlinx.coroutines.Dispatchers
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
-class TagsViewModel(private val tagsRepository: TagsRepository) : ViewModel() {
+@HiltViewModel
+class TagsViewModel @Inject constructor(private val tagsRepository: TagsRepository) : ViewModel() {
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.38'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 android.enableJetifier = true
 android.useAndroidX = true
-org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.enableJetifier = true
 android.useAndroidX = true
+org.gradle.caching=true


### PR DESCRIPTION
Fixes #1374 

### Fix

Adds support for dependency injection with Dagger/Hilt. Just tag-related screens were migrated. 

### Test

Test tag-related screens

### Review

Only one developer is required to review these changes, anyone can perform the review. Since @hichamboushaba has experience with Hilt, his feedback can be important to improve the integration.

### Release
These changes do not require release notes.
