### PR TITLE
Merge 2.25 code freeze into trunk

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 
 
-2.24.2
+2.25
 -----
 * Added ability to purchase a Simplenote Sustainer subscription [#1567](https://github.com/Automattic/simplenote-android/pull/1567)
 * [Internal] Upgrade to targetSdkVersion 31 (Android 31) [#1571](https://github.com/Automattic/simplenote-android/pull/1571)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+2.26
+-----
+
+
 2.24.2
 -----
 * Added ability to purchase a Simplenote Sustainer subscription [#1567](https://github.com/Automattic/simplenote-android/pull/1567)

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -33,9 +33,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "2.25-rc-1"
+            versionName "2.25-rc-2"
         }
-        versionCode 151
+        versionCode 152
         minSdkVersion 23
         targetSdkVersion 31
 

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -33,9 +33,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "2.24.1"
+            versionName "2.25-rc-1"
         }
-        versionCode 150
+        versionCode 151
         minSdkVersion 23
         targetSdkVersion 31
 

--- a/Simplenote/metadata/PlayStoreStrings.pot
+++ b/Simplenote/metadata/PlayStoreStrings.pot
@@ -11,18 +11,16 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_0225"
+msgid ""
+"2.25:\n"
+"New: Simplenote Sustainer. Help support the ongoing development of Simplenote with an annual subscription.\n"
+msgstr ""
+
 msgctxt "release_note_0224"
 msgid ""
 "2.24:\n"
 "* Updated simperium library\n"
-msgstr ""
-
-msgctxt "release_note_0222"
-msgid ""
-"2.22:\n"
-"* Fixed screen going into full-editing mode in tag editor\n"
-"* Fixed save button is disabled for a new tag after device rotation\n"
-"* Fixed tag rename dialog is closed on device rotation\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/Simplenote/metadata/release_notes.txt
+++ b/Simplenote/metadata/release_notes.txt
@@ -1,0 +1,1 @@
+New: Simplenote Sustainer. Help support the ongoing development of Simplenote with an annual subscription.

--- a/Simplenote/metadata/release_notes.txt
+++ b/Simplenote/metadata/release_notes.txt
@@ -1,2 +1,0 @@
-* Updated simperium library
-* Fixed links not opening in browser

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -347,6 +347,22 @@
     <string name="collaborators_note_trashed">Note was trashed. You cannot edit collaborators on a note that is in the trash.</string>
     <string name="no_collaborators">No Collaborators</string>
 
+    <!-- IAP -->
+    <string name="iap_banner_title">Become a Simplenote Sustainer</string>
+    <string name="iap_banner_subtitle">Support your favorite notes app and help unlock future features.</string>
+    <string name="iap_thank_you_banner_title">You are a Simplenote Sustainer</string>
+    <string name="iap_thank_you_banner_subtitle">Thank you for your continued support</string>
+    <string name="subscription_weekly">Weekly</string>
+    <string name="subscription_monthly">Monthly</string>
+    <string name="subscription_three_month">Three Month</string>
+    <string name="subscription_six_month">Six Month</string>
+    <string name="subscription_yearly_month">Yearly</string>
+    <string name="subscription_unknown">Unknown Length</string>
+    <string name="subscription_choose_plan">Choose a plan</string>
+    <string name="subscription_purchase_success">Purchase successful. Thank you for your continued support!</string>
+    <string name="subscription_purchase_error">Purchase failed</string>
+    <string name="subscription_plans_fetching_error">Error fetching plans. Please, check your connection and try again.</string>
+
     <!-- PASSCODE -->
     <string name="passcode_change_passcode">Change passcode</string>
     <string name="passcode_enter_old_passcode">Enter your old passcode</string>


### PR DESCRIPTION
This PR includes the changes from the 2.25 code freeze: 
- Version bump (It goes to rc-2 instead of rc-1 because the 151 version code that was initially used with rc-1 was actually uploaded a few months ago already to Google Play. So I upped the version code to 152 and made rc-2)
- Release notes that will be translated
- App strings that will be translated