### PR TITLE
Add check for was_sustainer property to verify sustainer status

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -243,10 +243,8 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
 
         final SwitchPreferenceCompat sustainerIconPreference = findPreference("pref_key_sustainer_icon");
         try {
-            if (
-                mPreferencesBucket.get(PREFERENCES_OBJECT_KEY).getCurrentSubscriptionPlatform() != null &&
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
-            ) {
+            boolean wasSustainer = mPreferencesBucket.get(PREFERENCES_OBJECT_KEY).getWasSustainer();
+            if (wasSustainer && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 sustainerIconPreference.setVisible(true);
                 sustainerIconPreference.setOnPreferenceChangeListener((preference, newValue) -> {
                     toggleSustainerAppIcon((boolean) newValue);

--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
@@ -19,6 +19,7 @@ public class Preferences extends BucketObject {
     private static final String SUBSCRIPTION_LEVEL_KEY = "subscription_level";
     private static final String SUBSCRIPTION_PLATFORM_KEY = "subscription_platform";
     private static final String SUBSCRIPTION_DATE_KEY = "subscription_date";
+    private static final String WAS_SUSTAINER_KEY = "was_sustainer";
 
     private Preferences(String key, JSONObject properties) {
         super(key, properties);
@@ -113,6 +114,15 @@ public class Preferences extends BucketObject {
 
     public void setSubscriptionLevel(SubscriptionLevel subscriptionLevel) {
         setProperty(SUBSCRIPTION_LEVEL_KEY, subscriptionLevel.getName());
+    }
+
+    public boolean getWasSustainer() {
+        Object wasSustainer = getProperty(WAS_SUSTAINER_KEY);
+        if (wasSustainer == null) {
+            return false;
+        }
+
+        return (Boolean)getProperty(WAS_SUSTAINER_KEY);
     }
 
     public static class Schema extends BucketSchema<Preferences> {


### PR DESCRIPTION
We've added a flag (or will be soon) to all users that have sustainer status in a `was_sustainer` property on the preferences bucket. This is a more reliable check than checking the `subscription_platform` and will also enable us to reuse the subscription levels in the future for other upgrades.

### Test
* On a non-sustainer account, view the preferences. You should not see the sustainer icon switch.
* Log in with a sustainer account that has the `was_sustainer` flag (DM me in Slack for creds). 
* You should see the sustainer icon switch and it should still work!
