### PR TITLE
Fix out of memory error on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,15 @@ orbs:
 version: 2.1
 jobs:
   Test:
-    executor: 
+    executor:
       name: android/default
       api-version: "29"
     steps:
       - checkout
       - android/restore-gradle-cache
+      - run:
+          name: Configure gradle
+          command: echo $'\norg.gradle.jvmargs=-Xmx3072m -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false' >> gradle.properties
       - run:
           name: Build
           command: ./gradlew --stacktrace assembleDebug assembleRelease
@@ -20,7 +23,7 @@ jobs:
       - android/save-gradle-cache
       - android/save-test-results
   Lint:
-    executor: 
+    executor:
       name: android/default
       api-version: "29"
     steps:


### PR DESCRIPTION
### Fix
This PR raises the amount of memory available to the JVM in order to fix an out of memory error during the build.

### Test
Check CI is green.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
