### PR TITLE
Improve IAP handling

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,7 @@
 2.28
 -----
+* Fixed occasional crash on Samsung devices [#1601](https://github.com/Automattic/simplenote-android/pull/1601)
+* Fixed recurring ANR issues [#1603](https://github.com/Automattic/simplenote-android/pull/1603)
 
 
 2.27

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/IapViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/IapViewModel.kt
@@ -329,10 +329,10 @@ class IapViewModel @Inject constructor(
     }
 
     private fun doesNotHaveSubscriptionOnOtherPlatforms(): Boolean {
-        val preference = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
+        val preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
 
-        preference?.let {
-            val currentSubscriptionPlatform = preference.currentSubscriptionPlatform
+        preferences?.let {
+            val currentSubscriptionPlatform = preferences.currentSubscriptionPlatform
 
             return currentSubscriptionPlatform == null
                     || currentSubscriptionPlatform == Preferences.SubscriptionPlatform.ANDROID

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/IapViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/IapViewModel.kt
@@ -357,8 +357,8 @@ class IapViewModel @Inject constructor(
     }
 
     private fun updateIapBannerVisibility() = try {
-        val preference: Preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
-        if (preference.currentSubscriptionPlatform != null) {
+        val preferences: Preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
+        if (preferences.currentSubscriptionPlatform != null) {
             _iapBannerVisibility.postValue(false)
         } else {
             _iapBannerVisibility.postValue(true)

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/IapViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/IapViewModel.kt
@@ -1,25 +1,43 @@
 package com.automattic.simplenote.viewmodels
 
 import android.app.Activity
-import android.app.Application
 import android.util.Log
 import androidx.annotation.StringRes
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import com.android.billingclient.api.*
 import com.automattic.simplenote.R
 import com.automattic.simplenote.Simplenote
 import com.automattic.simplenote.analytics.AnalyticsTracker
+import com.automattic.simplenote.di.IO_THREAD
 import com.automattic.simplenote.models.Preferences
 import com.simperium.client.Bucket
 import com.simperium.client.BucketObjectMissingException
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.lang.IllegalStateException
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.math.min
 
-class IapViewModel(application: Application) :
+private const val RECONNECT_TIMER_START_MILLISECONDS = 1L * 1000L
+private const val RECONNECT_TIMER_MAX_TIME_MILLISECONDS = 1000L * 60L * 15L // 15 minutes
+
+@HiltViewModel
+class IapViewModel @Inject constructor(
+    application: Simplenote, @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher
+) :
     AndroidViewModel(application), PurchasesUpdatedListener, ProductDetailsResponseListener,
     Bucket.OnNetworkChangeListener<Preferences>, Bucket.OnSaveObjectListener<Preferences>,
     Bucket.OnDeleteObjectListener<Preferences> {
+    // how long before the data source tries to reconnect to Google play
+    private var reconnectMilliseconds = RECONNECT_TIMER_START_MILLISECONDS
+
     private val billingClient = BillingClient.newBuilder(application)
         .setListener(this)
         .enablePendingPurchases()
@@ -46,7 +64,9 @@ class IapViewModel(application: Application) :
         preferencesBucket.addOnNetworkChangeListener(this)
         preferencesBucket.addOnSaveObjectListener(this)
         preferencesBucket.addOnDeleteObjectListener(this)
-        startBillingConnection()
+        viewModelScope.launch {
+            startBillingConnection()
+        }
     }
 
     private val productDetails = ArrayList<ProductDetails>()
@@ -77,26 +97,40 @@ class IapViewModel(application: Application) :
 
     // Billing
 
-    private fun startBillingConnection() {
-        try {
-            billingClient.startConnection(object : BillingClientStateListener {
-                override fun onBillingSetupFinished(billingResult: BillingResult) {
-                    if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                        Log.d(TAG, "Billing response OK")
-                        queryPurchases()
-                    } else {
-                        Log.e(TAG, billingResult.debugMessage)
-                    }
-                }
+    private val billingListener = object : BillingClientStateListener {
+        override fun onBillingSetupFinished(billingResult: BillingResult) {
+            if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                Log.i(TAG, "Billing response OK")
+                reconnectMilliseconds = RECONNECT_TIMER_START_MILLISECONDS
+                queryPurchases()
+            } else {
+                Log.e(TAG, billingResult.debugMessage)
+            }
+        }
 
-                override fun onBillingServiceDisconnected() {
-                    Log.i(TAG, "Billing connection disconnected")
-                    startBillingConnection()
-                }
-            })
+        override fun onBillingServiceDisconnected() {
+            Log.i(TAG, "Billing connection disconnected")
+            viewModelScope.launch {
+                retryBillingServiceConnectionWithExponentialBackoff()
+            }
+        }
+    }
+
+    private suspend fun startBillingConnection() = withContext(ioDispatcher) {
+        try {
+            billingClient.startConnection(billingListener)
         } catch (e: IllegalStateException) {
             Log.e(TAG, "Error starting billing connection: ${e.message}")
         }
+    }
+
+    private suspend fun retryBillingServiceConnectionWithExponentialBackoff() {
+        Log.i(TAG, "Retrying billing service connection after $reconnectMilliseconds MS delay")
+        delay(reconnectMilliseconds)
+        startBillingConnection()
+
+        reconnectMilliseconds =
+            min(reconnectMilliseconds * 2, RECONNECT_TIMER_MAX_TIME_MILLISECONDS)
     }
 
     private fun queryProductDetails() {
@@ -287,7 +321,7 @@ class IapViewModel(application: Application) :
     data class IapSnackbarMessage(@StringRes val messageResId: Int)
 
     companion object {
-        private const val TAG: String = "MainViewModel"
+        private const val TAG: String = "IapViewModel"
 
         private const val SUSTAINER_SUB_PRODUCT = "sustainer_subscription"
 
@@ -295,10 +329,10 @@ class IapViewModel(application: Application) :
     }
 
     private fun doesNotHaveSubscriptionOnOtherPlatforms(): Boolean {
-        val preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
+        val preference = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
 
-        preferences?.let {
-            val currentSubscriptionPlatform = preferences.currentSubscriptionPlatform
+        preference?.let {
+            val currentSubscriptionPlatform = preference.currentSubscriptionPlatform
 
             return currentSubscriptionPlatform == null
                     || currentSubscriptionPlatform == Preferences.SubscriptionPlatform.ANDROID
@@ -323,8 +357,8 @@ class IapViewModel(application: Application) :
     }
 
     private fun updateIapBannerVisibility() = try {
-        val preferences: Preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
-        if (preferences.currentSubscriptionPlatform != null) {
+        val preference: Preferences = preferencesBucket.get(Preferences.PREFERENCES_OBJECT_KEY)
+        if (preference.currentSubscriptionPlatform != null) {
             _iapBannerVisibility.postValue(false)
         } else {
             _iapBannerVisibility.postValue(true)


### PR DESCRIPTION
This PR fixes some ANR's that result from billing service. Despite following Google's guidelines, we are getting ANR's when initializing billing service, so I moved some calls to background thread, and added a backoff logic.


Backoff logic:
- Comment out [this](https://github.com/Automattic/simplenote-android/compare/issue/fix-iap-anr?expand=1#diff-02da68460a4936efcb23323f8b23eefb45c739341570425c672e05ae67af3362R104) line.
- Add   debuggable true to the release config. Should look like this:
```
release {
            debuggable true
            minifyEnabled true
            shrinkResources false
            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
        }
```
- Launch app in release configuration.
- In the logcat, confirm that you see `IapViewModel I  Billing response OK`
- Open device settings, navigate to Apps, and find Play Store.
- Clear Play Store storage.
- Check logcat, and confirm that you see `IapViewModel I  Retrying billing service connection after 1000 MS delay`
- Do this again, and confirm that same message with 2000 MS delay.
- etc. 

Afte this:

- Confirm that billing flow works by purchasing sustainer plan.
