### PR TITLE
Update Simperium to version `v1.3.0`

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
-    implementation 'com.automattic:simperium:248-45b683bc8445340222df4c80136f7b9fa05d1a89'
+    implementation 'com.automattic:simperium:v1.3.0'
     implementation 'com.github.Automattic:Automattic-Tracks-Android:2.1.0'
     implementation 'org.wordpress:passcodelock:2.0.2'
 


### PR DESCRIPTION
This PR updates Simperium from a hash to the `v1.3.0` release. There is no functional change here. The  `45b683bc8445340222df4c80136f7b9fa05d1a89` hash was the latest commit before the `v1.3.0` release was created. 