### PR TITLE
Modify message shown to user when trying to delete account and when doesn't have connectivity

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -49,6 +49,7 @@ import com.automattic.simplenote.utils.CrashUtils;
 import com.automattic.simplenote.utils.DeleteAccountRequestHandler;
 import com.automattic.simplenote.utils.DialogUtils;
 import com.automattic.simplenote.utils.HtmlCompat;
+import com.automattic.simplenote.utils.NetworkUtils;
 import com.automattic.simplenote.utils.PrefUtils;
 import com.automattic.simplenote.utils.SimplenoteProgressDialogFragment;
 import com.simperium.Simperium;
@@ -393,17 +394,23 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
                             // it can be related to memory constraints or something else that is
                             // just a transient fault
                             try {
-                                AppLog.add(Type.ACCOUNT, "Making request to delete account");
+                                if (NetworkUtils.isNetworkAvailable(requireContext())) {
+                                    AppLog.add(Type.ACCOUNT, "Making request to delete account");
+                                    String userToken = simperium.getUser().getAccessToken();
+                                    AccountNetworkUtils.makeDeleteAccountRequest(
+                                            userEmail,
+                                            userToken,
+                                            deleteAccountHandler);
+                                } else {
+                                    AppLog.add(Type.ACCOUNT, "No connectivity to make request to delete account");
+                                    closeProgressDialogDeleteAccount();
+                                    showDialogDeleteAccountNoConnectivity();
+                                }
 
-                                String userToken = simperium.getUser().getAccessToken();
-                                AccountNetworkUtils.makeDeleteAccountRequest(
-                                        userEmail,
-                                        userToken,
-                                        deleteAccountHandler);
                             } catch (IllegalArgumentException exception) {
                                 AppLog.add(Type.ACCOUNT, "Error trying to make request " +
                                         "to delete account. Error: " + exception.getMessage());
-
+                                closeProgressDialogDeleteAccount();
                                 showDialogDeleteAccountError();
                             }
                         }
@@ -427,6 +434,28 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
             }
         });
         dialogDeleteAccount.show();
+    }
+
+    private void showDialogDeleteAccountNoConnectivity() {
+        FragmentActivity activity = getActivity();
+        if (activity == null) {
+            return;
+        }
+
+        AlertDialog dialogDeleteAccountConfirmation = new AlertDialog.Builder(
+                new ContextThemeWrapper(activity, R.style.Dialog))
+                .setTitle(R.string.error)
+                .setMessage(R.string.simperium_dialog_message_network)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int i) {
+                                dialogInterface.dismiss();
+                            }
+                        }
+                )
+                .create();
+
+        dialogDeleteAccountConfirmation.show();
     }
 
     private void showDialogDeleteAccountError() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -372,9 +372,12 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
 
         final DeleteAccountRequestHandler deleteAccountHandler = new DeleteAccountRequestHandlerImpl(this);
 
+        Simplenote currentApp = (Simplenote) requireActivity().getApplication();
+        Simperium simperium = currentApp.getSimperium();
+        String userEmail = simperium.getUser().getEmail();
         final AlertDialog dialogDeleteAccount = new AlertDialog.Builder(new ContextThemeWrapper(context, R.style.Dialog))
                 .setTitle(R.string.delete_account)
-                .setMessage(R.string.delete_account_message)
+                .setMessage(getString(R.string.delete_account_email_message, userEmail))
                 .setPositiveButton(R.string.delete_account, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {
@@ -385,11 +388,6 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
 
                             showProgressDialogDeleteAccount();
 
-                            Simplenote currentApp = (Simplenote) activity.getApplication();
-                            Simperium simperium = currentApp.getSimperium();
-                            String userEmail = simperium.getUser().getEmail();
-                            String userToken = simperium.getUser().getAccessToken();
-
                             // makeDeleteAccountRequest can throw an exception when it cannot build
                             // the JSON object. In those cases, we show the error dialog since
                             // it can be related to memory constraints or something else that is
@@ -397,6 +395,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
                             try {
                                 AppLog.add(Type.ACCOUNT, "Making request to delete account");
 
+                                String userToken = simperium.getUser().getAccessToken();
                                 AccountNetworkUtils.makeDeleteAccountRequest(
                                         userEmail,
                                         userToken,

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="new_note">New Note</string>
     <string name="account">Account</string>
     <string name="delete_account">Delete Account</string>
-    <string name="delete_account_message">By deleting your account, all notes created with this account will be permanently deleted. This action is not reversible.</string>
+    <string name="delete_account_email_message">By deleting the account for email %1$s, all notes created with this account will be permanently deleted. This action is not reversible.</string>
     <string name="request_received">Request Received</string>
     <string name="account_deletion_message">An email was sent to %1$s. Check your inbox and follow the instructions to confirm account deletion.\n\nYour account won\'t be deleted until we receive your confirmation.</string>
     <string name="error_ocurred_message">An error occurred. Please, try again. If the problem continues, contact us at %1$s%2$s%3$s%4$s%5$s for help.</string>


### PR DESCRIPTION
Fixes #1469 #1464

### Fix

Android does not show the currently logged-in account. Because of this, when Delete Account is clicked, it's not clear what is the account email from the first alert. Changes the message shown to the user to:

```
By deleting the account for <email>, all notes created with this account will be permanently deleted. This action is not reversible.
``` 

Also, when the user doesn't have connectivity, it shows an error that the user doesn't have Internet. 

| With Internet      | Without Internet |
| ----------- | ----------- |
|  ![20210902_135004](https://user-images.githubusercontent.com/195721/131916412-a3d5a65c-a613-4959-9329-8b7cc4303edf.gif) |  ![20210902_134850](https://user-images.githubusercontent.com/195721/131916445-a4f76a3f-0ddc-4afd-ad1d-b91341826d5e.gif)        |


### Test
**Note: use Simperium key for production and create accounts for tests. You can create accounts with the following format: youremail+n@automattic.com where n is an integer number (e.g. danilo.dominguez+1@automattic.com). Follow the instructions in the email to setup password.**

1. Put the phone on Airplane Mode
2. Open the left menu by tapping on the top-left corner icon
3. Tap on Settings
4. Scroll down and Tap on the preference `Delete Account`
5. A message `There is no network available` should pop in a dialog
6. Tap OK
7. Set off Airplane Mode
8. Open the left menu by tapping on the top-left corner icon
9. Tap on Settings
10. Scroll down and Tap on the preference `Delete Account`
11. That will open a dialog. Tap on `DELETE ACCOUNT` button
12. Open your email and proceed to delete the account
13. Open Simplenote and it should logout automatically

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
