### PR TITLE
Revert collaboration removal notice

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/CollaboratorsActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/CollaboratorsActivity.kt
@@ -1,7 +1,6 @@
 package com.automattic.simplenote
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.text.SpannableString
 import android.view.MenuItem
@@ -26,7 +25,6 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class CollaboratorsActivity : ThemedAppCompatActivity() {
     private val viewModel: CollaboratorsViewModel by viewModels()
-    private val collaborationRetirementUrl = "https://simplenote.com/2024/05/01/collaboration-feature-retirement"
 
     companion object {
         const val NOTE_ID_ARG = "note_id"
@@ -81,7 +79,6 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
         collaboratorsList.setEmptyView(empty.root)
 
         buttonAddCollaborator.setOnClickListener { viewModel.clickAddCollaborator() }
-        collaborationBanner.setOnClickListener { viewModel.clickCollaborationRetirement() }
 
         empty.image.setImageResource(R.drawable.ic_collaborate_24dp)
         empty.title.text = getString(R.string.no_collaborators)
@@ -118,7 +115,6 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
             when (event) {
                 is Event.AddCollaboratorEvent -> showAddCollaboratorFragment(event)
                 is Event.RemoveCollaboratorEvent -> showRemoveCollaboratorDialog(event)
-                is Event.ViewCollaborationRetirementEvent -> viewCollaborationRetirement()
                 Event.CloseCollaboratorsEvent -> finish()
             }
         })
@@ -150,11 +146,6 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
     private fun showAddCollaboratorFragment(event: Event.AddCollaboratorEvent) {
         val dialog = AddCollaboratorFragment(event.noteId)
         dialog.show(supportFragmentManager.beginTransaction(), DIALOG_TAG)
-    }
-
-    private fun viewCollaborationRetirement() {
-        val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(collaborationRetirementUrl))
-        startActivity(browserIntent)
     }
 
     private fun showRemoveCollaboratorDialog(event: Event.RemoveCollaboratorEvent) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModel.kt
@@ -62,10 +62,6 @@ class CollaboratorsViewModel @Inject constructor(
         _event.value = Event.AddCollaboratorEvent(noteId)
     }
 
-    fun clickCollaborationRetirement() {
-        _event.value = Event.ViewCollaborationRetirementEvent
-    }
-
     fun clickRemoveCollaborator(collaborator: String) {
         _event.value = Event.RemoveCollaboratorEvent(collaborator)
     }
@@ -107,6 +103,5 @@ class CollaboratorsViewModel @Inject constructor(
         data class AddCollaboratorEvent(val noteId: String) : Event()
         object CloseCollaboratorsEvent : Event()
         data class RemoveCollaboratorEvent(val collaborator: String) : Event()
-        object ViewCollaborationRetirementEvent : Event()
     }
 }

--- a/Simplenote/src/main/res/drawable/bg_banner.xml
+++ b/Simplenote/src/main/res/drawable/bg_banner.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/blue_50" />
-    <corners android:radius="8dp" />
-</shape>

--- a/Simplenote/src/main/res/layout/activity_collaborators.xml
+++ b/Simplenote/src/main/res/layout/activity_collaborators.xml
@@ -9,49 +9,6 @@
 
     <include layout="@layout/toolbar" />
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
-        <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            android:id="@+id/collaboration_banner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/padding_medium"
-            android:background="@drawable/bg_banner"
-            android:padding="@dimen/padding_large">
-
-            <ImageView
-                android:id="@+id/simplenote_logo"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_centerVertical="true"
-                android:layout_marginEnd="@dimen/padding_large"
-                android:src="@drawable/ic_simplenote_24dp" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/collaboration_banner_title"
-                android:layout_width="wrap_content"
-                android:textAppearance="?attr/textAppearanceSubtitle2"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/padding_extra_small"
-                android:layout_toEndOf="@+id/simplenote_logo"
-                android:text="@string/collaboration_retirement"
-                android:textColor="@android:color/white"
-                android:textStyle="bold" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_below="@+id/collaboration_banner_title"
-                android:layout_toEndOf="@+id/simplenote_logo"
-                android:text="@string/collaboration_retire_details"
-                android:textAppearance="?attr/textAppearanceBody2"
-                android:textColor="@android:color/white" />
-        </RelativeLayout>
-    </LinearLayout>
-
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -347,8 +347,6 @@
     <string name="collaborators_note_deleted">Note was deleted. You cannot edit collaborators on a note that was deleted.</string>
     <string name="collaborators_note_trashed">Note was trashed. You cannot edit collaborators on a note that is in the trash.</string>
     <string name="no_collaborators">No Collaborators</string>
-    <string name="collaboration_retire_details">Collaboration is retiring on July 1st, 2024. For more details, tap here.</string>
-    <string name="collaboration_retirement">Collaboration Retirement</string>
 
     <!-- PASSCODE -->
     <string name="passcode_change_passcode">Change passcode</string>


### PR DESCRIPTION
Collaboration is going to stick around for now!

This reverts commit 533baf071302b08120aa5e8a5bd7100c9df0e2d6, #1652

### Test
Open collaboration panel, no notice about collaboration removal should be displayed.

### Review
Only one developer is required to review these changes, but anyone can perform the review.