### PR TITLE
Update kotlin syntax

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/AddTagActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AddTagActivity.kt
@@ -98,6 +98,7 @@ class AddTagActivity : AppCompatActivity() {
                     DisplayUtils.hideKeyboard(tagInput)
                     showDialogError()
                 }
+                else -> {}
             }
         })
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumCollaboratorsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumCollaboratorsRepository.kt
@@ -69,17 +69,17 @@ class SimperiumCollaboratorsRepository @Inject constructor(
     override suspend fun collaboratorsChanged(noteId: String): Flow<Boolean> = callbackFlow {
         val callbackOnSaveObject = Bucket.OnSaveObjectListener<Note> { _, note ->
             if (note.simperiumKey == noteId) {
-                offer(true)
+                trySend(true)
             }
         }
         val callbackOnDeleteObject = Bucket.OnDeleteObjectListener<Note> { _, note ->
             if (note.simperiumKey == noteId) {
-                offer(true)
+                trySend(true)
             }
         }
         val callbackOnNetworkChange = Bucket.OnNetworkChangeListener<Note> { _, _, updatedNoteId ->
             if (updatedNoteId != null && noteId == updatedNoteId) {
-                offer(true)
+                trySend(true)
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
@@ -82,9 +82,9 @@ class SimperiumTagsRepository @Inject constructor(
     }
 
     override suspend fun tagsChanged(): Flow<Boolean> = callbackFlow {
-        val callbackOnSaveObject = Bucket.OnSaveObjectListener<Tag> { _, _ -> offer(true) }
-        val callbackOnDeleteObject = Bucket.OnDeleteObjectListener<Tag> { _, _ -> offer(true) }
-        val callbackOnNetworkChange = Bucket.OnNetworkChangeListener<Tag> { _, _, _ -> offer(true) }
+        val callbackOnSaveObject = Bucket.OnSaveObjectListener<Tag> { _, _ -> trySend(true) }
+        val callbackOnDeleteObject = Bucket.OnDeleteObjectListener<Tag> { _, _ -> trySend(true) }
+        val callbackOnNetworkChange = Bucket.OnNetworkChangeListener<Tag> { _, _, _ -> trySend(true) }
 
         tagsBucket.addOnSaveObjectListener(callbackOnSaveObject)
         tagsBucket.addOnDeleteObjectListener(callbackOnDeleteObject)


### PR DESCRIPTION
This PR updates the kotlin syntax to support v1.8. There were a few deprecations for `offer` and a requirement for a `when` default that I just stubbed out.