### PR TITLE
WIP – Update release-toolkit and code using it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 
 gem 'danger-dangermattic', '~> 1.0'
 gem 'fastlane', '~> 2.219'
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 10.0'

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,7 @@ source 'https://rubygems.org'
 
 gem 'danger-dangermattic', '~> 1.0'
 gem 'fastlane', '~> 2.219'
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 10.0'
+# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 10.0'
+#
+# Temporary using this bug-fix branch
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'mokagio/add-missing-gradle-param'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.6)
       rexml
-    activesupport (7.1.3)
+    activesupport (7.1.3.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -95,8 +95,7 @@ GEM
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.1)
     emoji_regex (3.2.3)
     excon (0.109.0)
     faraday (1.10.3)
@@ -171,7 +170,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (9.4.0)
+    fastlane-plugin-wpmreleasetoolkit (10.0.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
@@ -180,7 +179,7 @@ GEM
       git (~> 1.3)
       google-cloud-storage (~> 1.31)
       java-properties (~> 0.3.0)
-      nokogiri (~> 1.11, < 1.16)
+      nokogiri (~> 1.11, < 1.17)
       octokit (~> 6.1)
       parallel (~> 1.14)
       plist (~> 3.1)
@@ -232,8 +231,9 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.14.1)
+    i18n (1.14.3)
       concurrent-ruby (~> 1.0)
+      racc (~> 1.7)
     java-properties (0.3.0)
     jmespath (1.6.2)
     json (2.7.1)
@@ -246,7 +246,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitest (5.22.1)
+    minitest (5.22.2)
     multi_json (1.15.0)
     multipart-post (2.3.0)
     mutex_m (0.2.0)
@@ -254,7 +254,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     no_proxy_fix (0.1.2)
-    nokogiri (1.15.5)
+    nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (6.1.1)
@@ -349,7 +349,7 @@ PLATFORMS
 DEPENDENCIES
   danger-dangermattic (~> 1.0)
   fastlane (~> 2.219)
-  fastlane-plugin-wpmreleasetoolkit (~> 9.1)
+  fastlane-plugin-wpmreleasetoolkit (~> 10.0)
 
 BUNDLED WITH
    2.4.13

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,32 @@
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit
+  revision: e0fb5d41d69fc46d4f511f0a8619bedd747c1646
+  branch: mokagio/add-missing-gradle-param
+  specs:
+    fastlane-plugin-wpmreleasetoolkit (10.0.0)
+      activesupport (>= 6.1.7.1)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      fastlane (~> 2.213)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      java-properties (~> 0.3.0)
+      nokogiri (~> 1.11, < 1.17)
+      octokit (~> 6.1)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+      xcodeproj (~> 1.22)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.6)
+    CFPropertyList (3.0.7)
+      base64
+      nkf
       rexml
     activesupport (7.1.3.2)
       base64
@@ -15,12 +40,12 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
-    artifactory (3.0.15)
+    artifactory (3.0.17)
     ast (2.4.2)
     atomos (0.1.3)
     aws-eventstream (1.3.0)
-    aws-partitions (1.887.0)
-    aws-sdk-core (3.191.0)
+    aws-partitions (1.895.0)
+    aws-sdk-core (3.191.3)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
@@ -170,23 +195,6 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (10.0.0)
-      activesupport (>= 6.1.7.1)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      fastlane (~> 2.213)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      java-properties (~> 0.3.0)
-      nokogiri (~> 1.11, < 1.17)
-      octokit (~> 6.1)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-      xcodeproj (~> 1.22)
     gh_inspector (1.1.3)
     git (1.19.1)
       addressable (~> 2.8)
@@ -237,7 +245,8 @@ GEM
     java-properties (0.3.0)
     jmespath (1.6.2)
     json (2.7.1)
-    jwt (2.7.1)
+    jwt (2.8.1)
+      base64
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -248,11 +257,12 @@ GEM
     mini_portile2 (2.8.5)
     minitest (5.22.2)
     multi_json (1.15.0)
-    multipart-post (2.3.0)
+    multipart-post (2.4.0)
     mutex_m (0.2.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     naturally (2.2.1)
+    nkf (0.2.0)
     no_proxy_fix (0.1.2)
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
@@ -308,7 +318,7 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     security (0.1.3)
-    signet (0.18.0)
+    signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
@@ -349,7 +359,7 @@ PLATFORMS
 DEPENDENCIES
   danger-dangermattic (~> 1.0)
   fastlane (~> 2.219)
-  fastlane-plugin-wpmreleasetoolkit (~> 10.0)
+  fastlane-plugin-wpmreleasetoolkit!
 
 BUNDLED WITH
    2.4.13

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -67,9 +67,10 @@ platform :android do
   #####################################################################################
   desc 'Creates a new release branch from the current trunk'
   lane :code_freeze do |options|
-    android_codefreeze_prechecks(options)
+    build_gradle_path = File.join(PROJECT_ROOT_FOLDER, 'Simplenote', 'build.gradle')
+    android_codefreeze_prechecks(options.merge(build_gradle_path: build_gradle_path))
 
-    android_bump_version_release
+    android_bump_version_release(build_gradle_path: build_gradle_path)
     new_version = android_get_app_version
     extract_release_notes_for_version(
       version: new_version,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -97,7 +97,7 @@ platform :android do
       from_branch: DEFAULT_BRANCH,
       to_branch: "release/#{new_version}"
     )
-    setfrozentag(
+    set_milestone_frozen_marker(
       repository: GITHUB_REPO,
       milestone: new_version
     )


### PR DESCRIPTION
This is in the attempt to solve a runtime crash where the plugin fails because `build_gradle_path` is not provided.

The crash was likely introduced when upgrading from 9.1.0 to 9.4.0, in 65d742c.

### Fix
<!--
***(Required)*** Add a concise description of what you fixed.  If this is related to an issue, add a link to it.  If applicable, add screenshots, animations, or videos to help illustrate the fix.
-->

### Test
<!--
***(Required)*** List the steps to test the behavior.  For example:
1. Go to...
2. Tap on...
3. See error...
-->

### Review
<!--
***(Required)*** Add instructions for reviewers.  For example:
Only one developer and one designer are required to review these changes, but anyone can perform the review.
-->

### Release
<!--
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.txt` was updated in d3adb3ef with:
> Added markdown support
-->
<!--
If the changes should not be included in release notes, add a statement to this section. For example:
These changes do not require release notes.
-->
