### PR TITLE
Add themed icon

### DIFF
--- a/Simplenote/src/main/res/drawable/ic_launcher_mono.xml
+++ b/Simplenote/src/main/res/drawable/ic_launcher_mono.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="108dp"
+    android:width="108dp"
+    android:viewportHeight="108.0"
+    android:viewportWidth="108.0">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M52.5,57.8c-11.7-3.2-18.7-11.9-17.8-22.2c0-0.1,0-0.2,0-0.3C29.9,40,27,46.6,27,54C27,68,38.4,80.1,51.7,80.5c3,0.1,5.8-0.7,8.1-2.6c2.3-1.9,3.7-4.7,4-7.7C64.4,62.3,57,59,52.5,57.8L52.5,57.8z">
+    </path>
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M80.3,54C80.3,40,69.2,28,56,27.4c-2.6-0.1-5.2,0.6-7.2,2.3c-2,1.7-3.3,4.1-3.5,6.8c-0.5,5.9,4.8,9.6,10,11c12.6,3.4,19.8,12.3,19.1,23.2C78.1,66.1,80.3,60.3,80.3,54L80.3,54z">
+    </path>
+
+</vector>

--- a/Simplenote/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/Simplenote/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -11,4 +11,8 @@
         android:drawable="@drawable/ic_launcher_foreground">
     </foreground>
 
+    <monochrome
+        android:drawable="@drawable/ic_launcher_mono">
+    </monochrome>
+
 </adaptive-icon>


### PR DESCRIPTION
### Fix
<!--
***(Required)*** Add a concise description of what you fixed.  If this is related to an issue, add a link to it.  If applicable, add screenshots, animations, or videos to help illustrate the fix.
-->
Added support for themed icons that were introduced with Android 13. This ensures the app looks consistent with other themed apps on setups that use Android 13 with the themed app icons enabled.

<div>
    <img width="40%" src="https://github.com/Automattic/simplenote-android/assets/25235249/006d07c5-7eb9-4b6b-9837-5b1138d863fd" alt="Dark mode screenshot" title="Overview"></img>
    <img width="40%" src="https://github.com/Automattic/simplenote-android/assets/25235249/81bfdc07-7572-4666-a34e-0ea12fd94161" alt="Light mode screenshot" title="Add drug form"></img>
</div>

Closes #1565

### Test
<!--
***(Required)*** List the steps to test the behavior.  For example:
1. Go to...
2. Tap on...
3. See error...
-->
1. Use Android 13 or newer[^1] (tested on Pixel 3a with API level 34, extension level 7 x86_64 emulator)
2. Enable themed icons: press and hold on an empty space on the homescreen, go to wallpaper and style, and ensure themed icons are enabled
3. Go back to the homescreen
4. Observe that the icon is like in the screenshots above

### Review
<!--
***(Required)*** Add instructions for reviewers.  For example:
Only one developer and one designer are required to review these changes, but anyone can perform the review.
-->
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
<!--
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.txt` was updated in d3adb3ef with:
> Added markdown support
-->
<!--
If the changes should not be included in release notes, add a statement to this section. For example:
These changes do not require release notes.
-->
Added themed app icon

[^1]: I couldn't get the app running without running the AGP Upgrade Assistant (probably because my Android SDK was too new). This might impact the reproducibility of the testing, so please do verify whether it works without this intervention.