### PR TITLE
Add simperium strings to handle compromised passwords to Simplenote

### DIFF
--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -404,8 +404,8 @@
     <string name="simperium_account_verification_message">You must verify your email before logging in to your account.</string>
     <string name="simperium_account_verification_url">https://app.simplenote.com/account/verify-email/%1$s</string>
     <string name="simperium_compromised_password">Compromised Password</string>
-    <string name="simperium_compromised_password_message">This password has appeared in a data breach, which puts your account at high risk of compromise. It is recommended that you change your password immediately.</string>
-    <string name="simperium_not_now">Not Now</string>
+    <string name="simperium_compromised_password_message">This password has appeared in a data breach, which puts your account at high risk of compromise. To protect your data, you\'ll need to update your password before being able to log in again.</string>
+    <string name="simperium_not_now">Cancel</string>
     <string name="simperium_change_password">Change Password</string>
     <string name="simperium_okay">Okay</string>
 </resources>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -403,5 +403,9 @@
     <string name="simperium_account_verification">Account Verification Required</string>
     <string name="simperium_account_verification_message">You must verify your email before logging in to your account.</string>
     <string name="simperium_account_verification_url">https://app.simplenote.com/account/verify-email/%1$s</string>
+    <string name="simperium_compromised_password">Compromised Password</string>
+    <string name="simperium_compromised_password_message">This password has appeared in a data breach, which puts your account at high risk of compromise. It is recommended that you change your password immediately.</string>
+    <string name="simperium_not_now">Not Now</string>
+    <string name="simperium_change_password">Change Password</string>
     <string name="simperium_okay">Okay</string>
 </resources>


### PR DESCRIPTION
Fixes #1506

### Fix
Login in Simplenote is handled by the simperium library. In order to make the string translatable at the Simplenote level, we need to include those strings in the project. This PR adds the string to handle compromised passwords during login. 

It also updates the strings with respect to the request in #1506. 

### Test

1. Create an account and use a compromised password such as `password` or `123456`
2. Try login into the account
3. A dialog with the title `Compromised Password` and the message `This password has appeared in a data breach, which puts your account at high risk of compromise. To protect your data, you'll need to update your password before being able to log in again.` should appear. 

### Review

Only one developer or designer is required to review these changes, but anyone can perform the review.


### Release
These changes do not require release notes.
