### PR TITLE
Use the default implementation for getExtractedText

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 2.27
 -----
-
+* Fixed problem with editor in Samsung devices where text duplicating [#1591](https://github.com/Automattic/simplenote-android/pull/1591)
 
 2.26
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 2.27
 -----
-* Fixed problem with editor in Samsung devices where text duplicating [#1591](https://github.com/Automattic/simplenote-android/pull/1591)
+* Fixed problem with editor in Samsung devices where users observed text duplication [#1591](https://github.com/Automattic/simplenote-android/pull/1591)
 
 2.26
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SamsungInputConnection.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SamsungInputConnection.kt
@@ -56,9 +56,12 @@ class SamsungInputConnection(
     }
 
     // Extracted text on Samsung devices on Android 13 is somehow used for Grammarly suggestions which causes a lot of
-    // issues with spans and cursors. We do not use extracted text, so returning null
-    // (default behavior of BaseInputConnection) prevents Grammarly from messing up content most of the time
+    // issues with spans and cursors. IF we return null, then it causes text duplication, so we implement the
     override fun getExtractedText(request: ExtractedTextRequest?, flags: Int): ExtractedText? {
+        val et = ExtractedText()
+        if (mTextView.extractText(request, et)) {
+            return et
+        }
         return null
     }
 


### PR DESCRIPTION
Fixes #1590.

### Fix
Users using Samsung devices with Android 13 are experiencing text duplication. 

### Test

**Note:** Please test on a Samsung device with Android 13.

1. Create a new note
2. Type `Hello 2.22`. In the current version, the editor duplicates the version and adds `Hello. 2.22.2`.
3.  Check steps in issue #1590 and verify that the problem is fixed.
4. Check steps in issue #1582 and verify that the problem is fixed.
5. Check steps in issue #1580 and verify that the problem is fixed.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 70f15503a129c11904b407258374ee4aa6ad6107 with:
> Fixed problem with editor in Samsung devices where users observed text duplication.
