### PR TITLE
Build with SDK 34, Bump Dependencies

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     buildTypes {
         debug {
@@ -35,8 +35,8 @@ android {
             versionName "2.30"
         }
         versionCode 162
-        minSdkVersion 23
-        targetSdkVersion 33
+        minSdk 23
+        targetSdk 34
 
         testInstrumentationRunner 'com.automattic.simplenote.SimplenoteAppRunner'
     }
@@ -54,21 +54,22 @@ android {
 
     // Target Java8 to avoid use certain Kotlin's features
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     viewBinding {
         enabled = true
     }
+    namespace 'com.automattic.simplenote'
 }
 
 buildscript {
     dependencies {
-        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.4'
+        classpath 'io.sentry:sentry-android-gradle-plugin:3.5.0'
     }
 
     repositories {
@@ -78,15 +79,15 @@ buildscript {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.8.47'
-    androidTestImplementation 'androidx.test:core:1.3.0'
-    androidTestImplementation 'androidx.annotation:annotation:1.0.0'
-    androidTestImplementation 'androidx.test:runner:1.3.0'
-    androidTestImplementation 'androidx.test:rules:1.3.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0'
-    androidTestImplementation('androidx.test.espresso:espresso-contrib:3.1.0') {
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:3.9.0'
+    androidTestImplementation 'androidx.test:core:1.5.0'
+    androidTestImplementation 'androidx.annotation:annotation:1.7.1'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.5.1'
+    androidTestImplementation('androidx.test.espresso:espresso-contrib:3.5.1') {
         // Necessary to avoid version conflicts
         exclude group: 'androidx', module: 'appcompat'
         exclude group: 'androidx', module: 'support-v4'
@@ -94,8 +95,8 @@ dependencies {
         exclude module: 'recyclerview-v7'
     }
     // Infrastructure to test fragments
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.3"
+    testImplementation "androidx.arch.core:core-testing:2.2.0"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1"
     testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"
 
 
@@ -106,43 +107,43 @@ dependencies {
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
     implementation 'com.automattic:simperium:v1.3.0'
-    implementation 'com.github.Automattic:Automattic-Tracks-Android:2.1.0'
+    implementation 'com.automattic:Automattic-Tracks-Android:3.3.0'
     implementation 'org.wordpress:passcodelock:2.0.2'
 
     // Kotlin's coroutines
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1'
 
     // Google Play Billing
-    implementation("com.android.billingclient:billing:5.0.0")
+    implementation("com.android.billingclient:billing:6.1.0")
 
     // Google Support
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0-beta01'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
-    implementation 'androidx.preference:preference:1.1.0'
+    implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
-    implementation 'androidx.work:work-runtime:2.7.1'
+    implementation 'androidx.work:work-runtime:2.9.0'
     implementation 'androidx.concurrent:concurrent-futures:1.1.0'
     implementation "androidx.multidex:multidex:2.0.1"
     // Support for ViewModels and LiveData
-    implementation "androidx.activity:activity-ktx:1.3.1"
-    implementation "androidx.fragment:fragment-ktx:1.3.6"
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.1'
+    implementation "androidx.activity:activity-ktx:1.8.2"
+    implementation "androidx.fragment:fragment-ktx:1.6.2"
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.7.0'
     // Support for androidx Fragments
-    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0"
 
     // Google Play Services
-    implementation 'com.google.android.gms:play-services-wearable:17.0.0'
+    implementation 'com.google.android.gms:play-services-wearable:18.1.0'
     // Third Party
-    implementation 'com.squareup.okhttp3:okhttp:3.12.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.commonsware.cwac:anddown:0.4.0'
     implementation 'net.openid:appauth:0.7.0'
 
     // Dagger Hilt dependencies
-    implementation 'com.google.dagger:hilt-android:2.38.1'
-    annotationProcessor 'com.google.dagger:hilt-compiler:2.38.1'
-    kapt 'com.google.dagger:hilt-compiler:2.38.1'
+    implementation 'com.google.dagger:hilt-android:2.50'
+    annotationProcessor 'com.google.dagger:hilt-compiler:2.50'
+    kapt 'com.google.dagger:hilt-compiler:2.50'
 
     wearApp project(':Wear')
 }
@@ -202,7 +203,7 @@ static String toSnakeCase( String text ) {
     text.replaceAll( /([A-Z])/, /_$1/ ).replaceAll( /^_/, '' )
 }
 
-android.applicationVariants.all { variant ->
+android.applicationVariants.configureEach { variant ->
     variant.generateBuildConfigProvider.configure {
         dependsOn(copyGradlePropertiesIfMissing)
     }

--- a/Simplenote/src/debug/AndroidManifest.xml
+++ b/Simplenote/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.automattic.simplenote">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <activity

--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.automattic.simplenote"
     android:installLocation="auto">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/Wear/build.gradle
+++ b/Wear/build.gradle
@@ -7,8 +7,7 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-    buildToolsVersion '29.0.2'
-    compileSdkVersion 29
+    compileSdk 34
 
     buildTypes {
         release {
@@ -20,18 +19,19 @@ android {
 
     defaultConfig {
         applicationId "com.automattic.simplenote"
-        minSdkVersion 23
-        targetSdkVersion 29
+        minSdk 23
+        targetSdk 34
         versionCode 2
         versionName "1.1.0"
     }
+    namespace 'com.automattic.simplenote'
 }
 
 dependencies {
-    compileOnly 'androidx.wear:wear:1.0.0'
+    compileOnly 'androidx.wear:wear:1.3.0'
 
-    implementation 'androidx.wear:wear:1.0.0'
-    implementation 'com.google.android.gms:play-services-wearable:17.0.0'
+    implementation 'androidx.wear:wear:1.3.0'
+    implementation 'com.google.android.gms:play-services-wearable:18.1.0'
 }
 
 repositories {

--- a/Wear/src/main/AndroidManifest.xml
+++ b/Wear/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.automattic.simplenote" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-feature android:name="android.hardware.type.watch" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.4.32'
+    ext.kotlin_version = '1.8.20'
 
     repositories {
         maven {
-            url 'https://a8c-libs.s3.amazonaws.com/android' 
+            url 'https://a8c-libs.s3.amazonaws.com/android'
             content {
                 includeGroup "com.automattic.android"
                 includeGroup "com.automattic.android.publish-to-s3"
@@ -15,9 +15,9 @@ buildscript {
         maven { url 'https://maven.google.com' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:8.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.38'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.50'
         classpath 'com.automattic.android:configure:0.6.1'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,6 @@ org.gradle.jvmargs=-Xmx1536m
 
 android.enableJetifier = true
 android.useAndroidX = true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip


### PR DESCRIPTION
The goal of this PR is to get the app building with SDK 34 as the target. 

**This currently doesn't build**. I'm going to create PRs fix that and once merged then it should start building :)

ToDo
- [ ] Update Kotlin 1.8 syntax
- [ ] Update tracks code to support syntax changes in v3.3.0 of the library

### Fix
<!--
***(Required)*** Add a concise description of what you fixed.  If this is related to an issue, add a link to it.  If applicable, add screenshots, animations, or videos to help illustrate the fix.
-->

### Test
<!--
***(Required)*** List the steps to test the behavior.  For example:
1. Go to...
2. Tap on...
3. See error...
-->

### Review
<!--
***(Required)*** Add instructions for reviewers.  For example:
Only one developer and one designer are required to review these changes, but anyone can perform the review.
-->

### Release
<!--
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.txt` was updated in d3adb3ef with:
> Added markdown support
-->
<!--
If the changes should not be included in release notes, add a statement to this section. For example:
These changes do not require release notes.
-->
