### PR TITLE
Upgrade  tagetSdkVersion to Android 31

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.24.2
 -----
 * Added ability to purchase a Simplenote Sustainer subscription [#1567](https://github.com/Automattic/simplenote-android/pull/1567)
+* [Internal] Upgrade to targetSdkVersion 31 (Android 31) [#1571](https://github.com/Automattic/simplenote-android/pull/1571)
 
 2.24.1
 -----

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -37,7 +37,7 @@ android {
         }
         versionCode 150
         minSdkVersion 23
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         testInstrumentationRunner 'com.automattic.simplenote.SimplenoteAppRunner'
     }

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -122,7 +122,7 @@ dependencies {
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation 'androidx.preference:preference:1.1.0'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
-    implementation 'androidx.work:work-runtime:2.5.0'
+    implementation 'androidx.work:work-runtime:2.7.1'
     implementation 'androidx.concurrent:concurrent-futures:1.1.0'
     implementation "androidx.multidex:multidex:2.0.1"
     // Support for ViewModels and LiveData

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'dagger.hilt.android.plugin'
 
 android {
     buildToolsVersion '30.0.3'
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     buildTypes {
         debug {

--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -46,6 +46,7 @@
             android:configChanges="screenSize|smallestScreenSize|orientation|screenLayout"
             android:label="@string/app_launcher_name"
             android:resizeableActivity="true"
+            android:exported="true"
             android:windowSoftInputMode="adjustResize|stateHidden">
 
             <intent-filter>
@@ -101,6 +102,7 @@
 
         <activity
             android:name="com.automattic.simplenote.NoteWidgetDarkConfigureActivity"
+            android:exported="true"
             android:theme="@style/Theme.Transparent">
 
             <intent-filter>
@@ -113,6 +115,7 @@
 
         <activity
             android:name="com.automattic.simplenote.NoteWidgetLightConfigureActivity"
+            android:exported="true"
             android:theme="@style/Theme.Transparent">
 
             <intent-filter>
@@ -153,7 +156,9 @@
             android:configChanges="orientation|keyboardHidden|screenSize">
         </activity>
 
-        <activity android:name="com.automattic.simplenote.DeepLinkActivity">
+        <activity
+            android:name="com.automattic.simplenote.DeepLinkActivity"
+            android:exported="true">
 
             <intent-filter>
 
@@ -204,6 +209,7 @@
 
         <receiver
             android:name="com.automattic.simplenote.NoteListWidgetDark"
+            android:exported="true"
             android:label="@string/note_list_widget_dark">
 
             <intent-filter>
@@ -221,6 +227,7 @@
 
         <receiver
             android:name="com.automattic.simplenote.NoteListWidgetLight"
+            android:exported="true"
             android:label="@string/note_list_widget_light">
 
             <intent-filter>
@@ -238,6 +245,7 @@
 
         <receiver
             android:name="com.automattic.simplenote.NoteWidgetDark"
+            android:exported="true"
             android:label="@string/note_widget_dark">
 
             <intent-filter>
@@ -255,6 +263,7 @@
 
         <receiver
             android:name="com.automattic.simplenote.NoteWidgetLight"
+            android:exported="true"
             android:label="@string/note_widget_light">
 
             <intent-filter>
@@ -282,7 +291,8 @@
 
         <!-- Android Wear -->
         <service
-            android:name="com.automattic.simplenote.utils.SimplenoteWearListenerService">
+            android:name="com.automattic.simplenote.utils.SimplenoteWearListenerService"
+            android:exported="true">
 
             <intent-filter>
 

--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -148,13 +148,11 @@
         <activity
             android:name="com.automattic.simplenote.StyleActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
-            android:parentActivityName=".PreferencesActivity">
-        </activity>
+            android:parentActivityName=".PreferencesActivity"></activity>
 
         <activity
             android:name="com.automattic.simplenote.TagsActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize">
-        </activity>
+            android:configChanges="orientation|keyboardHidden|screenSize"></activity>
 
         <activity
             android:name="com.automattic.simplenote.DeepLinkActivity"

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
@@ -11,6 +11,7 @@ import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
 import static com.automattic.simplenote.utils.WidgetUtils.MINIMUM_HEIGHT_FOR_BUTTON;
 import static com.automattic.simplenote.utils.WidgetUtils.MINIMUM_WIDTH_FOR_BUTTON;
 
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
@@ -99,6 +100,7 @@ public class NoteListWidgetDark extends AppWidgetProvider {
         }
     }
 
+    @SuppressLint("UnspecifiedImmutableFlag")
     private void updateWidget(Context context, AppWidgetManager appWidgetManager, int appWidgetId, Bundle appWidgetOptions) {
         RemoteViews views = new RemoteViews(context.getPackageName(), PrefUtils.getLayoutWidgetList(context, false));
         resizeWidget(context, appWidgetOptions, views);
@@ -148,7 +150,12 @@ public class NoteListWidgetDark extends AppWidgetProvider {
 
                 // Create intent to navigate to note editor on note list item click
                 Intent intentItem = new Intent(context, NoteEditorActivity.class);
-                PendingIntent pendingIntentItem = PendingIntent.getActivity(context, appWidgetId, intentItem, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+                PendingIntent pendingIntentItem = null;
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                    pendingIntentItem = PendingIntent.getActivity(context, appWidgetId, intentItem, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+                } else {
+                    pendingIntentItem = PendingIntent.getActivity(context, appWidgetId, intentItem, PendingIntent.FLAG_UPDATE_CURRENT);
+                }
                 views.setPendingIntentTemplate(R.id.widget_list, pendingIntentItem);
 
                 // Create intent to navigate to note editor on note list add button click

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
@@ -1,5 +1,16 @@
 package com.automattic.simplenote;
 
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_BUTTON_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_DELETED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_FIRST_ADDED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_LAST_DELETED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_SIGN_IN_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_TAPPED;
+import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
+import static com.automattic.simplenote.utils.WidgetUtils.MINIMUM_HEIGHT_FOR_BUTTON;
+import static com.automattic.simplenote.utils.WidgetUtils.MINIMUM_WIDTH_FOR_BUTTON;
+
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
@@ -16,17 +27,6 @@ import com.simperium.Simperium;
 import com.simperium.client.Bucket;
 import com.simperium.client.Query;
 import com.simperium.client.User;
-
-import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_BUTTON_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_DELETED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_FIRST_ADDED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_LAST_DELETED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_SIGN_IN_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_TAPPED;
-import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
-import static com.automattic.simplenote.utils.WidgetUtils.MINIMUM_HEIGHT_FOR_BUTTON;
-import static com.automattic.simplenote.utils.WidgetUtils.MINIMUM_WIDTH_FOR_BUTTON;
 
 public class NoteListWidgetDark extends AppWidgetProvider {
     public static final String KEY_LIST_WIDGET_IDS_DARK = "key_list_widget_ids_dark";

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetDark.java
@@ -118,7 +118,7 @@ public class NoteListWidgetDark extends AppWidgetProvider {
 
             // Reset intent to navigate to note editor on note list add button click to navigate to notes activity, which redirects to login/signup
             Intent intentButton = new Intent(context, NotesActivity.class);
-            views.setOnClickPendingIntent(R.id.widget_button, PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT));
+            views.setOnClickPendingIntent(R.id.widget_button, PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE));
 
             views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.log_in_use_widget));
             views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_dark, context.getTheme()));
@@ -137,7 +137,7 @@ public class NoteListWidgetDark extends AppWidgetProvider {
                 Intent intentLoading = new Intent(context, NotesActivity.class);
                 intentLoading.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_TAPPED);
                 intentLoading.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                PendingIntent pendingIntentLoading = PendingIntent.getActivity(context, appWidgetId, intentLoading, 0);
+                PendingIntent pendingIntentLoading = PendingIntent.getActivity(context, appWidgetId, intentLoading, PendingIntent.FLAG_IMMUTABLE);
                 views.setOnClickPendingIntent(R.id.widget_layout, pendingIntentLoading);
 
                 // Create intent for note list widget service
@@ -148,14 +148,14 @@ public class NoteListWidgetDark extends AppWidgetProvider {
 
                 // Create intent to navigate to note editor on note list item click
                 Intent intentItem = new Intent(context, NoteEditorActivity.class);
-                PendingIntent pendingIntentItem = PendingIntent.getActivity(context, appWidgetId, intentItem, PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent pendingIntentItem = PendingIntent.getActivity(context, appWidgetId, intentItem, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
                 views.setPendingIntentTemplate(R.id.widget_list, pendingIntentItem);
 
                 // Create intent to navigate to note editor on note list add button click
                 Intent intentButton = new Intent(context, NotesActivity.class);
                 intentButton.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_BUTTON_TAPPED);
                 intentButton.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                PendingIntent pendingIntentButton = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent pendingIntentButton = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
                 views.setOnClickPendingIntent(R.id.widget_button, pendingIntentButton);
 
                 views.setEmptyView(R.id.widget_list, R.id.widget_text);
@@ -175,7 +175,7 @@ public class NoteListWidgetDark extends AppWidgetProvider {
                 Intent intentButton = new Intent(context, NotesActivity.class);
                 intentButton.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_BUTTON_TAPPED);
                 intentButton.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                PendingIntent pendingIntentButton = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent pendingIntentButton = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
                 views.setOnClickPendingIntent(R.id.widget_button, pendingIntentButton);
 
                 views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_dark, context.getTheme()));

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
@@ -1,5 +1,16 @@
 package com.automattic.simplenote;
 
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_BUTTON_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_DELETED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_FIRST_ADDED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_LAST_DELETED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_SIGN_IN_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_TAPPED;
+import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
+import static com.automattic.simplenote.utils.WidgetUtils.MINIMUM_HEIGHT_FOR_BUTTON;
+import static com.automattic.simplenote.utils.WidgetUtils.MINIMUM_WIDTH_FOR_BUTTON;
+
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
@@ -16,17 +27,6 @@ import com.simperium.Simperium;
 import com.simperium.client.Bucket;
 import com.simperium.client.Query;
 import com.simperium.client.User;
-
-import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_BUTTON_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_DELETED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_FIRST_ADDED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_LAST_DELETED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_SIGN_IN_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_LIST_WIDGET_TAPPED;
-import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
-import static com.automattic.simplenote.utils.WidgetUtils.MINIMUM_HEIGHT_FOR_BUTTON;
-import static com.automattic.simplenote.utils.WidgetUtils.MINIMUM_WIDTH_FOR_BUTTON;
 
 public class NoteListWidgetLight extends AppWidgetProvider {
     public static final String KEY_LIST_WIDGET_IDS_LIGHT = "key_list_widget_ids_light";

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
@@ -11,6 +11,7 @@ import static com.automattic.simplenote.utils.WidgetUtils.KEY_LIST_WIDGET_CLICK;
 import static com.automattic.simplenote.utils.WidgetUtils.MINIMUM_HEIGHT_FOR_BUTTON;
 import static com.automattic.simplenote.utils.WidgetUtils.MINIMUM_WIDTH_FOR_BUTTON;
 
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
@@ -99,6 +100,7 @@ public class NoteListWidgetLight extends AppWidgetProvider {
         }
     }
 
+    @SuppressLint("UnspecifiedImmutableFlag")
     private void updateWidget(Context context, AppWidgetManager appWidgetManager, int appWidgetId, Bundle appWidgetOptions) {
         RemoteViews views = new RemoteViews(context.getPackageName(), PrefUtils.getLayoutWidgetList(context, true));
         resizeWidget(context, appWidgetOptions, views);
@@ -148,7 +150,12 @@ public class NoteListWidgetLight extends AppWidgetProvider {
 
                 // Create intent to navigate to note editor on note list item click
                 Intent intentItem = new Intent(context, NoteEditorActivity.class);
-                PendingIntent pendingIntentItem = PendingIntent.getActivity(context, appWidgetId, intentItem, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+                PendingIntent pendingIntentItem = null;
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                    pendingIntentItem = PendingIntent.getActivity(context, appWidgetId, intentItem, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+                } else {
+                    pendingIntentItem = PendingIntent.getActivity(context, appWidgetId, intentItem, PendingIntent.FLAG_UPDATE_CURRENT);
+                }
                 views.setPendingIntentTemplate(R.id.widget_list, pendingIntentItem);
 
                 // Create intent to navigate to note editor on note list add button click

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteListWidgetLight.java
@@ -113,12 +113,12 @@ public class NoteListWidgetLight extends AppWidgetProvider {
             Intent intent = new Intent(context, NotesActivity.class);
             intent.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_SIGN_IN_TAPPED);
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
+            PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_IMMUTABLE);
             views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
 
             // Reset intent to navigate to note editor on note list add button click to navigate to notes activity, which redirects to login/signup
             Intent intentButton = new Intent(context, NotesActivity.class);
-            views.setOnClickPendingIntent(R.id.widget_button, PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT));
+            views.setOnClickPendingIntent(R.id.widget_button, PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE));
 
             views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.log_in_use_widget));
             views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_light, context.getTheme()));
