### PR TITLE
Fix issues in Editor for Samsung devices running Android 13

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 2.26
 -----
-
+* Fixed problem with editor in Samsung devices with Android 13 [#1585](https://github.com/Automattic/simplenote-android/pull/1585)
 
 2.25
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/AppLog.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/AppLog.java
@@ -25,7 +25,8 @@ public class AppLog {
         NETWORK,
         SCREEN,
         SYNC,
-        IMPORT
+        IMPORT,
+        EDITOR
     }
 
     public static void add(Type type, String message) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SamsungInputConnection.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SamsungInputConnection.kt
@@ -8,6 +8,7 @@ import android.text.Spanned
 import android.text.style.SuggestionSpan
 import android.view.KeyEvent
 import android.view.inputmethod.*
+import com.automattic.simplenote.utils.AppLog
 
 /**
  * Wrapper around proprietary Samsung InputConnection. Forwards all the calls to it, except for getExtractedText and
@@ -78,6 +79,10 @@ class SamsungInputConnection(
         // In this method we do everything replaceText method of EditableInputConnection does, apart from actually
         // replacing text. Instead we copy the suggestions from incoming text into editor directly.
         if (incomingTextHasSuggestions) {
+            AppLog.add(
+                AppLog.Type.EDITOR,
+                "Detected spellchecker trying to commit partial text with suggestions"
+            )
             // delete composing text set previously.
             var composingSpanStart = getComposingSpanStart(editable)
             var composingSpanEnd = getComposingSpanEnd(editable)

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SamsungInputConnection.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SamsungInputConnection.kt
@@ -1,0 +1,187 @@
+package com.automattic.simplenote.widgets
+
+import android.os.Build
+import android.os.Bundle
+import android.text.Editable
+import android.text.Selection
+import android.text.Spanned
+import android.text.style.SuggestionSpan
+import android.view.KeyEvent
+import android.view.inputmethod.*
+
+/**
+ * Wrapper around proprietary Samsung InputConnection. Forwards all the calls to it, except for getExtractedText and
+ * some custom logic in commitText
+ */
+class SamsungInputConnection(
+    private val mTextView: SimplenoteEditText,
+    private val baseInputConnection: InputConnection,
+) : BaseInputConnection(mTextView, true) {
+
+    override fun getEditable(): Editable {
+        return mTextView.editableText
+    }
+
+    override fun beginBatchEdit(): Boolean {
+        return baseInputConnection.beginBatchEdit()
+    }
+
+    override fun endBatchEdit(): Boolean {
+        return baseInputConnection.endBatchEdit()
+    }
+
+    override fun clearMetaKeyStates(states: Int): Boolean {
+        return baseInputConnection.clearMetaKeyStates(states)
+    }
+
+    override fun sendKeyEvent(event: KeyEvent?): Boolean {
+        return super.sendKeyEvent(event)
+    }
+
+    override fun commitCompletion(text: CompletionInfo?): Boolean {
+        return baseInputConnection.commitCompletion(text)
+    }
+
+    override fun commitCorrection(correctionInfo: CorrectionInfo?): Boolean {
+        return baseInputConnection.commitCorrection(correctionInfo)
+    }
+
+    override fun performEditorAction(actionCode: Int): Boolean {
+        return baseInputConnection.performEditorAction(actionCode)
+    }
+
+    override fun performContextMenuAction(id: Int): Boolean {
+        return baseInputConnection.performContextMenuAction(id)
+    }
+
+    // Extracted text on Samsung devices on Android 13 is somehow used for Grammarly suggestions which causes a lot of
+    // issues with spans and cursors. We do not use extracted text, so returning null
+    // (default behavior of BaseInputConnection) prevents Grammarly from messing up content most of the time
+    override fun getExtractedText(request: ExtractedTextRequest?, flags: Int): ExtractedText? {
+        return null
+    }
+
+    override fun performPrivateCommand(action: String?, data: Bundle?): Boolean {
+        return baseInputConnection.performPrivateCommand(action, data)
+    }
+
+    override fun setComposingText(text: CharSequence?, newCursorPosition: Int): Boolean {
+        return baseInputConnection.setComposingText(text, newCursorPosition)
+    }
+
+    override fun commitText(text: CharSequence?, newCursorPosition: Int): Boolean {
+        val incomingTextHasSuggestions = text is Spanned &&
+                text.getSpans(0, text.length, SuggestionSpan::class.java).isNotEmpty()
+
+        // Sometime spellchecker tries to commit partial text with suggestions. This mostly works ok,
+        // but CheckableSpan spans are finicky, and tend to get messed when content of the editor is replaced.
+        // In this method we do everything replaceText method of EditableInputConnection does, apart from actually
+        // replacing text. Instead we copy the suggestions from incoming text into editor directly.
+        if (incomingTextHasSuggestions) {
+            // delete composing text set previously.
+            var composingSpanStart = getComposingSpanStart(editable)
+            var composingSpanEnd = getComposingSpanEnd(editable)
+
+            if (composingSpanEnd < composingSpanStart) {
+                val tmp = composingSpanStart
+                composingSpanStart = composingSpanEnd
+                composingSpanEnd = tmp
+            }
+
+            if (composingSpanStart != -1 && composingSpanEnd != -1) {
+                removeComposingSpans(editable)
+            } else {
+                composingSpanStart = Selection.getSelectionStart(editable)
+                composingSpanEnd = Selection.getSelectionEnd(editable)
+                if (composingSpanStart < 0) composingSpanStart = 0
+                if (composingSpanEnd < 0) composingSpanEnd = 0
+                if (composingSpanEnd < composingSpanStart) {
+                    val tmp = composingSpanStart
+                    composingSpanStart = composingSpanEnd
+                    composingSpanEnd = tmp
+                }
+            }
+
+            var cursorPosition = newCursorPosition
+            cursorPosition += if (cursorPosition > 0) {
+                composingSpanEnd - 1
+            } else {
+                composingSpanStart
+            }
+            if (newCursorPosition < 0) cursorPosition = 0
+            if (newCursorPosition > editable.length) cursorPosition = editable.length
+            Selection.setSelection(editable, cursorPosition)
+
+            (text as Spanned).getSpans(0, text.length, SuggestionSpan::class.java).forEach {
+                val st: Int = text.getSpanStart(it)
+                val en: Int = text.getSpanEnd(it)
+                val fl: Int = text.getSpanFlags(it)
+
+                if (editable.length > composingSpanStart + en) {
+                    editable.setSpan(it, composingSpanStart + st, composingSpanStart + en, fl)
+                }
+            }
+
+            return true
+        }
+
+        return baseInputConnection.commitText(text, newCursorPosition)
+    }
+
+    override fun commitContent(inputContentInfo: InputContentInfo, flags: Int, opts: Bundle?): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            baseInputConnection.commitContent(inputContentInfo, flags, opts)
+        } else {
+            super.commitContent(inputContentInfo, flags, opts)
+        }
+    }
+
+    override fun deleteSurroundingText(beforeLength: Int, afterLength: Int): Boolean {
+        return baseInputConnection.deleteSurroundingText(beforeLength, afterLength)
+    }
+
+    override fun requestCursorUpdates(cursorUpdateMode: Int): Boolean {
+        return baseInputConnection.requestCursorUpdates(cursorUpdateMode)
+    }
+
+    override fun reportFullscreenMode(enabled: Boolean): Boolean {
+        return baseInputConnection.reportFullscreenMode(enabled)
+    }
+
+    override fun setSelection(start: Int, end: Int): Boolean {
+        return baseInputConnection.setSelection(start, end)
+    }
+
+    override fun finishComposingText(): Boolean {
+        return baseInputConnection.finishComposingText()
+    }
+
+    override fun setComposingRegion(start: Int, end: Int): Boolean {
+        return baseInputConnection.setComposingRegion(start, end)
+    }
+
+    override fun deleteSurroundingTextInCodePoints(beforeLength: Int, afterLength: Int): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            baseInputConnection.deleteSurroundingTextInCodePoints(beforeLength, afterLength)
+        } else {
+            // We should not reach this code on Android < N, but just in case we do, we call the old method.
+            baseInputConnection.deleteSurroundingText(beforeLength, afterLength)
+        }
+    }
+
+    override fun getCursorCapsMode(reqModes: Int): Int {
+        return baseInputConnection.getCursorCapsMode(reqModes)
+    }
+
+    override fun getSelectedText(flags: Int): CharSequence? {
+        return baseInputConnection.getSelectedText(flags)
+    }
+
+    override fun getTextAfterCursor(length: Int, flags: Int): CharSequence? {
+        return baseInputConnection.getTextAfterCursor(length, flags)
+    }
+
+    override fun getTextBeforeCursor(length: Int, flags: Int): CharSequence? {
+        return baseInputConnection.getTextBeforeCursor(length, flags)
+    }
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -1,9 +1,14 @@
 package com.automattic.simplenote.widgets;
 
