### PR TITLE
ci: set Java 17 on GH workflow

### DIFF
--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
       - name: Setup Gradle to generate and submit dependency graphs
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
## Description

This PR fixes the GitHub Actions workflow for sending dependencies to GitHub Dependency Graph by setting Java version used by the workflow to 17. It's needed after #1627 

## Testing

No need for manual testing, this should work as soon as it'll land on the main branch. Works fine on fork: https://github.com/wzieba/simplenote-android/actions/runs/7637594726/job/20806763175