### PR TITLE
Merge 2.27 code freeze

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+2.28
+-----
+
+
 2.27
 -----
 * Fixed problem with editor in Samsung devices where users observed text duplication [#1591](https://github.com/Automattic/simplenote-android/pull/1591)

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -33,9 +33,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "2.26"
+            versionName "2.27-rc-1"
         }
-        versionCode 155
+        versionCode 156
         minSdkVersion 23
         targetSdkVersion 31
 

--- a/Simplenote/metadata/PlayStoreStrings.pot
+++ b/Simplenote/metadata/PlayStoreStrings.pot
@@ -11,16 +11,16 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_0227"
+msgid ""
+"2.27:\n"
+"Fixed a problem with the editor in Samsung devices where duplication could sometime occur.\n"
+msgstr ""
+
 msgctxt "release_note_0226"
 msgid ""
 "2.26:\n"
 "Fixed several editor issues on Samsung devices that use Android 13\n"
-msgstr ""
-
-msgctxt "release_note_0225"
-msgid ""
-"2.25:\n"
-"New: Simplenote Sustainer. Help support the ongoing development of Simplenote with an annual subscription.\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/Simplenote/metadata/release_notes.txt
+++ b/Simplenote/metadata/release_notes.txt
@@ -1,2 +1,1 @@
-* Fixed problem with editor in Samsung devices where users observed text duplication [#1591](https://github.com/Automattic/simplenote-android/pull/1591)
-
+Fixed a problem with the editor in Samsung devices where duplication could sometime occur.

--- a/Simplenote/metadata/release_notes.txt
+++ b/Simplenote/metadata/release_notes.txt
@@ -1,1 +1,2 @@
-Fixed several editor issues on Samsung devices that use Android 13
+* Fixed problem with editor in Samsung devices where users observed text duplication [#1591](https://github.com/Automattic/simplenote-android/pull/1591)
+


### PR DESCRIPTION
Simplenote Android is in maintenance mode (internal ref pd9EXI-oM-p2) so I thought we could have simply cut a release and submitted it, bypassing the release cycle we adopt for active apps. However, I then realized we ought to at least perform the code freeze merge step in order to send the release notes localization up for translation