+import static com.automattic.simplenote.utils.SimplenoteLinkify.SIMPLENOTE_LINK_ID;
+import static com.automattic.simplenote.utils.SimplenoteLinkify.SIMPLENOTE_LINK_PREFIX;
+
 import android.content.Context;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Handler;
+import android.provider.Settings;
 import android.text.Editable;
 import android.text.Layout;
 import android.text.SpannableStringBuilder;
@@ -12,6 +17,8 @@ import android.text.style.ImageSpan;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 import android.widget.AdapterView;
 
 import androidx.annotation.DrawableRes;
@@ -30,11 +37,9 @@ import com.simperium.client.Bucket;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static com.automattic.simplenote.utils.SimplenoteLinkify.SIMPLENOTE_LINK_ID;
-import static com.automattic.simplenote.utils.SimplenoteLinkify.SIMPLENOTE_LINK_PREFIX;
 
 public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView implements AdapterView.OnItemClickListener {
     private static final Pattern INTERNOTE_LINK_PATTERN_EDIT = Pattern.compile("([^]]*)(]\\(" + SIMPLENOTE_LINK_PREFIX + SIMPLENOTE_LINK_ID + "\\))");
@@ -42,7 +47,7 @@ public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView imple
     private static final int CHECKBOX_LENGTH = 2; // one ClickableSpan character + one space character
 
     private LinkTokenizer mTokenizer;
-    private List<OnSelectionChangedListener> listeners;
+    private final List<OnSelectionChangedListener> listeners;
     private OnCheckboxToggledListener mOnCheckboxToggledListener;
 
     @Override
@@ -104,12 +109,33 @@ public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView imple
         setThreshold(1);
     }
 
