### PR TITLE
Inject CrashLogging into the main application

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -28,6 +28,7 @@ import androidx.work.NetworkType;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
 
+import com.automattic.android.tracks.crashlogging.CrashLogging;
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.analytics.AnalyticsTrackerNosara;
 import com.automattic.simplenote.models.Account;
@@ -60,6 +61,8 @@ import java.util.concurrent.TimeUnit;
 
 import dagger.hilt.android.HiltAndroidApp;
 
+import javax.inject.Inject;
+
 @HiltAndroidApp
 public class Simplenote extends Application implements HeartbeatListener {
     public static final String DELETED_NOTE_ID = "deletedNoteId";
@@ -89,6 +92,10 @@ public class Simplenote extends Application implements HeartbeatListener {
     private Runnable mHeartbeatRunnable;
     private Simperium mSimperium;
     private boolean mIsInBackground = true;
+
+    //Do not remove, it's needed for Sentry initialization
+    @Inject
+    CrashLogging crashLogging;
 
     public void onCreate() {
         super.onCreate();


### PR DESCRIPTION
### Description

This PR resolves an issue of not initialising Sentry SDK and therefore - not catching crashes and unhandled exceptions.

### Reason

Because `CrashLogging` (contrary to WordPress and WooCommerce) wasn't injected anywhere, the constructor of `SentryCrashLogging` wasn't called and therefore - Sentry wasn't initialised. This is very hidden and easy to miss - I've already created an issue to improve API of Tracks: https://github.com/Automattic/Automattic-Tracks-Android/issues/103

### Test
<!--
***(Required)*** List the steps to test the behavior.  For example:
1. Go to...
2. Tap on...
3. See error...
-->
1. Apply PATCH available at the bottom.
2. Run the app
3. Go to edit tags activity
4. Click return back
5. **Assert that app crashed**
6. Run the app again
7. Open Sentry dashboard
8. **Assert there's `This is an unhandled exception`** issue


```
Index: Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.kt b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.kt
--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.kt	(revision a0416bc9c9afc9c6c8160ddc639ae37d864c363d)
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.kt	(date 1634050316642)
@@ -182,6 +182,7 @@
     public override fun onPause() {
         super.onPause()
         viewModel.stopListeningTagChanges()
+        throw Exception("This is an unhandled exception")
     }
 
     @Suppress("DEPRECATION")
```