@@ -148,14 +148,14 @@ public class NoteListWidgetLight extends AppWidgetProvider {
 
                 // Create intent to navigate to note editor on note list item click
                 Intent intentItem = new Intent(context, NoteEditorActivity.class);
-                PendingIntent pendingIntentItem = PendingIntent.getActivity(context, appWidgetId, intentItem, PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent pendingIntentItem = PendingIntent.getActivity(context, appWidgetId, intentItem, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
                 views.setPendingIntentTemplate(R.id.widget_list, pendingIntentItem);
 
                 // Create intent to navigate to note editor on note list add button click
                 Intent intentButton = new Intent(context, NotesActivity.class);
                 intentButton.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_BUTTON_TAPPED);
                 intentButton.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                PendingIntent pendingIntentButton = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent pendingIntentButton = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
                 views.setOnClickPendingIntent(R.id.widget_button, pendingIntentButton);
 
                 views.setEmptyView(R.id.widget_list, R.id.widget_text);
@@ -175,7 +175,7 @@ public class NoteListWidgetLight extends AppWidgetProvider {
                 Intent intentButton = new Intent(context, NotesActivity.class);
                 intentButton.putExtra(KEY_LIST_WIDGET_CLICK, NOTE_LIST_WIDGET_BUTTON_TAPPED);
                 intentButton.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                PendingIntent pendingIntentButton = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent pendingIntentButton = PendingIntent.getActivity(context, appWidgetId, intentButton, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
                 views.setOnClickPendingIntent(R.id.widget_button, pendingIntentButton);
 
                 views.setTextColor(R.id.widget_text, context.getResources().getColor(R.color.text_title_light, context.getTheme()));

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDark.java
@@ -111,7 +111,7 @@ public class NoteWidgetDark extends AppWidgetProvider {
             Intent intent = new Intent(context, NotesActivity.class);
             intent.putExtra(KEY_WIDGET_CLICK, NOTE_WIDGET_SIGN_IN_TAPPED);
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
+            PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_IMMUTABLE);
 
             views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
             views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.log_in_use_widget));
@@ -143,7 +143,7 @@ public class NoteWidgetDark extends AppWidgetProvider {
                     intent.putExtras(arguments);
                     intent.putExtra(KEY_WIDGET_CLICK, NOTE_WIDGET_NOTE_TAPPED);
                     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                    PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+                    PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
                     // Remove title from content
                     String title = updatedNote.getTitle();
@@ -169,7 +169,7 @@ public class NoteWidgetDark extends AppWidgetProvider {
                     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
                     intent.putExtra(KEY_WIDGET_CLICK, NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED);
                     intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
-                    PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+                    PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
                     views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
                     views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.note_not_found));

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDark.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDark.java
@@ -1,5 +1,14 @@
 package com.automattic.simplenote;
 
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_DELETED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_FIRST_ADDED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_LAST_DELETED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_SIGN_IN_TAPPED;
+import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
+
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
@@ -18,15 +27,6 @@ import com.simperium.Simperium;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObjectMissingException;
 import com.simperium.client.User;
-
-import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_DELETED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_FIRST_ADDED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_LAST_DELETED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_SIGN_IN_TAPPED;
-import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
 
 public class NoteWidgetDark extends AppWidgetProvider {
     public static final String KEY_WIDGET_IDS_DARK = "key_widget_ids_dark";

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
@@ -203,7 +203,7 @@ public class NoteWidgetDarkConfigureActivity extends AppCompatActivity {
                     intent.putExtras(arguments);
                     intent.putExtra(KEY_WIDGET_CLICK, NOTE_WIDGET_NOTE_TAPPED);
                     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                    PendingIntent pendingIntent = PendingIntent.getActivity(context, mAppWidgetId, intent, 0);
+                    PendingIntent pendingIntent = PendingIntent.getActivity(context, mAppWidgetId, intent, PendingIntent.FLAG_IMMUTABLE);
 
                     // Remove title from content
                     String title = note.getTitle();

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetDarkConfigureActivity.java
@@ -1,5 +1,10 @@
 package com.automattic.simplenote;
 
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_TAPPED;
+import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
+
 import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
@@ -34,11 +39,6 @@ import com.simperium.client.Bucket;
 import com.simperium.client.Bucket.ObjectCursor;
 import com.simperium.client.Query;
 import com.simperium.client.User;
-
-import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_TAPPED;
-import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
 
 public class NoteWidgetDarkConfigureActivity extends AppCompatActivity {
     private AppWidgetManager mWidgetManager;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLight.java
@@ -1,5 +1,14 @@
 package com.automattic.simplenote;
 
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_DELETED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_FIRST_ADDED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_LAST_DELETED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_SIGN_IN_TAPPED;
+import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
+
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
@@ -18,15 +27,6 @@ import com.simperium.Simperium;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObjectMissingException;
 import com.simperium.client.User;
-
-import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_DELETED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_FIRST_ADDED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_LAST_DELETED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_SIGN_IN_TAPPED;
-import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
 
 public class NoteWidgetLight extends AppWidgetProvider {
     public static final String KEY_WIDGET_IDS_LIGHT = "key_widget_ids_light";

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLight.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLight.java
@@ -111,7 +111,7 @@ public class NoteWidgetLight extends AppWidgetProvider {
             Intent intent = new Intent(context, NotesActivity.class);
             intent.putExtra(KEY_WIDGET_CLICK, NOTE_WIDGET_SIGN_IN_TAPPED);
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
+            PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_IMMUTABLE);
 
             views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
             views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.log_in_use_widget));
@@ -143,7 +143,7 @@ public class NoteWidgetLight extends AppWidgetProvider {
                     intent.putExtras(arguments);
                     intent.putExtra(KEY_WIDGET_CLICK, NOTE_WIDGET_NOTE_TAPPED);
                     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                    PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+                    PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
                     // Remove title from content
                     String title = updatedNote.getTitle();
@@ -169,7 +169,7 @@ public class NoteWidgetLight extends AppWidgetProvider {
                     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
                     intent.putExtra(KEY_WIDGET_CLICK, NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED);
                     intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
-                    PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+                    PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
                     views.setOnClickPendingIntent(R.id.widget_layout, pendingIntent);
                     views.setTextViewText(R.id.widget_text, context.getResources().getString(R.string.note_not_found));

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLightConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLightConfigureActivity.java
@@ -1,5 +1,10 @@
 package com.automattic.simplenote;
 
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_TAPPED;
+import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
+
 import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
@@ -34,11 +39,6 @@ import com.simperium.client.Bucket;
 import com.simperium.client.Bucket.ObjectCursor;
 import com.simperium.client.Query;
 import com.simperium.client.User;
-
-import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_WIDGET;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_NOT_FOUND_TAPPED;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.NOTE_WIDGET_NOTE_TAPPED;
-import static com.automattic.simplenote.utils.WidgetUtils.KEY_WIDGET_CLICK;
 
 public class NoteWidgetLightConfigureActivity extends AppCompatActivity {
     private AppWidgetManager mWidgetManager;

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLightConfigureActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteWidgetLightConfigureActivity.java
@@ -203,7 +203,7 @@ public class NoteWidgetLightConfigureActivity extends AppCompatActivity {
                     intent.putExtras(arguments);
                     intent.putExtra(KEY_WIDGET_CLICK, NOTE_WIDGET_NOTE_TAPPED);
                     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                    PendingIntent pendingIntent = PendingIntent.getActivity(context, mAppWidgetId, intent, 0);
+                    PendingIntent pendingIntent = PendingIntent.getActivity(context, mAppWidgetId, intent, PendingIntent.FLAG_IMMUTABLE);
 
                     // Remove title from content
                     String title = note.getTitle();


### PR DESCRIPTION
Fixes ##1570.

### Fix
Upgrade to `targetSdkVersion = 31` and `compileSdkVersion = 31`. Following the [recommendations](https://developer.android.com/google/play/requirements/target-sdk) for the upgrade, we were affected by the following:

- Intent filters: If your app contains [activities](https://developer.android.com/guide/components/activities/intro-activities), [services](https://developer.android.com/guide/components/services), or [broadcast receivers](https://developer.android.com/guide/components/broadcasts) that use [intent filters](https://developer.android.com/guide/components/intents-filters#Receiving), you must explicitly declare the [android:exported](https://developer.android.com/guide/topics/manifest/activity-element#exported) attribute for these components.
- [Pending intent mutability](https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability): You must specify the mutability of each PendingIntent object that your app creates.

We apply the following changes to support the new `targetSdkVersion`:

- Upgrade `androidx.work:work-runtime` to `2.7.1`. The previous version was crashing the app because immutability of pending intents. 
- Ad immutable flag to pending intents. In one case (widgets) we need mutable pending intents. 
- Added `exported:true` to components that use intent filters.

### Test

Smoke test the whole app. 

- Test notes, adding, editing, opening links, etc.
- Add collaborators
- Add tags
- Setup lock screen
- Import/Export
- Widgets

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in a7465aeee3a84990e006b6038b633b28acf1728e with:
> Upgrade to targetSdkVersion 31 (Android 31)
