### PR TITLE
Upgrade Simperium dependency and upgrade to SDK 33

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 2.30
 -----
-
+* Fixed crashes when a big note is tried to be synced [#1612](https://github.com/Automattic/simplenote-android/pull/1612)
 
 2.29
 -----

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -5,8 +5,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
 
 android {
-    buildToolsVersion '30.0.3'
-    compileSdkVersion 31
+    compileSdkVersion 33
     ndkVersion '25.2.9519653'
 
     buildTypes {
@@ -38,7 +37,7 @@ android {
         }
         versionCode 161
         minSdkVersion 23
-        targetSdkVersion 31
+        targetSdkVersion 33
 
         testInstrumentationRunner 'com.automattic.simplenote.SimplenoteAppRunner'
     }
@@ -107,7 +106,7 @@ dependencies {
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
-    implementation 'com.automattic:simperium:v1.2.0'
+    implementation 'com.automattic:simperium:248-45b683bc8445340222df4c80136f7b9fa05d1a89'
     implementation 'com.github.Automattic:Automattic-Tracks-Android:2.1.0'
     implementation 'org.wordpress:passcodelock:2.0.2'
 

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'dagger.hilt.android.plugin'
 
 android {
     compileSdkVersion 33
-    ndkVersion '25.2.9519653'
 
     buildTypes {
         debug {


### PR DESCRIPTION
### Fix

Fixes #1611.

Simperium PR: https://github.com/Simperium/simperium-android/pull/248.

On Simplenote, we get crashes when a note is big and exceeds the SQLite row size (2 MB). We are going to catch `SQLException` and return a missing object for the cases in which we get an exception. 

### Test

Smoke test the whole app:

1. Test login
2. Test adding a new note and check that the note is synced and available in other devices (you can try the web app https://app.simplenote.com/)
3. Test adding notes from the web app and check that they are visible on the Android device.
4. Try adding tasks lists and checking their boxes. Check that the updates are seen in other devices.
5. Try adding a collaborator and check that the user you share the note to receives an email.
6. Try adding note references in your note. Type `[title of note]` to see if you get a list of possible notes to link.
7. Try adding, editing and deleting tags. 
8. Try searching for notes. 
9. Try changing the theme.
10. Try changing the font size and see that the note list and the notes font size (in the editor) use the font size set.
11. Try setting up a lock screen in Settings. Leave the app and then enter it again using the code you setup.
12. Try publishing a note. Go to a note and tap on the top-right menu and tap.
13. Try to reverse a note to an earlier revision. Tap on the top-right menu and then tap on History. Change the slider to different versions and see how the note changes. Select one version and see that the note is updated to that version on other devices.  

### Review
Only one developer is required to review these changes, but anyone can perform the review.


### Release
`RELEASE-NOTES.txt` was updated in 21e349f0206bcd9984719aeddd14f6f585d0530f with:
> Fixed crashes when a big note is tried to be synced.

