### PR TITLE
Update the plus icon to add new notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+2.20
+-----
+* Changed the new note icon [https://github.com/Automattic/simplenote-android/pull/1436]
+
 2.19
 -----
 * Added support to import notes [https://github.com/Automattic/simplenote-android/pull/1333]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,13 +1,10 @@
-2.20
------
-* Changed the new note icon [https://github.com/Automattic/simplenote-android/pull/1436]
-
 2.19
 -----
 * Added support to import notes [https://github.com/Automattic/simplenote-android/pull/1333]
 * Fixed crash when searching notes in tablets [https://github.com/Automattic/simplenote-android/pull/1425]
 * Added In App Account Deletion [https://github.com/Automattic/simplenote-android/pull/1416]
 * Fixed email verification screen appears with verified accounts [https://github.com/Automattic/simplenote-android/pull/1423]
+* Changed the new note icon [https://github.com/Automattic/simplenote-android/pull/1436]
 
 2.18
 -----

--- a/Simplenote/src/main/res/drawable/ic_new_note_24dp.xml
+++ b/Simplenote/src/main/res/drawable/ic_new_note_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M9.707,12.879L19.59,3 21,4.41l-9.879,9.883L9,15l0.707,-2.121zM18,18H6V6h7V4H6.002A2.002,2.002 0,0 0,4 6.002v11.996C4,19.104 4.896,20 6.002,20h11.996A2.002,2.002 0,0 0,20 17.998V11h-2v7z"/>
+</vector>

--- a/Simplenote/src/main/res/layout/fragment_notes_list.xml
+++ b/Simplenote/src/main/res/layout/fragment_notes_list.xml
@@ -63,7 +63,7 @@
         android:layout_marginBottom="@dimen/padding_large"
         android:layout_marginEnd="@dimen/padding_large"
         android:layout_width="wrap_content"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         app:backgroundTint="?attr/fabColor"
         app:borderWidth="0dp"
         app:elevation="8dp"

--- a/Simplenote/src/main/res/layout/note_list_widget_dark_black.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_dark_black.xml
@@ -39,20 +39,22 @@
 
     <ImageView
         android:id="@+id/widget_button"
+        android:layout_width="@dimen/minimum_target"
+        android:layout_height="@dimen/minimum_target"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="@dimen/padding_small"
+        android:layout_marginTop="@dimen/padding_small"
+        android:layout_marginEnd="@dimen/padding_small"
+        android:layout_marginBottom="@dimen/padding_small"
         android:background="@drawable/bg_ripple_oval_black"
         android:clickable="true"
         android:contentDescription="@string/new_note"
         android:focusable="true"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentEnd="true"
-        android:layout_height="@dimen/minimum_target"
-        android:layout_margin="@dimen/padding_small"
-        android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@android:color/white"
         android:visibility="gone"
-        tools:visibility="visible">
-    </ImageView>
+        tools:visibility="visible"></ImageView>
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_list_widget_dark_classic.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_dark_classic.xml
@@ -49,7 +49,7 @@
         android:layout_margin="@dimen/padding_small"
         android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@color/gray_100"
         android:visibility="gone"
         tools:visibility="visible">

--- a/Simplenote/src/main/res/layout/note_list_widget_dark_default.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_dark_default.xml
@@ -39,20 +39,22 @@
 
     <ImageView
         android:id="@+id/widget_button"
+        android:layout_width="@dimen/minimum_target"
+        android:layout_height="@dimen/minimum_target"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="@dimen/padding_small"
+        android:layout_marginTop="@dimen/padding_small"
+        android:layout_marginEnd="@dimen/padding_small"
+        android:layout_marginBottom="@dimen/padding_small"
         android:background="@drawable/bg_ripple_oval_default_dark"
         android:clickable="true"
         android:contentDescription="@string/new_note"
         android:focusable="true"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentEnd="true"
-        android:layout_height="@dimen/minimum_target"
-        android:layout_margin="@dimen/padding_small"
-        android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@color/gray_100"
         android:visibility="gone"
-        tools:visibility="visible">
-    </ImageView>
+        tools:visibility="visible"></ImageView>
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_list_widget_dark_matrix.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_dark_matrix.xml
@@ -40,20 +40,22 @@
 
     <ImageView
         android:id="@+id/widget_button"
+        android:layout_width="@dimen/minimum_target"
+        android:layout_height="@dimen/minimum_target"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="@dimen/padding_small"
+        android:layout_marginTop="@dimen/padding_small"
+        android:layout_marginEnd="@dimen/padding_small"
+        android:layout_marginBottom="@dimen/padding_small"
         android:background="@drawable/bg_ripple_oval_matrix_dark"
         android:clickable="true"
         android:contentDescription="@string/new_note"
         android:focusable="true"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentEnd="true"
-        android:layout_height="@dimen/minimum_target"
-        android:layout_margin="@dimen/padding_small"
-        android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@color/gray_100"
         android:visibility="gone"
-        tools:visibility="visible">
-    </ImageView>
+        tools:visibility="visible"></ImageView>
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_list_widget_dark_mono.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_dark_mono.xml
@@ -40,20 +40,22 @@
 
     <ImageView
         android:id="@+id/widget_button"
+        android:layout_width="@dimen/minimum_target"
+        android:layout_height="@dimen/minimum_target"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="@dimen/padding_small"
+        android:layout_marginTop="@dimen/padding_small"
+        android:layout_marginEnd="@dimen/padding_small"
+        android:layout_marginBottom="@dimen/padding_small"
         android:background="@drawable/bg_ripple_oval_mono_dark"
         android:clickable="true"
         android:contentDescription="@string/new_note"
         android:focusable="true"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentEnd="true"
-        android:layout_height="@dimen/minimum_target"
-        android:layout_margin="@dimen/padding_small"
-        android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@color/gray_100"
         android:visibility="gone"
-        tools:visibility="visible">
-    </ImageView>
+        tools:visibility="visible"></ImageView>
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_list_widget_dark_publication.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_dark_publication.xml
@@ -40,20 +40,22 @@
 
     <ImageView
         android:id="@+id/widget_button"
+        android:layout_width="@dimen/minimum_target"
+        android:layout_height="@dimen/minimum_target"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="@dimen/padding_small"
+        android:layout_marginTop="@dimen/padding_small"
+        android:layout_marginEnd="@dimen/padding_small"
+        android:layout_marginBottom="@dimen/padding_small"
         android:background="@drawable/bg_ripple_oval_publication_dark"
         android:clickable="true"
         android:contentDescription="@string/new_note"
         android:focusable="true"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentEnd="true"
-        android:layout_height="@dimen/minimum_target"
-        android:layout_margin="@dimen/padding_small"
-        android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@color/gray_100"
         android:visibility="gone"
-        tools:visibility="visible">
-    </ImageView>
+        tools:visibility="visible"></ImageView>
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_list_widget_dark_sepia.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_dark_sepia.xml
@@ -49,7 +49,7 @@
         android:layout_margin="@dimen/padding_small"
         android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@color/gray_100"
         android:visibility="gone"
         tools:visibility="visible">

--- a/Simplenote/src/main/res/layout/note_list_widget_light_black.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_light_black.xml
@@ -49,7 +49,7 @@
         android:layout_margin="@dimen/padding_small"
         android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@android:color/white"
         android:visibility="gone">
     </ImageView>

--- a/Simplenote/src/main/res/layout/note_list_widget_light_classic.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_light_classic.xml
@@ -39,20 +39,22 @@
 
     <ImageView
         android:id="@+id/widget_button"
+        android:layout_width="@dimen/minimum_target"
+        android:layout_height="@dimen/minimum_target"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="@dimen/padding_small"
+        android:layout_marginTop="@dimen/padding_small"
+        android:layout_marginEnd="@dimen/padding_small"
+        android:layout_marginBottom="@dimen/padding_small"
         android:background="@drawable/bg_ripple_oval_classic_light"
         android:clickable="true"
         android:contentDescription="@string/new_note"
         android:focusable="true"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentEnd="true"
-        android:layout_height="@dimen/minimum_target"
-        android:layout_margin="@dimen/padding_small"
-        android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@android:color/white"
         android:visibility="gone"
-        tools:visibility="visible">
-    </ImageView>
+        tools:visibility="visible"></ImageView>
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_list_widget_light_default.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_light_default.xml
@@ -49,7 +49,7 @@
         android:layout_margin="@dimen/padding_small"
         android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@android:color/white"
         android:visibility="gone"
         tools:visibility="visible">

--- a/Simplenote/src/main/res/layout/note_list_widget_light_matrix.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_light_matrix.xml
@@ -40,20 +40,22 @@
 
     <ImageView
         android:id="@+id/widget_button"
+        android:layout_width="@dimen/minimum_target"
+        android:layout_height="@dimen/minimum_target"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="@dimen/padding_small"
+        android:layout_marginTop="@dimen/padding_small"
+        android:layout_marginEnd="@dimen/padding_small"
+        android:layout_marginBottom="@dimen/padding_small"
         android:background="@drawable/bg_ripple_oval_matrix_light"
         android:clickable="true"
         android:contentDescription="@string/new_note"
         android:focusable="true"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentEnd="true"
-        android:layout_height="@dimen/minimum_target"
-        android:layout_margin="@dimen/padding_small"
-        android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@android:color/white"
         android:visibility="gone"
-        tools:visibility="visible">
-    </ImageView>
+        tools:visibility="visible"></ImageView>
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_list_widget_light_mono.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_light_mono.xml
@@ -40,20 +40,22 @@
 
     <ImageView
         android:id="@+id/widget_button"
+        android:layout_width="@dimen/minimum_target"
+        android:layout_height="@dimen/minimum_target"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="@dimen/padding_small"
+        android:layout_marginTop="@dimen/padding_small"
+        android:layout_marginEnd="@dimen/padding_small"
+        android:layout_marginBottom="@dimen/padding_small"
         android:background="@drawable/bg_ripple_oval_mono_light"
         android:clickable="true"
         android:contentDescription="@string/new_note"
         android:focusable="true"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentEnd="true"
-        android:layout_height="@dimen/minimum_target"
-        android:layout_margin="@dimen/padding_small"
-        android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@android:color/white"
         android:visibility="gone"
-        tools:visibility="visible">
-    </ImageView>
+        tools:visibility="visible"></ImageView>
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_list_widget_light_publication.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_light_publication.xml
@@ -40,20 +40,22 @@
 
     <ImageView
         android:id="@+id/widget_button"
+        android:layout_width="@dimen/minimum_target"
+        android:layout_height="@dimen/minimum_target"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="@dimen/padding_small"
+        android:layout_marginTop="@dimen/padding_small"
+        android:layout_marginEnd="@dimen/padding_small"
+        android:layout_marginBottom="@dimen/padding_small"
         android:background="@drawable/bg_ripple_oval_publication_light"
         android:clickable="true"
         android:contentDescription="@string/new_note"
         android:focusable="true"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentEnd="true"
-        android:layout_height="@dimen/minimum_target"
-        android:layout_margin="@dimen/padding_small"
-        android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@android:color/white"
         android:visibility="gone"
-        tools:visibility="visible">
-    </ImageView>
+        tools:visibility="visible"></ImageView>
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/layout/note_list_widget_light_sepia.xml
+++ b/Simplenote/src/main/res/layout/note_list_widget_light_sepia.xml
@@ -39,20 +39,22 @@
 
     <ImageView
         android:id="@+id/widget_button"
+        android:layout_width="@dimen/minimum_target"
+        android:layout_height="@dimen/minimum_target"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="@dimen/padding_small"
+        android:layout_marginTop="@dimen/padding_small"
+        android:layout_marginEnd="@dimen/padding_small"
+        android:layout_marginBottom="@dimen/padding_small"
         android:background="@drawable/bg_ripple_oval_sepia_light"
         android:clickable="true"
         android:contentDescription="@string/new_note"
         android:focusable="true"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentEnd="true"
-        android:layout_height="@dimen/minimum_target"
-        android:layout_margin="@dimen/padding_small"
-        android:layout_width="@dimen/minimum_target"
         android:padding="@dimen/padding_medium"
-        android:src="@drawable/ic_add_24dp"
+        android:src="@drawable/ic_new_note_24dp"
         android:tint="@android:color/white"
         android:visibility="gone"
-        tools:visibility="visible">
-    </ImageView>
+        tools:visibility="visible"></ImageView>
 
 </RelativeLayout>


### PR DESCRIPTION
Fixes #1434 

### Fix

Update the icon to add a new note using new designs.

### Test

1. Go to main screen (list of notes)
2. Tap on add note which should have the new icon

**Phone**

| Light      | Dark |
| ----------- | ----------- |
|  ![20210805_174121](https://user-images.githubusercontent.com/195721/128430752-48dc49de-2e64-44f0-bb9c-dccda09c56bc.gif)    |  ![20210805_174823](https://user-images.githubusercontent.com/195721/128431126-71072ef2-9a60-461b-9ad5-4e3f7ff45f0d.gif)  |

**Table**

| Light      | Dark |
| ----------- | ----------- |
| ![20210805_174944](https://user-images.githubusercontent.com/195721/128431439-d5223181-fdd2-4141-a23f-a3a86e4b6b71.gif)  | ![20210805_175100](https://user-images.githubusercontent.com/195721/128431445-34764f5d-6861-45d9-ae3a-e188af9c58bb.gif) |

### Review

Only one designer is required to review these changes. @SylvesterWilmott can review this PR.


### Release

`RELEASE-NOTES.txt` was updated in f3023a97d57dcba5ce9a3c52505a7ad3d640452d with:
> Changed the new note icon
