### PR TITLE
Handle back press button when NoteEditorActivity is the Task Root

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 2.20
 -----
-* Removed sort bar from notes list but still accessible from settings [1438](https://github.com/Automattic/simplenote-android/pull/1438)
-* Fixed back button return to home screen when a note is accessed from a widget [1450](https://github.com/Automattic/simplenote-android/pull/1450)
+* Removed sort bar from notes list but still accessible from settings [#1438](https://github.com/Automattic/simplenote-android/pull/1438)
+* Fixed back button return to home screen when a note is accessed from a widget [#1450](https://github.com/Automattic/simplenote-android/pull/1450)
 
 2.19
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.20
 -----
 * Removed sort bar from notes list but still accessible from settings [1438](https://github.com/Automattic/simplenote-android/pull/1438)
+* Fixed back button return to home screen when a note is accessed from a widget [1450](https://github.com/Automattic/simplenote-android/pull/1450)
 
 2.19
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -1,5 +1,15 @@
 package com.automattic.simplenote;
 
+import static androidx.fragment.app.FragmentStatePagerAdapter.BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_NOTE_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_TAPPED;
+import static com.automattic.simplenote.utils.DisplayUtils.disableScreenshotsIfLocked;
+import static com.automattic.simplenote.utils.MatchOffsetHighlighter.MATCH_INDEX_COUNT;
+import static com.automattic.simplenote.utils.MatchOffsetHighlighter.MATCH_INDEX_START;
+import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
+import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
+
 import android.app.Activity;
 import android.content.Intent;
 import android.content.res.Configuration;
@@ -37,16 +47,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
-
-import static androidx.fragment.app.FragmentStatePagerAdapter.BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_NOTE_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_TAPPED;
-import static com.automattic.simplenote.utils.DisplayUtils.disableScreenshotsIfLocked;
-import static com.automattic.simplenote.utils.MatchOffsetHighlighter.MATCH_INDEX_COUNT;
-import static com.automattic.simplenote.utils.MatchOffsetHighlighter.MATCH_INDEX_START;
-import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
-import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
 
 public class NoteEditorActivity extends ThemedAppCompatActivity {
     private static final String STATE_TAB_EDIT = "TAB_EDIT";
@@ -88,6 +88,13 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
         setSupportActionBar(toolbar);
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            // Add a custom handler for back button click
+            toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    handleBackPressed();
+                }
+            });
         }
 
         mNoteEditorFragment = new NoteEditorFragment();
@@ -222,8 +229,21 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
 
     @Override
     public void onBackPressed() {
+        handleBackPressed();
+    }
+
+    private void handleBackPressed() {
         AppLog.add(Type.ACTION, "Tapped back button in navigation bar (NoteEditorActivity)");
-        super.onBackPressed();
+        if (isTaskRoot()) {
+            // The editor can be the task root when it comes from an action on a widget
+            // In these cases, instead of going to the home screen, the notes activity
+            // is started
+            Intent intent = new Intent(getApplicationContext(), NotesActivity.class);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            startActivity(intent);
+        } else {
+            super.onBackPressed();
+        }
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -239,7 +239,7 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
             // In these cases, instead of going to the home screen, the notes activity
             // is started
             Intent intent = new Intent(getApplicationContext(), NotesActivity.class);
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(intent);
         } else {
             super.onBackPressed();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorActivity.java
@@ -241,6 +241,8 @@ public class NoteEditorActivity extends ThemedAppCompatActivity {
             Intent intent = new Intent(getApplicationContext(), NotesActivity.class);
             intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(intent);
+
+            finish();
         } else {
             super.onBackPressed();
         }


### PR DESCRIPTION
Fixes #1429

The editor can be the task root when it comes from an action on a widget. In these cases, instead of going to the home screen, the notes activity is started. The toolbar's back button also follows this behavior.

### Fix

Tapping the back button after entering a note through a widget, should return to the list of notes in Simplenote.

**Without Passcode**

https://user-images.githubusercontent.com/195721/129981459-b9490a6d-8729-4398-991e-5e37ab0d37e6.mp4

**With Passcode**

https://user-images.githubusercontent.com/195721/129981490-667f720a-e145-4f2a-a29a-60e067fda05b.mp4

### Test

1. Add a widget to the home screen with the list of notes
2. Close the app permanently
3. Go to the widget and tap on one of the notes in the list
4. Tap on the back button (top of the toolbar and also the Android back button)
5. The list of notes should be shown

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in b1a42e7f1723214b7d84d2fa0b4afc1028bbd7dc with:
> Fixed back button return to home screen when a note is accessed from a widget
