### PR TITLE
Update error handling in login to handle 429 response (too many wrong credentials at login)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * Fixed crash when note reference is null in editor while hiding toolbar in landscape mode [#1504](https://github.com/Automattic/simplenote-android/pull/1504)
 * [Internal] Updated list of tags to filter out collaborators (emails) [#1509](https://github.com/Automattic/simplenote-android/pull/1509)
 * Fixed case in delete account button in settings [#1512](https://github.com/Automattic/simplenote-android/pull/1512)
+* Added error handling for when the user has made too many wrong credential requests at login [#1514](https://github.com/Automattic/simplenote-android/pull/1514)
 
 2.22
 -----

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
-    implementation 'com.automattic:simperium:243-47016828510f59eb4c58fb4c4cebf765ca714294'
+    implementation 'com.automattic:simperium:develop-86ea7abdda7aece428ca5144a0a099b727b2473e'
     implementation 'com.github.Automattic:Automattic-Tracks-Android:2.1.0'
     implementation 'org.wordpress:passcodelock:2.0.2'
 

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
-    implementation 'com.automattic:simperium:v1.0.0'
+    implementation 'com.automattic:simperium:243-47016828510f59eb4c58fb4c4cebf765ca714294'
     implementation 'com.github.Automattic:Automattic-Tracks-Android:2.1.0'
     implementation 'org.wordpress:passcodelock:2.0.2'
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteCredentialsActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteCredentialsActivity.java
@@ -44,6 +44,9 @@ public class SimplenoteCredentialsActivity extends CredentialsActivity {
                                 case UNVERIFIED_ACCOUNT:
                                     showUnverifiedAccountDialog();
                                     break;
+                                case TOO_MANY_REQUESTS:
+                                    showDialogError(getString(R.string.simperium_too_many_attempts));
+                                    break;
                                 case INVALID_ACCOUNT:
                                 default:
                                     showDialogError(getString(

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -429,4 +429,5 @@
     <string name="simperium_not_now">Cancel</string>
     <string name="simperium_change_password">Change Password</string>
     <string name="simperium_okay">Okay</string>
+    <string name="simperium_too_many_attempts">Too many log in attempts. Try again later.</string>
 </resources>


### PR DESCRIPTION
Fixes #1513.

### Fix
 
Currently, Simperium doesn't handle the error code `429` which represents the user is temporarily blocked because too many failed attempts to log in.

#### Expected Behavior

The expected behavior is to show the user a specific error message for this error: `Too many log in attempts. Try again later.`

#### Current Behavior

The user sees the wrong credentials default error.

### Test
1. Go to login
2. Try to introduce wrong credentials 5 to 10 times
3. See error

![image](https://user-images.githubusercontent.com/195721/135494046-f6d2b1fe-5e82-42cb-86c7-8f454e64431e.png)


### Review

Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 268445185fcf5f580cdd5989e07e6b313d851b9f with:
> Added error handling for when the user has made too many wrong credential requests at login
