### PR TITLE
Fix case in delete account button in settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * Added collaboration status indicator to the note list [#1499](https://github.com/Automattic/simplenote-android/pull/1499)
 * Fixed crash when note reference is null in editor while hiding toolbar in landscape mode [#1504](https://github.com/Automattic/simplenote-android/pull/1504)
 * [Internal] Updated list of tags to filter out collaborators (emails) [#1509](https://github.com/Automattic/simplenote-android/pull/1509)
+* Fixed case in delete account button in settings [#1512](https://github.com/Automattic/simplenote-android/pull/1512)
 
 2.22
 -----

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="share">Share</string>
     <string name="new_note">New Note</string>
     <string name="account">Account</string>
-    <string name="delete_account">Delete Account</string>
+    <string name="delete_account">Delete account</string>
     <string name="delete_account_email_message">By deleting the account for email %1$s, all notes created with this account will be permanently deleted. This action is not reversible.</string>
     <string name="request_received">Request Received</string>
     <string name="account_deletion_message">An email was sent to %1$s. Check your inbox and follow the instructions to confirm account deletion.\n\nYour account won\'t be deleted until we receive your confirmation.</string>


### PR DESCRIPTION
Fixes #1511.

### Fix

Following the format of titles in settings options, `Delete Account` should be changed to `Delete account`.

| Settings Screen      | Delete account dialog |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/195721/135136228-b5b9a6c9-3157-40dc-bb65-726c1a5827a7.png)      | ![image](https://user-images.githubusercontent.com/195721/135136533-408424df-ac94-4590-b8bb-2e4e1b204fa5.png)       |

### Test

1. Open the left panel and tap on Settings
2. Scroll down and see `Delete account`
3. Tap on `Delete account` option and see dialog

### Review
Only one designer is required to review these changes, but anyone can perform the review.


### Release
`RELEASE-NOTES.txt` was updated in f67e53a3f230d7b00345e8ac54dee3c40d68f519 with:
> Fixed case in delete account button in settings
