### PR TITLE
Add query in AndroidManifest to support resolving browsers

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
+2.24.1
+-----
+* Fixed links not opening in browser [#1553](https://github.com/Automattic/simplenote-android/pull/1553)
+
 2.24
 -----
-
+* Fixed problem with login [#1549](https://github.com/Automattic/simplenote-android/pull/1549)
 
 2.23
 -----

--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -10,6 +10,15 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- Add query to support resolving browser Intents -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
     <application
         android:name="com.automattic.simplenote.Simplenote"
         android:allowBackup="true"


### PR DESCRIPTION
Fixes #1551.

### Fix
With the upgrade to `targetSdkVersion 30`, we can't longer use `Intent.resolveActivity(...)` without some queries declarations in the `AndroidManifest.xml`. This PR adds queries to support resolving browsers. 

### Test

1. Go to a note
2. Add link, raw link and markdown links
3. Tap on the link and try to open it in a browser (use the button on the top bar)
4. The link should be opened in the browser. 


### Review
Only one developer is required to review these changes, but anyone can perform the review.


### Release
`RELEASE-NOTES.txt` was updated in a4f623e8be8c536c707b4b911fc174b98a8a1977 with:
> Fixed links not opening in browser