### PR TITLE
Add cross platform IAP status sync and tracking.

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesActivity.java
@@ -10,21 +10,25 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.Preference;
 
 import com.automattic.simplenote.billing.SubscriptionBottomSheetDialog;
+import com.automattic.simplenote.models.Preferences;
 import com.automattic.simplenote.utils.BrowserUtils;
-import com.automattic.simplenote.utils.PrefUtils;
 import com.automattic.simplenote.viewmodels.IapViewModel;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.android.material.snackbar.Snackbar;
+import com.simperium.client.Bucket;
+import com.simperium.client.BucketObjectMissingException;
 
 import org.wordpress.passcodelock.PasscodePreferenceFragment;
 import org.wordpress.passcodelock.PasscodePreferenceFragmentCompat;
 
 import static com.automattic.simplenote.PreferencesFragment.WEB_APP_URL;
+import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
 import static com.automattic.simplenote.utils.DisplayUtils.disableScreenshotsIfLocked;
 
 public class PreferencesActivity extends ThemedAppCompatActivity {
     private PasscodePreferenceFragmentCompat mPasscodePreferenceFragment;
     private PreferencesFragment mPreferencesFragment;
+    private Bucket<Preferences> mPreferencesBucket;
 
     private IapViewModel mViewModel;
 
@@ -49,47 +53,60 @@ public class PreferencesActivity extends ThemedAppCompatActivity {
         mIapBanner = findViewById(R.id.iap_banner);
         mIapThankYouBanner = findViewById(R.id.iap_thank_you_banner);
 
-        if (!PrefUtils.isSubscriptionActive(this)) {
-            mIapThankYouBanner.setVisibility(View.GONE);
+        Simplenote currentApp = (Simplenote) getApplication();
+        mPreferencesBucket = currentApp.getPreferencesBucket();
 
-            mViewModel = new ViewModelProvider(this).get(IapViewModel.class);
+        try {
+            if (mPreferencesBucket.get(PREFERENCES_OBJECT_KEY).getCurrentSubscriptionPlatform() == null) {
+                mIapThankYouBanner.setVisibility(View.GONE);
 
-            findViewById(R.id.iap_banner).setOnClickListener(view -> mViewModel.onIapBannerClicked());
+                mViewModel = new ViewModelProvider(this).get(IapViewModel.class);
 
-            mViewModel.getPlansBottomSheetVisibility().observe(this, isVisible -> {
-                BottomSheetDialogFragment fragment = (BottomSheetDialogFragment) getSupportFragmentManager().findFragmentByTag(SubscriptionBottomSheetDialog.getTAG());
-                if (isVisible) {
-                    if (fragment == null) {
-                        fragment = new SubscriptionBottomSheetDialog();
+                findViewById(R.id.iap_banner).setOnClickListener(view -> mViewModel.onIapBannerClicked());
+
+                mViewModel.getPlansBottomSheetVisibility().observe(this, isVisible -> {
+                    BottomSheetDialogFragment fragment = (BottomSheetDialogFragment) getSupportFragmentManager().findFragmentByTag(SubscriptionBottomSheetDialog.getTAG());
+                    if (isVisible) {
+                        if (fragment == null) {
+                            fragment = new SubscriptionBottomSheetDialog();
+                        }
+                        if (!(fragment.getDialog() != null && fragment.getDialog().isShowing())) {
+                            fragment.show(getSupportFragmentManager(), SubscriptionBottomSheetDialog.getTAG());
+                        }
+                    } else {
+                        if (fragment != null && fragment.isVisible()) {
+                            fragment.dismiss();
+                        }
                     }
-                    if (!(fragment.getDialog() != null && fragment.getDialog().isShowing())) {
-                        fragment.show(getSupportFragmentManager(), SubscriptionBottomSheetDialog.getTAG());
-                    }
-                } else {
-                    if (fragment != null && fragment.isVisible()) {
-                        fragment.dismiss();
-                    }
-                }
-            });
+                });
 
-            mViewModel.getSnackbarMessage().observe(this, message -> {
-                Snackbar.make(findViewById(R.id.main_parent_view), message.getMessageResId(), Snackbar.LENGTH_SHORT).show();
-            });
+                mViewModel.getSnackbarMessage().observe(this, message -> {
+                    Snackbar.make(findViewById(R.id.main_parent_view), message.getMessageResId(), Snackbar.LENGTH_SHORT).show();
+                });
 
-            mViewModel.getIapBannerVisibility().observe(this, isVisible -> {
-                if (isVisible) {
-                    mIapBanner.setVisibility(View.GONE);
-                    mIapBanner.setVisibility(View.VISIBLE);
-                } else {
-                    mIapBanner.setVisibility(View.GONE);
-                    if (PrefUtils.isSubscriptionActive(this)){
-                        mIapThankYouBanner.setVisibility(View.VISIBLE);
+                mViewModel.getIapBannerVisibility().observe(this, isVisible -> {
+                    if (isVisible) {
+                        mIapBanner.setVisibility(View.GONE);
+                        mIapBanner.setVisibility(View.VISIBLE);
+                    } else {
+                        mIapBanner.setVisibility(View.GONE);
+                        try {
+                            if (mPreferencesBucket.get(PREFERENCES_OBJECT_KEY)
+                                    .getCurrentSubscriptionPlatform() != null) {
+                                mIapThankYouBanner.setVisibility(View.VISIBLE);
+                            }
+                        } catch (BucketObjectMissingException e) {
+                            mIapThankYouBanner.setVisibility(View.GONE);
+                        }
                     }
-                }
-            });
-        } else {
+                });
+            } else {
+                mIapBanner.setVisibility(View.GONE);
+                mIapThankYouBanner.setVisibility(View.VISIBLE);
+            }
+        } catch (BucketObjectMissingException e) {
             mIapBanner.setVisibility(View.GONE);
-            mIapThankYouBanner.setVisibility(View.VISIBLE);
+            mIapThankYouBanner.setVisibility(View.GONE);
         }
 
         String preferencesTag = "tag_preferences";

--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
@@ -65,7 +65,7 @@ public final class AnalyticsTracker {
         }
     }
 
-    public void track(Stat stat) {
+    public static void track(Stat stat) {
         if (!Simplenote.analyticsIsEnabled()) {
             return;
         }
@@ -75,7 +75,7 @@ public final class AnalyticsTracker {
         }
     }
 
-    public void track(Stat stat, Map<String, ?> properties) {
+    public static void track(Stat stat, Map<String, ?> properties) {
         if (!Simplenote.analyticsIsEnabled()) {
             return;
         }
@@ -172,7 +172,12 @@ public final class AnalyticsTracker {
         VERIFICATION_CHANGE_EMAIL_BUTTON_TAPPED,
         VERIFICATION_RESEND_EMAIL_BUTTON_TAPPED,
         VERIFICATION_DISMISSED,
-        SETTINGS_SEARCH_SORT_MODE
+        SETTINGS_SEARCH_SORT_MODE,
+        IAP_MONTHLY_BUTTON_TAPPED,
+        IAP_YEARLY_BUTTON_TAPPED,
+        IAP_UNKNOWN_BUTTON_TAPPED, // for other subscription duration options from Play Store not specifically handled in the client
+        IAP_PURCHASE_COMPLETED,
+        IAP_PLANS_DIALOG_DISMISSED
     }
 
     public interface Tracker {

--- a/Simplenote/src/main/java/com/automattic/simplenote/billing/SubscriptionBottomSheetDialog.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/billing/SubscriptionBottomSheetDialog.kt
@@ -1,5 +1,6 @@
 package com.automattic.simplenote.billing
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -10,13 +11,13 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.automattic.simplenote.BottomSheetDialogBase
 import com.automattic.simplenote.R
+import com.automattic.simplenote.analytics.AnalyticsTracker
 import com.automattic.simplenote.databinding.BottomSheetSubscriptionsBinding
 import com.automattic.simplenote.viewmodels.IapViewModel
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
 class SubscriptionBottomSheetDialog : BottomSheetDialogBase() {
-
     private lateinit var viewModel: IapViewModel
 
     override fun onCreateView(
@@ -69,8 +70,13 @@ class SubscriptionBottomSheetDialog : BottomSheetDialogBase() {
         }
     }
 
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        AnalyticsTracker.track(AnalyticsTracker.Stat.IAP_PLANS_DIALOG_DISMISSED)
+    }
+
     companion object {
         @JvmStatic
-        val TAG = SubscriptionBottomSheetDialog::class.java.simpleName
+        val TAG: String = SubscriptionBottomSheetDialog::class.java.simpleName
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/billing/SubscriptionDurationAdapter.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/billing/SubscriptionDurationAdapter.kt
@@ -42,7 +42,7 @@ class SubscriptionDurationAdapter :
             planPrice.text = uiState.price
 
             container.setOnClickListener {
-                uiState.onTapListener.invoke(uiState.offerId)
+                uiState.onTapListener.invoke(uiState.offerId, uiState.tracker)
             }
         }
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
@@ -18,6 +18,10 @@ public class Preferences extends BucketObject {
     private static final String ANALYTICS_ENABLED_KEY = "analytics_enabled";
     private static final String RECENT_SEARCHES_KEY = "recent_searches";
 
+    private static final String SUBSCRIPTION_LEVEL_KEY = "subscription_level";
+    private static final String SUBSCRIPTION_PLATFORM_KEY = "subscription_platform";
+    private static final String SUBSCRIPTION_DATE_KEY = "subscription_date";
+
     private Preferences(String key, JSONObject properties) {
         super(key, properties);
     }
@@ -73,6 +77,45 @@ public class Preferences extends BucketObject {
         setProperty(RECENT_SEARCHES_KEY, new JSONArray(recents));
     }
 
+    public void setActiveSubscription(long purchaseTime){
+        setSubscriptionPlatform(Preferences.SubscriptionPlatform.ANDROID);
+        setSubscriptionLevel(Preferences.SubscriptionLevel.SUSTAINER);
+        setSubscriptionDate(purchaseTime);
+        save();
+    }
+
+    public void removeActiveSubscription(){
+        setSubscriptionPlatform(SubscriptionPlatform.NONE);
+        setSubscriptionLevel(SubscriptionLevel.NONE);
+        setSubscriptionDate(null);
+        save();
+    }
+
+    public SubscriptionPlatform getCurrentSubscriptionPlatform() {
+        Object subscriptionPlatform = getProperty(SUBSCRIPTION_PLATFORM_KEY);
+        if (subscriptionPlatform == null) {
+            return null;
+        }
+
+        if (subscriptionPlatform instanceof String) {
+            return SubscriptionPlatform.fromString((String) subscriptionPlatform);
+        } else {
+            return null;
+        }
+    }
+
+    public void setSubscriptionDate(Long subscriptionDate) {
+        setProperty(SUBSCRIPTION_DATE_KEY, subscriptionDate);
+    }
+
+    public void setSubscriptionPlatform(SubscriptionPlatform subscriptionPlatform) {
+        setProperty(SUBSCRIPTION_PLATFORM_KEY, subscriptionPlatform.platformName);
+    }
+
+    public void setSubscriptionLevel(SubscriptionLevel subscriptionLevel) {
+        setProperty(SUBSCRIPTION_LEVEL_KEY, subscriptionLevel.getName());
+    }
+
     public static class Schema extends BucketSchema<Preferences> {
 
         public Schema() {
@@ -89,6 +132,61 @@ public class Preferences extends BucketObject {
 
         public void update(Preferences prefs, JSONObject properties) {
             prefs.setProperties(properties);
+        }
+    }
+
+    public enum SubscriptionPlatform {
+        ANDROID("android"),
+        IOS("iOS"),
+        WEB("WEB"),
+        NONE(null);
+
+        private final String platformName;
+
+        SubscriptionPlatform(final String platform) {
+            this.platformName = platform;
+        }
+
+        public String getName() {
+            return platformName;
+        }
+
+        public static SubscriptionPlatform fromString(String platformName) {
+            if (platformName != null) {
+                for (SubscriptionPlatform platform : SubscriptionPlatform.values()) {
+                    if (platformName.equalsIgnoreCase(platform.getName())) {
+                        return platform;
+                    }
+                }
+            }
+            return null;
+        }
+
+    }
+
+    public enum SubscriptionLevel {
+        SUSTAINER("sustainer"),
+        NONE(null);
+
+        private final String subscriptionLevel;
+
+        SubscriptionLevel(final String level) {
+            this.subscriptionLevel = level;
+        }
+
+        public String getName() {
+            return subscriptionLevel;
+        }
+
+        public static SubscriptionLevel fromString(String level) {
+            if (level != null) {
+                for (SubscriptionLevel subscriptionLevel : SubscriptionLevel.values()) {
+                    if (level.equalsIgnoreCase(subscriptionLevel.getName())) {
+                        return subscriptionLevel;
+                    }
+                }
+            }
+            return null;
         }
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -87,9 +87,6 @@ public class PrefUtils {
     // string. Store notes linked to note widget instances.
     public static final String PREF_NOTE_WIDGET_NOTE = "pref_key_note_widget_";
 
-    // boolean. determines if analytics is enabled
-    public static final String PREF_ACTIVE_SUBSCRIPTION = "pref_key_active_subscription";
-
     public static final String ALPHABETICAL_ASCENDING_LABEL = "alphabetical_az";
     public static final String ALPHABETICAL_DESCENDING_LABEL = "alphabetical_za";
     public static final String DATE_CREATED_ASCENDING_LABEL = "created_oldest";
@@ -176,14 +173,6 @@ public class PrefUtils {
 
     public static void setIsPremium(Context context, boolean isPremium) {
         getPrefs(context).edit().putBoolean(PREF_PREMIUM, isPremium).apply();
-    }
-
-    public static boolean isSubscriptionActive(Context context) {
-        return getPrefs(context).getBoolean(PREF_ACTIVE_SUBSCRIPTION, false);
-    }
-
-    public static void setIsSubscriptionActive(Context context, boolean isActive) {
-        getPrefs(context).edit().putBoolean(PREF_ACTIVE_SUBSCRIPTION, isActive).apply();
     }
 
     public static int getLayoutWidget(Context context, boolean isLight) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/IapViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/IapViewModel.kt
@@ -128,7 +128,7 @@ class IapViewModel(application: Application) :
                     val preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
                     preferences.removeActiveSubscription()
                 }
-
+                updateIapBannerVisibility()
             } else {
                 Log.e(TAG, billingResult.debugMessage)
             }

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/IapViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/IapViewModel.kt
@@ -289,10 +289,10 @@ class IapViewModel(application: Application) :
     }
 
     private fun doesNotHaveSubscriptionOnOtherPlatforms(): Boolean {
-        val preference = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
+        val preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
 
-        preference?.let {
-            val currentSubscriptionPlatform = preference.currentSubscriptionPlatform
+        preferences?.let {
+            val currentSubscriptionPlatform = preferences.currentSubscriptionPlatform
 
             return currentSubscriptionPlatform == null
                     || currentSubscriptionPlatform == Preferences.SubscriptionPlatform.ANDROID
@@ -317,8 +317,8 @@ class IapViewModel(application: Application) :
     }
 
     private fun updateIapBannerVisibility() = try {
-        val preference: Preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
-        if (preference.currentSubscriptionPlatform != null) {
+        val preferences: Preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
+        if (preferences.currentSubscriptionPlatform != null) {
             _iapBannerVisibility.postValue(false)
         } else {
             _iapBannerVisibility.postValue(true)

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/IapViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/IapViewModel.kt
@@ -9,10 +9,16 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.android.billingclient.api.*
 import com.automattic.simplenote.R
-import com.automattic.simplenote.utils.PrefUtils
+import com.automattic.simplenote.Simplenote
+import com.automattic.simplenote.analytics.AnalyticsTracker
+import com.automattic.simplenote.models.Preferences
+import com.simperium.client.Bucket
+import com.simperium.client.BucketObjectMissingException
 
 class IapViewModel(application: Application) :
-    AndroidViewModel(application), PurchasesUpdatedListener, ProductDetailsResponseListener {
+    AndroidViewModel(application), PurchasesUpdatedListener, ProductDetailsResponseListener,
+    Bucket.OnNetworkChangeListener<Preferences>, Bucket.OnSaveObjectListener<Preferences>,
+    Bucket.OnDeleteObjectListener<Preferences> {
     private val billingClient = BillingClient.newBuilder(application)
         .setListener(this)
         .enablePendingPurchases()
@@ -33,13 +39,18 @@ class IapViewModel(application: Application) :
     private val _snackbarMessage = SingleLiveEvent<IapSnackbarMessage>()
     val snackbarMessage: LiveData<IapSnackbarMessage> = _snackbarMessage
 
+    private val preferencesBucket = getApplication<Simplenote>().preferencesBucket
+
     init {
+        preferencesBucket.addOnNetworkChangeListener(this)
+        preferencesBucket.addOnSaveObjectListener(this)
+        preferencesBucket.addOnDeleteObjectListener(this)
         startBillingConnection()
     }
 
     private val productDetails = ArrayList<ProductDetails>()
 
-    var isStarted: Boolean = false
+    private var isStarted: Boolean = false
 
     fun start() {
         if (isStarted) {
@@ -57,7 +68,8 @@ class IapViewModel(application: Application) :
         queryProductDetails()
     }
 
-    private fun onPlanSelected(offerToken: String) {
+    private fun onPlanSelected(offerToken: String, tracker: AnalyticsTracker.Stat) {
+        AnalyticsTracker.track(tracker)
         _onPurchaseRequest.postValue(offerToken)
         _plansBottomSheetVisibility.postValue(false)
     }
@@ -109,8 +121,14 @@ class IapViewModel(application: Application) :
         ) { billingResult, purchaseList ->
             if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
                 val hasActiveSubscription = purchaseList.isNotEmpty()
-                PrefUtils.setIsSubscriptionActive(getApplication(), hasActiveSubscription)
-                _iapBannerVisibility.postValue(!hasActiveSubscription)
+                if (hasActiveSubscription && doesNotHaveSubscriptionOnOtherPlatforms()) {
+                    val preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
+                    preferences.setActiveSubscription(purchaseList.first().purchaseTime / 1000)
+                } else if (doesNotHaveSubscriptionOnOtherPlatforms()) {
+                    val preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
+                    preferences.removeActiveSubscription()
+                }
+
             } else {
                 Log.e(TAG, billingResult.debugMessage)
             }
@@ -151,8 +169,15 @@ class IapViewModel(application: Application) :
                     if (billingResult.responseCode == BillingClient.BillingResponseCode.OK &&
                         it.purchaseState == Purchase.PurchaseState.PURCHASED
                     ) {
-                        PrefUtils.setIsSubscriptionActive(getApplication(), true)
-                        _iapBannerVisibility.postValue(false)
+                        val product = purchase.packageName + "." + purchase.products.firstOrNull()
+                        AnalyticsTracker.track(
+                            AnalyticsTracker.Stat.IAP_PURCHASE_COMPLETED,
+                            mapOf("product" to product)
+                        )
+
+                        val preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
+                        preferences.setActiveSubscription(purchase.purchaseTime / 1000)
+
                         _snackbarMessage.postValue(IapSnackbarMessage(R.string.subscription_purchase_success))
                     } else {
                         _snackbarMessage.postValue(IapSnackbarMessage(R.string.subscription_purchase_error))
@@ -204,6 +229,10 @@ class IapViewModel(application: Application) :
                                     .pricingPhaseList.first().billingPeriod
                             ),
                             price = offerDetails.pricingPhases.pricingPhaseList.first().formattedPrice,
+                            tracker = periodCodeToTracker(
+                                offerDetails.pricingPhases
+                                    .pricingPhaseList.first().billingPeriod
+                            ),
                             onTapListener = this::onPlanSelected
                         )
                     }
@@ -233,11 +262,20 @@ class IapViewModel(application: Application) :
         }
     }
 
+    private fun periodCodeToTracker(code: String): AnalyticsTracker.Stat {
+        return when (code) {
+            "P1M" -> AnalyticsTracker.Stat.IAP_MONTHLY_BUTTON_TAPPED
+            "P1Y" -> AnalyticsTracker.Stat.IAP_YEARLY_BUTTON_TAPPED
+            else -> AnalyticsTracker.Stat.IAP_UNKNOWN_BUTTON_TAPPED
+        }
+    }
+
     data class PlansListItem(
         val offerId: String,
         @StringRes val period: Int,
         val price: String,
-        val onTapListener: ((String) -> Unit)
+        val tracker: AnalyticsTracker.Stat,
+        val onTapListener: ((String, AnalyticsTracker.Stat) -> Unit)
     )
 
     data class IapSnackbarMessage(@StringRes val messageResId: Int)
@@ -248,5 +286,44 @@ class IapViewModel(application: Application) :
         private const val SUSTAINER_SUB_PRODUCT = "sustainer_subscription"
 
         private val LIST_OF_PRODUCTS = listOf(SUSTAINER_SUB_PRODUCT)
+    }
+
+    private fun doesNotHaveSubscriptionOnOtherPlatforms(): Boolean {
+        val preference = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
+
+        preference?.let {
+            val currentSubscriptionPlatform = preference.currentSubscriptionPlatform
+
+            return currentSubscriptionPlatform == null
+                    || currentSubscriptionPlatform == Preferences.SubscriptionPlatform.ANDROID
+        }
+        return false
+    }
+
+    override fun onNetworkChange(
+        bucket: Bucket<Preferences>?,
+        type: Bucket.ChangeType?,
+        key: String?
+    ) {
+        updateIapBannerVisibility()
+    }
+
+    override fun onSaveObject(bucket: Bucket<Preferences>?, `object`: Preferences?) {
+        updateIapBannerVisibility()
+    }
+
+    override fun onDeleteObject(bucket: Bucket<Preferences>?, `object`: Preferences?) {
+        updateIapBannerVisibility()
+    }
+
+    private fun updateIapBannerVisibility() = try {
+        val preference: Preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
+        if (preference.currentSubscriptionPlatform != null) {
+            _iapBannerVisibility.postValue(false)
+        } else {
+            _iapBannerVisibility.postValue(true)
+        }
+    } catch (ignore: BucketObjectMissingException) {
+        _iapBannerVisibility.postValue(false)
     }
 }


### PR DESCRIPTION
This PR adds some tracking and a subscription status sync using Symperium. We are using existing Preferences bucket, to which we added subscription related fields.

Simperium has a totaly different mindset when it comes to networking, so I'm not sure I utilized it in the best possible way, but it works so far.

Before testing:

- Make sure you are logged in to the latest version of Play Store.
- Make sure you are using release version of the app (or the debug version without .debug preffix).
- Let me know what account you will be using for purchase testing so I can add it in Play Store. This will allow you to use test cards.
- Subscriptions renew every five minutes. You can cancel them from Subscription screen of Play Store.


Since we are using Simperium bucket to determine visibility of IAP banner the testing steps are mostly the same:
- Test purchase flow from sidebar with working test card. Confirm that after purchase is successful, "Thank you!" snackbar appears, Sustainer banner is not visible in sidebar, and black "Thank you" banner is visible in settings.
- Test purchase flow from Settings screen with working test card. Confirm that after purchase is successful, "Thank you!" snackbar appears, Sustainer banner is replaced with "Thank you" banner in Settings screen and it is not visible in Sidebar.
- Confirm that the subscription and banner visibility status remains the same after app is reinstalled.
- Cancel Subscription in Play store and confirm that the IAP banner is visible in the sidebar and Settings screen.

I completed the cross-platform testing part with Jorge and confirmed that it works as expected.
