### PR TITLE
[Analytics] Add trackers for magic link sign in.

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
@@ -173,7 +173,8 @@ public final class AnalyticsTracker {
         VERIFICATION_RESEND_EMAIL_BUTTON_TAPPED,
         VERIFICATION_DISMISSED,
         SETTINGS_SEARCH_SORT_MODE,
-        AUTH_MAGIC_LINK,
+        USER_REQUESTED_LOGIN_LINK,
+        USER_CONFIRMED_LOGIN_LINK,
     }
 
     public interface Tracker {

--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTracker.java
@@ -172,7 +172,8 @@ public final class AnalyticsTracker {
         VERIFICATION_CHANGE_EMAIL_BUTTON_TAPPED,
         VERIFICATION_RESEND_EMAIL_BUTTON_TAPPED,
         VERIFICATION_DISMISSED,
-        SETTINGS_SEARCH_SORT_MODE
+        SETTINGS_SEARCH_SORT_MODE,
+        AUTH_MAGIC_LINK,
     }
 
     public interface Tracker {

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
@@ -48,7 +48,7 @@ class SignInFragment: MagicLinkableFragment() {
                     hideDialogProgress()
                     showConfirmationScreen(state.username, false)
                     AnalyticsTracker.track(
-                        Stat.AUTH_MAGIC_LINK,
+                        Stat.USER_REQUESTED_LOGIN_LINK,
                         AnalyticsTracker.CATEGORY_USER,
                         "user_requested_login_link"
                     )

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
@@ -7,13 +7,14 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.TextView
+import androidx.fragment.app.viewModels
 import com.automattic.simplenote.R
+import com.automattic.simplenote.analytics.AnalyticsTracker
+import com.automattic.simplenote.analytics.AnalyticsTracker.Stat
 import com.automattic.simplenote.utils.NetworkUtils
 import com.automattic.simplenote.viewmodels.MagicLinkRequestUiState
 import com.automattic.simplenote.viewmodels.RequestMagicLinkViewModel
 import dagger.hilt.android.AndroidEntryPoint
-
-import androidx.fragment.app.viewModels
 
 @AndroidEntryPoint
 class SignInFragment: MagicLinkableFragment() {
@@ -46,6 +47,11 @@ class SignInFragment: MagicLinkableFragment() {
                 is MagicLinkRequestUiState.Success -> {
                     hideDialogProgress()
                     showConfirmationScreen(state.username, false)
+                    AnalyticsTracker.track(
+                        Stat.AUTH_MAGIC_LINK,
+                        AnalyticsTracker.CATEGORY_USER,
+                        "user_requested_login_link"
+                    )
                 }
             }
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteAuthenticationActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteAuthenticationActivity.java
@@ -1,8 +1,6 @@
 package com.automattic.simplenote.authentication;
 
-import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_USER;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.AUTH_MAGIC_LINK;
-import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.USER_SIGNED_IN;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_USER;;
 
 import android.app.AlertDialog;
 import android.content.Context;
@@ -62,7 +60,7 @@ public class SimplenoteAuthenticationActivity extends AuthenticationActivity {
                     notesIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION & (Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
                     startActivity(notesIntent);
                     AnalyticsTracker.track(
-                            AUTH_MAGIC_LINK,
+                            AnalyticsTracker.Stat.USER_CONFIRMED_LOGIN_LINK,
                             CATEGORY_USER,
                             "user_confirmed_login_link"
                     );

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteAuthenticationActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteAuthenticationActivity.java
@@ -1,5 +1,9 @@
 package com.automattic.simplenote.authentication;
 
+import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_USER;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.AUTH_MAGIC_LINK;
+import static com.automattic.simplenote.analytics.AnalyticsTracker.Stat.USER_SIGNED_IN;
+
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
@@ -57,6 +61,11 @@ public class SimplenoteAuthenticationActivity extends AuthenticationActivity {
                     final Intent notesIntent = IntentUtils.maybeAliasedIntent(this.getApplicationContext());
                     notesIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION & (Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
                     startActivity(notesIntent);
+                    AnalyticsTracker.track(
+                            AUTH_MAGIC_LINK,
+                            CATEGORY_USER,
+                            "user_confirmed_login_link"
+                    );
                     finish();
                 } else if (state instanceof MagicLinkUiState.Error) {
                     showDialogError(((MagicLinkUiState.Error) state).getMessageRes());


### PR DESCRIPTION
### Fix

This PR adds two analytics events for magic link: `user_requested_login_link` and `user_confirmed_login_link`. I added a new `Stat` for this to make it clearer.

### Test

- [ ] 🚬 test magic link and successfully log in.
- [ ] I assume tracks shows events in logs?

### Review

@roundhill since I believe you added analytics in the past. Let me know if the new `Stat` is necessary. I did it for clarity, but none of the other ones seemed to fit.