### PR TITLE
Add notice banner about collaboration removal.

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/CollaboratorsActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/CollaboratorsActivity.kt
@@ -118,7 +118,7 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
             when (event) {
                 is Event.AddCollaboratorEvent -> showAddCollaboratorFragment(event)
                 is Event.RemoveCollaboratorEvent -> showRemoveCollaboratorDialog(event)
-                is Event.ViewCollaborationRetirementEvent -> viewCollaborationRetirement(event)
+                is Event.ViewCollaborationRetirementEvent -> viewCollaborationRetirement()
                 Event.CloseCollaboratorsEvent -> finish()
             }
         })
@@ -152,7 +152,7 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
         dialog.show(supportFragmentManager.beginTransaction(), DIALOG_TAG)
     }
 
-    private fun viewCollaborationRetirement(event: Event.ViewCollaborationRetirementEvent) {
+    private fun viewCollaborationRetirement() {
         val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(collaborationRetirementUrl))
         startActivity(browserIntent)
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/CollaboratorsActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/CollaboratorsActivity.kt
@@ -1,6 +1,7 @@
 package com.automattic.simplenote
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.text.SpannableString
 import android.view.MenuItem
@@ -25,6 +26,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class CollaboratorsActivity : ThemedAppCompatActivity() {
     private val viewModel: CollaboratorsViewModel by viewModels()
+    private val collaborationRetirementUrl = "https://simplenote.com/2024/05/01/collaboration-feature-retirement"
 
     companion object {
         const val NOTE_ID_ARG = "note_id"
@@ -79,6 +81,7 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
         collaboratorsList.setEmptyView(empty.root)
 
         buttonAddCollaborator.setOnClickListener { viewModel.clickAddCollaborator() }
+        collaborationBanner.setOnClickListener { viewModel.clickCollaborationRetirement() }
 
         empty.image.setImageResource(R.drawable.ic_collaborate_24dp)
         empty.title.text = getString(R.string.no_collaborators)
@@ -115,6 +118,7 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
             when (event) {
                 is Event.AddCollaboratorEvent -> showAddCollaboratorFragment(event)
                 is Event.RemoveCollaboratorEvent -> showRemoveCollaboratorDialog(event)
+                is Event.ViewCollaborationRetirementEvent -> viewCollaborationRetirement(event)
                 Event.CloseCollaboratorsEvent -> finish()
             }
         })
@@ -146,6 +150,11 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
     private fun showAddCollaboratorFragment(event: Event.AddCollaboratorEvent) {
         val dialog = AddCollaboratorFragment(event.noteId)
         dialog.show(supportFragmentManager.beginTransaction(), DIALOG_TAG)
+    }
+
+    private fun viewCollaborationRetirement(event: Event.ViewCollaborationRetirementEvent) {
+        val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(collaborationRetirementUrl))
+        startActivity(browserIntent)
     }
 
     private fun showRemoveCollaboratorDialog(event: Event.RemoveCollaboratorEvent) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModel.kt
@@ -62,6 +62,10 @@ class CollaboratorsViewModel @Inject constructor(
         _event.value = Event.AddCollaboratorEvent(noteId)
     }
 
+    fun clickCollaborationRetirement() {
+        _event.value = Event.ViewCollaborationRetirementEvent
+    }
+
     fun clickRemoveCollaborator(collaborator: String) {
         _event.value = Event.RemoveCollaboratorEvent(collaborator)
     }
@@ -103,5 +107,6 @@ class CollaboratorsViewModel @Inject constructor(
         data class AddCollaboratorEvent(val noteId: String) : Event()
         object CloseCollaboratorsEvent : Event()
         data class RemoveCollaboratorEvent(val collaborator: String) : Event()
+        object ViewCollaborationRetirementEvent : Event()
     }
 }

--- a/Simplenote/src/main/res/drawable/bg_banner.xml
+++ b/Simplenote/src/main/res/drawable/bg_banner.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/blue_50" />
+    <corners android:radius="8dp" />
+</shape>

--- a/Simplenote/src/main/res/layout/activity_collaborators.xml
+++ b/Simplenote/src/main/res/layout/activity_collaborators.xml
@@ -9,6 +9,49 @@
 
     <include layout="@layout/toolbar" />
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+        <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            android:id="@+id/collaboration_banner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/padding_medium"
+            android:background="@drawable/bg_banner"
+            android:padding="@dimen/padding_large">
+
+            <ImageView
+                android:id="@+id/simplenote_logo"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_centerVertical="true"
+                android:layout_marginEnd="@dimen/padding_large"
+                android:src="@drawable/ic_simplenote_24dp" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/collaboration_banner_title"
+                android:layout_width="wrap_content"
+                android:textAppearance="?attr/textAppearanceSubtitle2"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/padding_extra_small"
+                android:layout_toEndOf="@+id/simplenote_logo"
+                android:text="@string/collaboration_retirement"
+                android:textColor="@android:color/white"
+                android:textStyle="bold" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/collaboration_banner_title"
+                android:layout_toEndOf="@+id/simplenote_logo"
+                android:text="@string/collaboration_retire_details"
+                android:textAppearance="?attr/textAppearanceBody2"
+                android:textColor="@android:color/white" />
+        </RelativeLayout>
+    </LinearLayout>
+
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -347,6 +347,8 @@
     <string name="collaborators_note_deleted">Note was deleted. You cannot edit collaborators on a note that was deleted.</string>
     <string name="collaborators_note_trashed">Note was trashed. You cannot edit collaborators on a note that is in the trash.</string>
     <string name="no_collaborators">No Collaborators</string>
+    <string name="collaboration_retire_details">Collaboration is retiring on July 1st, 2024. For more details, tap here.</string>
+    <string name="collaboration_retirement">Collaboration Retirement</string>
 
     <!-- PASSCODE -->
     <string name="passcode_change_passcode">Change passcode</string>


### PR DESCRIPTION
### Fix
Adds first notice about collaboration removal. Feature will still work at this point!

<img width="33%" src="https://github.com/Automattic/simplenote-android/assets/789137/024d1f43-8578-4290-905e-2e6c8fc8ae89.jpg" />

### Test
* View the collaborators view
* You should see the banner at the top
* Tap the banner, it should load the browser (the link may 404 if the post isn't published yet)
* Add a collaborator, it should still work and the banner shouldn't interfere with adding/removing collaborators

### Review
One developer please!

