### PR TITLE
Add check body for unverified accounts in 403 responses

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
-    implementation 'com.automattic:simperium:develop-c0bbbb8b6c34c671f810f530d2baf857a0ce5d87'
+    implementation 'com.automattic:simperium:235-77e6375bb79c5a0529e058610157de96e8bbd5ba'
     implementation('com.automattic:tracks:1.2') {
         exclude group: "org.jetbrains", module: "annotations-java5"
     }

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
-    implementation 'com.automattic:simperium:235-77e6375bb79c5a0529e058610157de96e8bbd5ba'
+    implementation 'com.automattic:simperium:235-b39349535a80eec6d0f32581847d14d000d237f4'
     implementation('com.automattic:tracks:1.2') {
         exclude group: "org.jetbrains", module: "annotations-java5"
     }

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
-    implementation 'com.automattic:simperium:235-b39349535a80eec6d0f32581847d14d000d237f4'
+    implementation 'com.automattic:simperium:develop-78e8200288a4d0e75937720cbd0e503ddb04f035'
     implementation('com.automattic:tracks:1.2') {
         exclude group: "org.jetbrains", module: "annotations-java5"
     }


### PR DESCRIPTION
Fixes #1466.

### Fix
The current implementation to handle 403 responses doesn't check for the body sent in the response. In order to be able to handle more kinds of responses with code 403, this PR adds a simperium library that handles unverified accounts with the following predicate:

```java
if (statusCode == 403 && body.equals("verification required")
```

### Test
1. Tap ***Log In*** button.
2. Tap ***Log In with Email*** button.
3. Enter email address in ***Email*** field.
4. Notice ***Log In*** button is disabled.
5. Enter incorrect password of more than four and less than eight characters in ***Password*** field.
6. Notice ***Log In*** button is enabled after four characters are input.
7. Tap ***Log In*** button.
8. Notice ***Error*** dialog that shows invalid credentials.
9. Tap ***OK*** button in dialog.
10. Enter correct password of more than seven characters in ***Password*** field.
11. Notice ***Log In*** button is enabled after four characters are input.
12. Tap ***Log In*** button.
13. Notice app is successfully logged in.
14. Logout and know try a user with unverified account. If the backend implementation has not been implemented, proxy system like Charles to interrupt responses from the auth endpoint. 
15. Notice ***Error*** dialog that shows unverified account. 
16. Tap on the `Resend Verification Email`
17. You must have received an email to verify your account. This email is rate limited, thus, you should be able to send just one email per day to the same email.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release

These changes do not require release notes.