+    private boolean shouldOverridePredictiveTextBehavior() {
+        String currentKeyboard = Settings.Secure.getString(
+                getContext().getContentResolver(),
+                Settings.Secure.DEFAULT_INPUT_METHOD
+        );
+
+        return "samsung".equals(Build.MANUFACTURER.toLowerCase(Locale.US)) && Build.VERSION.SDK_INT >= 33 &&
+                (currentKeyboard != null && currentKeyboard.startsWith("com.samsung.android.honeyboard"));
+    }
+
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        InputConnection baseInputConnection = super.onCreateInputConnection(outAttrs);
+
+        if (shouldOverridePredictiveTextBehavior()) {
+            return new SamsungInputConnection(this, baseInputConnection);
+        }
+
+        return baseInputConnection;
+    }
+
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         AnalyticsTracker.track(
-            AnalyticsTracker.Stat.INTERNOTE_LINK_CREATED,
-            AnalyticsTracker.CATEGORY_LINK,
-            "internote_link_created"
+                AnalyticsTracker.Stat.INTERNOTE_LINK_CREATED,
+                AnalyticsTracker.CATEGORY_LINK,
+                "internote_link_created"
         );
         @SuppressWarnings("unchecked")
         Bucket.ObjectCursor<Note> cursor = (Bucket.ObjectCursor<Note>) parent.getAdapter().getItem(position);
