### PR TITLE
Fix crash when visiting preference activity

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesActivity.java
@@ -25,6 +25,9 @@ import static com.automattic.simplenote.PreferencesFragment.WEB_APP_URL;
 import static com.automattic.simplenote.models.Preferences.PREFERENCES_OBJECT_KEY;
 import static com.automattic.simplenote.utils.DisplayUtils.disableScreenshotsIfLocked;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class PreferencesActivity extends ThemedAppCompatActivity {
     private PasscodePreferenceFragmentCompat mPasscodePreferenceFragment;
     private PreferencesFragment mPreferencesFragment;


### PR DESCRIPTION
This PR fixes the crash that happens when you open Preferences.

In recent IAP changes, I modified IAP view model, and dod not add a required `@AndroidEntryPoint` annotation to `PreferencesActivity`, which caused it to crash.

This PR addresses this.

To test, navigate to "Settings" from the nav drawer and confirm that you can see Settings activity without a crash.