### PR TITLE
Upgraded targetSdkVersion from 31 to 33

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'dagger.hilt.android.plugin'
 
 android {
     buildToolsVersion '30.0.3'
-    compileSdkVersion 31
+    compileSdkVersion 33
     ndkVersion '25.2.9519653'
 
     buildTypes {
@@ -38,7 +38,7 @@ android {
         }
         versionCode 161
         minSdkVersion 23
-        targetSdkVersion 31
+        targetSdkVersion 33
 
         testInstrumentationRunner 'com.automattic.simplenote.SimplenoteAppRunner'
     }


### PR DESCRIPTION
### Problem
According to new Google Play target API level requirement new apps must target Android 13 API level 33 or above except for wear OS 

https://developer.android.com/google/play/requirements/target-sdk

### Fix
Changed compileSdkVersion and targetSdkVersion from 31 to 33.
