### PR TITLE
Add a check for was_sustainer property to be an int.

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/models/Preferences.java
@@ -122,7 +122,11 @@ public class Preferences extends BucketObject {
             return false;
         }
 
-        return (Boolean)getProperty(WAS_SUSTAINER_KEY);
+        if (wasSustainer instanceof Boolean) {
+            return (Boolean) wasSustainer;
+        } else {
+            return wasSustainer instanceof Integer && ((Integer) wasSustainer) > 0;
+        }
     }
 
     public static class Schema extends BucketSchema<Preferences> {


### PR DESCRIPTION
### Fix
Simperium may return a 1 or 0 int value for the was_sustainer property. I've added a check for that.

### Test
* Not much to test here, I've verified it is working on my device that has the flag enabled or disabled with `1`, `0`, `true` and `false` values.