@@ -168,24 +194,21 @@ public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView imple
             int iconSize = DisplayUtils.getChecklistIconSize(context, false);
             iconDrawable.setBounds(0, 0, iconSize, iconSize);
             final CenteredImageSpan newImageSpan = new CenteredImageSpan(context, iconDrawable);
-            new Handler().post(new Runnable() {
-                @Override
-                public void run() {
-                    editable.setSpan(newImageSpan, checkboxStart, checkboxEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-                    editable.removeSpan(imageSpans[0]);
-                    fixLineSpacing();
+            new Handler().post(() -> {
+                editable.setSpan(newImageSpan, checkboxStart, checkboxEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                editable.removeSpan(imageSpans[0]);
+                fixLineSpacing();
 
-                    // Restore the selection
-                    if (selectionStart >= 0
-                            && selectionStart <= editable.length()
-                            && selectionEnd <= editable.length() && hasFocus()) {
-                        setSelection(selectionStart, selectionEnd);
-                        setCursorVisible(true);
-                    }
+                // Restore the selection
+                if (selectionStart >= 0
+                        && selectionStart <= editable.length()
+                        && selectionEnd <= editable.length() && hasFocus()) {
+                    setSelection(selectionStart, selectionEnd);
+                    setCursorVisible(true);
+                }
 
-                    if (mOnCheckboxToggledListener != null) {
-                        mOnCheckboxToggledListener.onCheckboxToggled();
-                    }
+                if (mOnCheckboxToggledListener != null) {
+                    mOnCheckboxToggledListener.onCheckboxToggled();
                 }
             });
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SimplenoteEditText.java
@@ -27,6 +27,7 @@ import androidx.appcompat.widget.AppCompatMultiAutoCompleteTextView;
 import com.automattic.simplenote.R;
 import com.automattic.simplenote.analytics.AnalyticsTracker;
 import com.automattic.simplenote.models.Note;
+import com.automattic.simplenote.utils.AppLog;
 import com.automattic.simplenote.utils.ChecklistUtils;
 import com.automattic.simplenote.utils.DisplayUtils;
 import com.automattic.simplenote.utils.DrawableUtils;
@@ -124,6 +125,7 @@ public class SimplenoteEditText extends AppCompatMultiAutoCompleteTextView imple
         InputConnection baseInputConnection = super.onCreateInputConnection(outAttrs);
 
         if (shouldOverridePredictiveTextBehavior()) {
+            AppLog.add(AppLog.Type.EDITOR, "Samsung keyboard detected, overriding predictive text behavior");
             return new SamsungInputConnection(this, baseInputConnection);
         }
 


### PR DESCRIPTION
Fixes #1582 and #1580.

### Fix
With the rollout of  One UI Version 5.0 Android 13 on Samsung devices, we have observed that the Grammarly component from the Samsung keyboard messes up some Spannables. We have introduced changes to prevent the entry from being changed automatically by the keyboard.

The fix uses a wrapper of the base `InputConnection` that for more of the cases uses the base implementation. It handles the special case in the method `commitText(...)` when there are `SuggestionSpan` coming in the committed text. This is where we found the issues reported in #1582 and #1580 are happening.

### Test

See issues #1582 and #1580 to follow the steps described in the issues.

### Review

Only one developer is required to review these changes, but anyone can perform the review.

### Release

`RELEASE-NOTES.txt` was updated in edd69acbea02eb3c02a47b37d25be2a95fa4534d with:
> Fixed problem with editor in Samsung devices with Android 13.
