### PR TITLE
Do not assemble project when running tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,6 @@ jobs:
           name: Configure gradle
           command: echo $'\norg.gradle.jvmargs=-Xmx3072m -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false' >> gradle.properties
       - run:
-          name: Build
-          command: ./gradlew --stacktrace assembleDebug assembleRelease
-      - run:
           name: Test
           command: ./gradlew --stacktrace testRelease
       - android/save-gradle-cache


### PR DESCRIPTION
Fixes: #1488 

### Fix
For reasons for the change please see description of #1488. This PR removes `build` step when running project tests.

### Test
Nothing to test - CI checks are sufficient.

### Release
These changes do not require release notes.
<!--
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.txt` was updated in d3adb3ef with:
> Added markdown support
-->
<!--
If the changes should not be included in release notes, add a statement to this section. For example:
These changes do not require release notes.
-->
