### PR TITLE
Fixes tag related bugs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,8 @@
 2.22
 -----
+* Fixed screen going into full-editing mode in tag editor [#1482](https://github.com/Automattic/simplenote-android/issues/1482)
+* Fixed save button is disabled for a new tag after device rotation [#1483](https://github.com/Automattic/simplenote-android/issues/1483)
+* Fixed tag rename dialog is closed on device rotation [#1484](https://github.com/Automattic/simplenote-android/issues/1484)
 
 
 2.21

--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
 
         <activity
             android:name="com.automattic.simplenote.AddTagActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"
             android:theme="@style/Theme.Transparent.Dialog"
             android:windowSoftInputMode="adjustResize">
         </activity>

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagDialogFragment.kt
@@ -31,11 +31,6 @@ class TagDialogFragment(private val tag: Tag) : AppCompatDialogFragment(), OnSho
     private var _binding: EditTagBinding? = null
     private val binding  get() = _binding!!
 
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        viewModel.close()
-    }
-
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         _binding = EditTagBinding.inflate(LayoutInflater.from(context))
         return buildDialog()

--- a/Simplenote/src/main/res/layout/activity_tag_add.xml
+++ b/Simplenote/src/main/res/layout/activity_tag_add.xml
@@ -43,6 +43,7 @@
                 android:id="@+id/tag_input"
                 android:hint="@string/dialog_tag_add_hint"
                 android:inputType="textEmailAddress"
+                android:imeOptions="flagNoExtractUi"
                 android:layout_height="wrap_content"
                 android:layout_width="fill_parent">
             </com.google.android.material.textfield.TextInputEditText>

--- a/Simplenote/src/main/res/layout/edit_tag.xml
+++ b/Simplenote/src/main/res/layout/edit_tag.xml
@@ -27,6 +27,7 @@
 
         <com.google.android.material.textfield.TextInputEditText
             android:inputType="textEmailAddress"
+            android:imeOptions="flagNoExtractUi"
             android:layout_height="match_parent"
             android:layout_width="match_parent">
         </com.google.android.material.textfield.TextInputEditText>


### PR DESCRIPTION
Fixes #1482 #1483 #1484

### Fix

Fixes a series of UX related bugs in the Tags screens:

- Fixed screen going into full-editing mode in tag editor
- Fixed save button is disabled for a new tag after device rotation
- Fixed tag rename dialog is closed on device rotation

Internal document: p5T066-2DS-p2#comment-9883

### Test

**Test screen going into full-editing model in tag editor**
1. Open left panel
2. Tap on Edit Tags
3. Tap on one of the tags in the list to edit. It will open a `Rename Tag` dialog
4. Tab on the field to edit the tag. It will open the soft keyboard
5. Rotate the phone. It should not go into full-screen keyboard editing mode
6. Close the soft keyboard

**Test save button is disabled for a new tag after device rotation**
1. Open left panel
2. Tap on Edit Tags
3. Tap on the (+) button to add a new tag
4. Start typing tag. The `Save` should be enabled
5. Rotate the phone. The `Save` button should stay enabled

**Test tag rename dialog close on device rotation**
1. Open left panel
2. Tap on Edit Tags
3. Tap on one of the tags in the list to edit. It will open a `Rename Tag` dialog
4. Rotate the phone. The rename tag dialog is not close

### Review'

Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 50caea3c44eb8980554b54c107cce540c2ed7acb with:
> Fixed screen going into full-editing mode in tag editor
   Fixed save button is disabled for a new tag after device rotation
   Fixed tag rename dialog is closed on device rotation