### PR TITLE
Do not filter collaborators until we launch the UI for collaborators

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/usecases/GetTagsUseCase.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/usecases/GetTagsUseCase.kt
@@ -20,6 +20,8 @@ class GetTagsUseCase @Inject constructor(
     }
 
     fun getTags(note: Note): List<String> {
-        return note.tags.filter { tag -> !collaboratorsRepository.isValidCollaborator(tag) }
+        //return note.tags.filter { tag -> !collaboratorsRepository.isValidCollaborator(tag) }
+        // Small patch until we launch collaborator UI
+        return note.tags
     }
 }

--- a/Simplenote/src/test/java/com/automattic/simplenote/usecases/GetTagsUseCaseTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/usecases/GetTagsUseCaseTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
@@ -54,6 +55,7 @@ class GetTagsUseCaseTest {
         assertEquals(tagItemsExpected, tagItemsResult)
     }
 
+    @Ignore("Patch for code freeze")
     @Test
     fun tagsForNoteShouldFilterCollaborators() {
         val note = Note("key1")

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/NoteEditorViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/NoteEditorViewModelTest.kt
@@ -10,6 +10,7 @@ import com.automattic.simplenote.viewmodels.NoteEditorViewModel.*
 import com.simperium.client.Bucket
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
@@ -39,6 +40,7 @@ class NoteEditorViewModelTest {
         whenever(tagsRepository.isTagMissing(any())).thenReturn(true)
     }
 
+    @Ignore("Patch for code freeze")
     @Test
     fun updateShouldUpdateUiState() {
         viewModel.update(note)
@@ -47,6 +49,7 @@ class NoteEditorViewModelTest {
         assertEquals(listOf("tag1", "tag2", "name@test.com"), note.tags)
     }
 
+    @Ignore("Patch for code freeze")
     @Test
     fun addTagShouldUpdateUiState() {
         viewModel.addTag("tag3", note)
@@ -55,6 +58,7 @@ class NoteEditorViewModelTest {
         assertEquals(listOf("tag1", "tag2", "name@test.com", "tag3"), note.tags)
     }
 
+    @Ignore("Patch for code freeze")
     @Test
     fun addCollaboratorShouldNotUpdateUiState() {
         viewModel.update(note)
@@ -73,6 +77,7 @@ class NoteEditorViewModelTest {
         assertEquals(NoteEditorEvent.TagAsCollaborator("name@email.com"), viewModel.event.value)
     }
 
+    @Ignore("Patch for code freeze")
     @Test
     fun addInvalidTagShouldNotUpdateUiState() {
         viewModel.update(note)
@@ -92,6 +97,7 @@ class NoteEditorViewModelTest {
     }
 
 
+    @Ignore("Patch for code freeze")
     @Test
     fun removeTagShouldUpdateUiStateAndNote() {
         viewModel.removeTag("tag2", note)


### PR DESCRIPTION
### Fix

Since we have not yet launched the dedicated UI for collaborators, users would not be able to remove or see collaborators in the notes. This PR disables filtering collaborators (emails) to show in the list of tags per note, so that users can add and remove collaborators.

### Test

1. Go to a note
2. Go to the bottom of a note
3. Add an email to the note. The email should be shown
4. Delete the tag from the note

### Review

Only one developer is required to review these changes, but anyone can perform the review.


### Release

These changes do not require release notes.
