### PR TITLE
Refactor tag screens to filter out collaborators

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Added a dedicated UI to add and remove collaborators to a note [#1491](https://github.com/Automattic/simplenote-android/pull/1491)
 * Added collaboration status indicator to the note list [#1499](https://github.com/Automattic/simplenote-android/pull/1499)
 * Fixed crash when note reference is null in editor while hiding toolbar in landscape mode [#1504](https://github.com/Automattic/simplenote-android/pull/1504)
+* [Internal] Updated list of tags to filter out collaborators (emails) [#1509](https://github.com/Automattic/simplenote-android/pull/1509)
 
 2.22
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -680,7 +680,6 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         }
 
         mTagsAdapter.submitList(tags);
-        //mTagsAdapter.changeCursor(tagCursor);
         mNavigationMenu.removeGroup(GROUP_SECONDARY);
         mNavigationMenu.removeGroup(GROUP_TERTIARY);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -654,10 +654,6 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
 
     private List<Tag> getTagsFromCursor(Bucket.ObjectCursor<Tag> tagCursor) {
         List<Tag> tags = new ArrayList<>();
-        if (tagCursor.getCount() == 0) {
-            return tags;
-        }
-
 
         for (int i = 0; i < tagCursor.getCount(); i++) {
             tagCursor.moveToNext();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NotesActivity.java
@@ -1,5 +1,34 @@
 package com.automattic.simplenote;
 
+import static com.automattic.simplenote.NoteListFragment.TAG_PREFIX;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_NOTE;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_TAG;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_USER;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.EDITOR_NOTE_RESTORED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_NOTES_SEARCHED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_NOTE_CREATED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_NOTE_DELETED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_NOTE_OPENED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_TAG_VIEWED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_TRASH_EMPTIED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_TRASH_VIEWED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_BUTTON_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_SIGN_IN_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_SIGN_IN_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.USER_ACCOUNT_CREATED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.USER_SIGNED_IN;
+import static com.automattic.simplenote.utils.DisplayUtils.disableScreenshotsIfLocked;
+import static com.automattic.simplenote.utils.TagsAdapter.ALL_NOTES_ID;
+import static com.automattic.simplenote.utils.TagsAdapter.DEFAULT_ITEM_POSITION;
+import static com.automattic.simplenote.utils.TagsAdapter.SETTINGS_ID;
+import static com.automattic.simplenote.utils.TagsAdapter.TAGS_ID;
+import static com.automattic.simplenote.utils.TagsAdapter.TRASH_ID;
+import static com.automattic.simplenote.utils.TagsAdapter.UNTAGGED_NOTES_ID;
+import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
+import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
+
 import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -44,6 +73,7 @@ import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.authentication.SimplenoteAuthenticationActivity;
 import com.automattic.simplenote.models.Note;
 import com.automattic.simplenote.models.Tag;
+import com.automattic.simplenote.repositories.CollaboratorsRepository;
 import com.automattic.simplenote.utils.AppLog;
 import com.automattic.simplenote.utils.AppLog.Type;
 import com.automattic.simplenote.utils.AuthUtils;
@@ -75,34 +105,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.automattic.simplenote.NoteListFragment.TAG_PREFIX;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_NOTE;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_TAG;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_USER;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.EDITOR_NOTE_RESTORED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_NOTES_SEARCHED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_NOTE_CREATED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_NOTE_DELETED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_NOTE_OPENED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_TAG_VIEWED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_TRASH_EMPTIED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.LIST_TRASH_VIEWED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_BUTTON_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_SIGN_IN_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_SIGN_IN_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.USER_ACCOUNT_CREATED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.USER_SIGNED_IN;
-import static com.automattic.simplenote.utils.DisplayUtils.disableScreenshotsIfLocked;
-import static com.automattic.simplenote.utils.TagsAdapter.ALL_NOTES_ID;
-import static com.automattic.simplenote.utils.TagsAdapter.DEFAULT_ITEM_POSITION;
-import static com.automattic.simplenote.utils.TagsAdapter.SETTINGS_ID;
-import static com.automattic.simplenote.utils.TagsAdapter.TAGS_ID;
-import static com.automattic.simplenote.utils.TagsAdapter.TRASH_ID;
-import static com.automattic.simplenote.utils.TagsAdapter.UNTAGGED_NOTES_ID;
-import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
-import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
+import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
 
@@ -152,6 +155,7 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
     private ActionBarDrawerToggle mDrawerToggle;
     private TagsAdapter mTagsAdapter;
     private TagsAdapter.TagMenuItem mSelectedTag;
+    @Inject CollaboratorsRepository collaboratorsRepository;
     // Tags bucket listener
     private Bucket.Listener<Tag> mTagsMenuUpdater = new Bucket.Listener<Tag>() {
         @Override
@@ -648,16 +652,35 @@ public class NotesActivity extends ThemedAppCompatActivity implements NoteListFr
         }
     }
 
-    private void updateNavigationDrawerItems() {
-        boolean isAlphaSort = PrefUtils.getBoolPref(this, PrefUtils.PREF_SORT_TAGS_ALPHA);
-        Bucket.ObjectCursor<Tag> tagCursor;
-        if (isAlphaSort) {
-            tagCursor = Tag.allSortedAlphabetically(mTagsBucket).execute();
-        } else {
-            tagCursor = Tag.allWithName(mTagsBucket).execute();
+    private List<Tag> getTagsFromCursor(Bucket.ObjectCursor<Tag> tagCursor) {
+        List<Tag> tags = new ArrayList<>();
+        if (tagCursor.getCount() == 0) {
+            return tags;
         }
 
-        mTagsAdapter.changeCursor(tagCursor);
+
+        for (int i = 0; i < tagCursor.getCount(); i++) {
+            tagCursor.moveToNext();
+            Tag tag = tagCursor.getObject();
+            if (!collaboratorsRepository.isValidCollaborator(tag.getName())) {
+                tags.add(tag);
+            }
+        }
+
+        return tags;
+    }
+
+    private void updateNavigationDrawerItems() {
+        boolean isAlphaSort = PrefUtils.getBoolPref(this, PrefUtils.PREF_SORT_TAGS_ALPHA);
+        List<Tag> tags;
+        if (isAlphaSort) {
+            tags = getTagsFromCursor(Tag.allSortedAlphabetically(mTagsBucket).execute());
+        } else {
+            tags = getTagsFromCursor(Tag.allWithName(mTagsBucket).execute());
+        }
+
+        mTagsAdapter.submitList(tags);
+        //mTagsAdapter.changeCursor(tagCursor);
         mNavigationMenu.removeGroup(GROUP_SECONDARY);
         mNavigationMenu.removeGroup(GROUP_TERTIARY);
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/usecases/GetTagsUseCase.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/usecases/GetTagsUseCase.kt
@@ -20,8 +20,6 @@ class GetTagsUseCase @Inject constructor(
     }
 
     fun getTags(note: Note): List<String> {
-        //return note.tags.filter { tag -> !collaboratorsRepository.isValidCollaborator(tag) }
-        // Small patch until we launch collaborator UI
-        return note.tags
+        return note.tags.filter { tag -> !collaboratorsRepository.isValidCollaborator(tag) }
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/usecases/GetTagsUseCase.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/usecases/GetTagsUseCase.kt
@@ -19,6 +19,11 @@ class GetTagsUseCase @Inject constructor(
             .filter { tagItem -> !collaboratorsRepository.isValidCollaborator(tagItem.tag.name) }
     }
 
+    suspend fun searchTags(query: String): List<TagItem> {
+        return tagsRepository.searchTags(query)
+            .filter { tagItem -> !collaboratorsRepository.isValidCollaborator(tagItem.tag.name) }
+    }
+
     fun getTags(note: Note): List<String> {
         return note.tags.filter { tag -> !collaboratorsRepository.isValidCollaborator(tag) }
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
@@ -7,11 +7,15 @@ import com.automattic.simplenote.R
 import com.automattic.simplenote.analytics.AnalyticsTracker
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.repositories.TagsRepository
+import com.automattic.simplenote.usecases.ValidateTagUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class TagDialogViewModel @Inject constructor(private val tagsRepository: TagsRepository) : ViewModel() {
+class TagDialogViewModel @Inject constructor(
+    private val tagsRepository: TagsRepository,
+    private val validateTagUseCase: ValidateTagUseCase
+) : ViewModel() {
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
 
@@ -34,22 +38,19 @@ class TagDialogViewModel @Inject constructor(private val tagsRepository: TagsRep
             return
         }
 
-        if (tagName.isEmpty()) {
-            _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = R.string.tag_error_empty)
-            return
+        when (validateTagUseCase.isTagValid(tagName)) {
+            ValidateTagUseCase.TagValidationResult.TagEmpty ->
+                _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = R.string.tag_error_empty)
+            ValidateTagUseCase.TagValidationResult.TagWithSpaces ->
+                _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = R.string.tag_error_spaces)
+            ValidateTagUseCase.TagValidationResult.TagTooLong ->
+                _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = R.string.tag_error_length)
+            ValidateTagUseCase.TagValidationResult.TagIsCollaborator ->
+                _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = R.string.tag_error_collaborator)
+            ValidateTagUseCase.TagValidationResult.TagExists, // If the tag exists, it will manage in a later stage
+            ValidateTagUseCase.TagValidationResult.TagValid ->
+                _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = null)
         }
-
-        if (tagName.contains(" ")) {
-            _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = R.string.tag_error_spaces)
-            return
-        }
-
-        if (!tagsRepository.isTagValid(tagName)) {
-            _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = R.string.tag_error_length)
-            return
-        }
-
-        _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = null)
     }
 
     fun renameTagIfValid() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagDialogViewModel.kt
@@ -47,7 +47,7 @@ class TagDialogViewModel @Inject constructor(
                 _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = R.string.tag_error_length)
             ValidateTagUseCase.TagValidationResult.TagIsCollaborator ->
                 _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = R.string.tag_error_collaborator)
-            ValidateTagUseCase.TagValidationResult.TagExists, // If the tag exists, it will manage in a later stage
+            ValidateTagUseCase.TagValidationResult.TagExists, // If the tag exists, it will be managed in a later stage
             ValidateTagUseCase.TagValidationResult.TagValid ->
                 _uiState.value = currentUiState.copy(tagName = tagName, errorMsg = null)
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.automattic.simplenote.analytics.AnalyticsTracker
 import com.automattic.simplenote.models.TagItem
 import com.automattic.simplenote.repositories.TagsRepository
+import com.automattic.simplenote.usecases.GetTagsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
@@ -15,7 +16,10 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class TagsViewModel @Inject constructor(private val tagsRepository: TagsRepository) : ViewModel() {
+class TagsViewModel @Inject constructor(
+    private val tagsRepository: TagsRepository,
+    private val getTagsUseCase: GetTagsUseCase
+) : ViewModel() {
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
 
@@ -26,7 +30,7 @@ class TagsViewModel @Inject constructor(private val tagsRepository: TagsReposito
 
     fun start() {
         viewModelScope.launch {
-            val tagItems = tagsRepository.allTags()
+            val tagItems = getTagsUseCase.allTags()
             _uiState.value = UiState(tagItems)
         }
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/TagsViewModel.kt
@@ -45,8 +45,8 @@ class TagsViewModel @Inject constructor(
     }
 
     private suspend fun updateUiState(searchQuery: String?, searchUpdate: Boolean = false) {
-        val tagItems = if (searchQuery == null) tagsRepository.allTags()
-            else tagsRepository.searchTags(searchQuery)
+        val tagItems = if (searchQuery == null) getTagsUseCase.allTags()
+            else getTagsUseCase.searchTags(searchQuery)
 
         _uiState.value = UiState(tagItems, searchUpdate, searchQuery)
     }

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@
     <string name="tag_error_exists">Tag already exists</string>
     <string name="tag_error_length">Tag length too long</string>
     <string name="tag_error_spaces">Tags cannot contain spaces</string>
+    <string name="tag_error_collaborator">Tags cannot be emails. Add them as collaborators</string>
 
     <!-- Undo -->
     <string name="undo">Undo</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -136,7 +136,7 @@
     <string name="tag_error_exists">Tag already exists</string>
     <string name="tag_error_length">Tag length too long</string>
     <string name="tag_error_spaces">Tags cannot contain spaces</string>
-    <string name="tag_error_collaborator">Tags cannot be emails. Add them as collaborators</string>
+    <string name="tag_error_collaborator">Tags cannot be emails</string>
 
     <!-- Undo -->
     <string name="undo">Undo</string>

--- a/Simplenote/src/test/java/com/automattic/simplenote/usecases/GetTagsUseCaseTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/usecases/GetTagsUseCaseTest.kt
@@ -17,6 +17,7 @@ import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.stub
 
@@ -33,7 +34,7 @@ class GetTagsUseCaseTest {
         TagItem(Tag("tag2"), 2),
         TagItem(Tag("tag3"), 5),
         TagItem(Tag("name@example.co.jp"), 2),
-        TagItem(Tag("name1@test.com"), 0),
+        TagItem(Tag("tag@test.com"), 0),
         TagItem(Tag("name@test"), 1),
         TagItem(Tag("あいうえお@example.com"), 1),
     )
@@ -53,7 +54,24 @@ class GetTagsUseCaseTest {
 
         val tagItemsExpected = tagItems.toMutableList()
         tagItemsExpected.removeAt(3) // TagItem(Tag("name@example.co.jp"), 2)
-        tagItemsExpected.removeAt(3) // TagItem(Tag("name1@test.com"), 0)
+        tagItemsExpected.removeAt(3) // TagItem(Tag("tag@test.com"), 0)
+        assertEquals(tagItemsExpected, tagItemsResult)
+    }
+
+    @Test
+    fun searchTagsShouldFilterCollaborators() = runBlockingTest {
+        val searchTagItems = listOf(
+            TagItem(Tag("tag1"), 0),
+            TagItem(Tag("tag2"), 2),
+            TagItem(Tag("tag3"), 5),
+            TagItem(Tag("tag@test.com"), 0),
+        )
+        tagsRepository.stub { onBlocking { searchTags(any()) }.doReturn(searchTagItems) }
+
+        val tagItemsResult = getTagsUseCase.searchTags("tag")
+
+        val tagItemsExpected = searchTagItems.toMutableList()
+        tagItemsExpected.removeAt(3) // TagItem(Tag("tag@test.com"), 0)
         assertEquals(tagItemsExpected, tagItemsResult)
     }
 

--- a/Simplenote/src/test/java/com/automattic/simplenote/usecases/GetTagsUseCaseTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/usecases/GetTagsUseCaseTest.kt
@@ -57,7 +57,6 @@ class GetTagsUseCaseTest {
         assertEquals(tagItemsExpected, tagItemsResult)
     }
 
-    @Ignore("Patch for code freeze")
     @Test
     fun tagsForNoteShouldFilterCollaborators() {
         val note = Note("key1")

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/AddTagViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/AddTagViewModelTest.kt
@@ -68,6 +68,17 @@ class AddTagViewModelTest {
     }
 
     @Test
+    fun validateTagIsCollaborator() {
+        val tagName = "tag1@email.com"
+        `when`(fakeTagsRepository.isTagValid(tagName)).thenReturn(true)
+        `when`(fakeTagsRepository.isTagMissing(tagName)).thenReturn(true)
+
+        viewModel.updateUiState(tagName)
+
+        assertEquals(viewModel.uiState.value?.errorMsg, R.string.tag_error_collaborator)
+    }
+
+    @Test
     fun validateValidTag() {
         val tagName = "tag1"
         `when`(fakeTagsRepository.isTagValid(tagName)).thenReturn(true)

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/AddTagViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/AddTagViewModelTest.kt
@@ -2,8 +2,14 @@ package com.automattic.simplenote.viewmodels
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.automattic.simplenote.R
+import com.automattic.simplenote.models.Note
+import com.automattic.simplenote.repositories.SimperiumCollaboratorsRepository
 import com.automattic.simplenote.repositories.TagsRepository
+import com.automattic.simplenote.usecases.ValidateTagUseCase
 import com.automattic.simplenote.utils.getLocalRandomStringOfLen
+import com.simperium.client.Bucket
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -12,17 +18,15 @@ import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 
-
+@ExperimentalCoroutinesApi
 class AddTagViewModelTest {
     @get:Rule val rule = InstantTaskExecutorRule()
 
-    private lateinit var viewModel: AddTagViewModel
     private val fakeTagsRepository = mock(TagsRepository::class.java)
-
-    @Before
-    fun setup() {
-        viewModel = AddTagViewModel(fakeTagsRepository)
-    }
+    private val notesBucket = mock(Bucket::class.java) as Bucket<Note>
+    private val collaboratorsRepository = SimperiumCollaboratorsRepository(notesBucket, TestCoroutineDispatcher())
+    private val validateTagUseCase = ValidateTagUseCase(fakeTagsRepository, collaboratorsRepository)
+    private val viewModel = AddTagViewModel(fakeTagsRepository, validateTagUseCase)
 
     @Test
     fun startShouldSetupUiState() {

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/AddTagViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/AddTagViewModelTest.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.`when`

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/NoteEditorViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/NoteEditorViewModelTest.kt
@@ -43,7 +43,6 @@ class NoteEditorViewModelTest {
         whenever(tagsRepository.isTagMissing(any())).thenReturn(true)
     }
 
-    @Ignore("Patch for code freeze")
     @Test
     fun updateShouldUpdateUiState() {
         viewModel.update(note)
@@ -52,7 +51,6 @@ class NoteEditorViewModelTest {
         assertEquals(listOf("tag1", "tag2", "name@test.com"), note.tags)
     }
 
-    @Ignore("Patch for code freeze")
     @Test
     fun addTagShouldUpdateUiState() {
         viewModel.addTag("tag3", note)
@@ -61,7 +59,6 @@ class NoteEditorViewModelTest {
         assertEquals(listOf("tag1", "tag2", "name@test.com", "tag3"), note.tags)
     }
 
-    @Ignore("Patch for code freeze")
     @Test
     fun addCollaboratorShouldNotUpdateUiState() {
         viewModel.update(note)
@@ -82,7 +79,6 @@ class NoteEditorViewModelTest {
         assertEquals(NoteEditorEvent.TagAsCollaborator("name@email.com"), viewModel.event.value)
     }
 
-    @Ignore("Patch for code freeze")
     @Test
     fun addInvalidTagShouldNotUpdateUiState() {
         viewModel.update(note)
@@ -103,8 +99,6 @@ class NoteEditorViewModelTest {
         assertEquals(NoteEditorEvent.InvalidTag, viewModel.event.value)
     }
 
-
-    @Ignore("Patch for code freeze")
     @Test
     fun removeTagShouldUpdateUiStateAndNote() {
         viewModel.removeTag("tag2", note)

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
@@ -72,6 +72,17 @@ class TagDialogViewModelTest {
     }
 
     @Test
+    fun validateTagIsCollaborator() {
+        val tagName = "tag1@email.com"
+        `when`(fakeTagsRepository.isTagValid(tagName)).thenReturn(true)
+        `when`(fakeTagsRepository.isTagMissing(tagName)).thenReturn(true)
+
+        viewModel.updateUiState(tagName)
+
+        assertEquals(viewModel.uiState.value?.errorMsg, R.string.tag_error_collaborator)
+    }
+
+    @Test
     fun validateValidTag() {
         val hewTagName = "tag2"
         `when`(fakeTagsRepository.isTagValid(hewTagName)).thenReturn(true)

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
@@ -2,9 +2,15 @@ package com.automattic.simplenote.viewmodels
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.automattic.simplenote.R
+import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.models.Tag
+import com.automattic.simplenote.repositories.SimperiumCollaboratorsRepository
 import com.automattic.simplenote.repositories.TagsRepository
+import com.automattic.simplenote.usecases.ValidateTagUseCase
 import com.automattic.simplenote.utils.getLocalRandomStringOfLen
+import com.simperium.client.Bucket
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -12,25 +18,23 @@ import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 
-
+@ExperimentalCoroutinesApi
 class TagDialogViewModelTest {
     @get:Rule val rule = InstantTaskExecutorRule()
 
-    private lateinit var viewModel: TagDialogViewModel
     private val fakeTagsRepository = mock(TagsRepository::class.java)
+    private val notesBucket = mock(Bucket::class.java) as Bucket<Note>
+    private val collaboratorsRepository = SimperiumCollaboratorsRepository(notesBucket, TestCoroutineDispatcher())
+    private val validateTagUseCase = ValidateTagUseCase(fakeTagsRepository, collaboratorsRepository)
+    private val viewModel = TagDialogViewModel(fakeTagsRepository, validateTagUseCase)
     private val tagName = "tag1"
-    private lateinit var tag: Tag
-
-    @Before
-    fun setup() {
-        viewModel = TagDialogViewModel(fakeTagsRepository)
+    private val tag = Tag(tagName).apply {
+        name = tagName
+        index = 0
     }
 
     @Before
-    fun setupInitialTag() {
-        tag = Tag(tagName)
-        tag.name = tagName
-        tag.index = 0
+    fun setup() {
         viewModel.start(tag)
     }
 

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
@@ -93,20 +93,22 @@ class TagsViewModelTest {
         assertEquals(viewModel.uiState.value?.searchUpdate, false)
         assertNull(viewModel.uiState.value?.searchQuery)
 
-        variableTagItems.add(TagItem(Tag("tag6"), 3))
+        val newTag = TagItem(Tag("tag6"), 3)
+        variableTagItems.add(newTag)
         fakeTagsRepository.stub {
             onBlocking { allTags() }.doReturn(variableTagItems)
         }
         tagsFlow.emit(true)
 
-        assertEquals(viewModel.uiState.value?.tagItems, variableTagItems)
+        val expectedVariableTags = expectedTagItems + listOf(newTag)
+        assertEquals(viewModel.uiState.value?.tagItems, expectedVariableTags)
         assertEquals(viewModel.uiState.value?.searchUpdate, false)
         assertNull(viewModel.uiState.value?.searchQuery)
     }
 
     @Test
     fun whenPauseIsCalledAllChangedToTagsAreNotListened() = runBlockingTest {
-        val variableTagItems = tagItems.toMutableList()
+        val variableTagItems = expectedTagItems.toMutableList()
         fakeTagsRepository.stub {
             onBlocking { allTags() }.doReturn(tagItems)
         }


### PR DESCRIPTION
Fixes #1480

### Fix

This PR makes a series of fixes to make the tag screens consistent with the dedicated UI for collaboration added in #1476. The changes are the following:

- Left panel (navigation drawer) filters out tags that are collaborators (emails)

| Before      | After |
| ----------- | ----------- |
| ![](https://d.pr/i/ZW14eJ+.jpg)      | ![](https://d.pr/i/2AMksx+.jpg)       |

- The list of tags (in the Edit Tags screen) filters out tags that are collaborators (emails)  

| Before      | After |
| ----------- | ----------- |
| ![](https://d.pr/i/3XJUBU+.jpg)      | ![](https://d.pr/i/HbIxq6+.jpg)       |



- If you try to add an email as a tag from the list of tags (in the Edit Tags screen), it shows an error

| Before      | After |
| ----------- | ----------- |
| ![](https://d.pr/i/WHYWgw+.jpg)      | ![](https://d.pr/i/KHmTF3+.jpg)       |



- If you try to edit a tag as an email from the list of tags (in the Edit Tags screen), it shows an error

| Before      | After |
| ----------- | ----------- |
| ![](https://d.pr/i/V9bafO+.jpg)      | ![](https://d.pr/i/mIXQm4+.jpg)       |



### Test

1. Go to a note
2. Tap on the tags field at the bottom and add a couple of tags
3. Tap on (...) button at the top right corner and tap on Collaborators
4. Add a couple of collaborators
5. Go back to edit the note
6. Go back to the list of notes
7. Open the left panel. Just the tags and not the emails should be shown
8. Tap on one of the tags and the list of notes should be filtered by the notes that have that tag.
9. Tap on All Note and the list of notes should be filtered to all notes
8. Tap on `EDIT` button on the left panel
9. Just the tags and not the emails should be shown
10. Try to add a tag
11. Try to add an email on the `Add Tag` form. It should show an error
12. Go back and dismiss the dialog
13. Tap on one of the tags on the list
14. Try to edit the tag and write it as an email on the `Edit Tag` form. It should show an error
12. Go back and dismiss the dialog

### Review

Only one developer and one designer are required to review these changes, but anyone can perform the review.


### Release

`RELEASE-NOTES.txt` was updated in  aa5c545f2c1bd35deebdb2c56cb8154c2cb5bf93 with:
> [Internal] Updated list of tags to filter out collaborators (emails)
