### PR TITLE
[Auth] Update magic links for the new complete login update.

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -125,6 +125,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
     implementation 'androidx.work:work-runtime:2.7.1'
     implementation 'androidx.concurrent:concurrent-futures:1.1.0'
+    implementation "androidx.constraintlayout:constraintlayout:1.1.3"
     implementation "androidx.multidex:multidex:2.0.1"
     // Support for ViewModels and LiveData
     implementation "androidx.activity:activity-ktx:1.3.1"

--- a/Simplenote/src/main/AndroidManifest.xml
+++ b/Simplenote/src/main/AndroidManifest.xml
@@ -176,7 +176,7 @@
 
         <activity
             android:name=".authentication.SimplenoteSignupActivity"
-            android:theme="@style/Simperium" />
+            android:theme="@style/SignUpOverride" />
 
         <activity
             android:name="com.automattic.simplenote.StyleActivity"

--- a/Simplenote/src/main/java/com/automattic/simplenote/DeepLinkActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/DeepLinkActivity.kt
@@ -80,7 +80,7 @@ class DeepLinkActivity : AppCompatActivity() {
         } else {
             Toast.makeText(
                 this,
-                getString(R.string.magic_link_complete_login_error_message),
+                getString(R.string.magic_link_general_error),
                 Toast.LENGTH_SHORT
             ).show()
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/DeepLinkActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/DeepLinkActivity.kt
@@ -3,12 +3,18 @@ package com.automattic.simplenote
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Base64
+import android.util.Log
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.automattic.simplenote.authentication.SimplenoteAuthenticationActivity
 import com.automattic.simplenote.utils.AuthUtils
 import com.automattic.simplenote.utils.IntentUtils
 import net.openid.appauth.RedirectUriReceiverActivity
+import java.lang.IllegalArgumentException
+import java.nio.charset.StandardCharsets
+
+const val TAG = "DeepLinkActivity"
 
 class DeepLinkActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -25,7 +31,7 @@ class DeepLinkActivity : AppCompatActivity() {
                 startMagicLinkConfirmation(uri)
             }
             LOGIN_SCHEME -> {
-                if (queryParamContainsData(uri.query, AUTH_KEY_QUERY) && queryParamContainsData(uri.query, AUTH_CODE_QUERY)) {
+                if (queryParamContainsData(uri.query, USERNAME_KEY_QUERY) && queryParamContainsData(uri.query, AUTH_CODE_QUERY)) {
                     startMagicLinkConfirmation(uri)
                 } else {
                     val intent = IntentUtils.maybeAliasedIntent(applicationContext)
@@ -55,12 +61,19 @@ class DeepLinkActivity : AppCompatActivity() {
             startActivity(intent)
             return
         }
-        val authKey = uri?.getQueryParameter(AUTH_KEY_QUERY)
+        val base64Username = uri?.getQueryParameter(USERNAME_KEY_QUERY)
+        var decodedUsername: String? = null
+        try {
+            decodedUsername = String(Base64.decode(base64Username, Base64.DEFAULT), StandardCharsets.UTF_8)
+        } catch (e: IllegalArgumentException) {
+            Log.e(TAG, "Problem decoding base64 username", e)
+        }
         val authCode = uri?.getQueryParameter(AUTH_CODE_QUERY)
-        if (!authKey.isNullOrBlank() && !authCode.isNullOrBlank()) {
+        if (!decodedUsername.isNullOrBlank() && !authCode.isNullOrBlank()) {
+
             val intent = Intent(this, SimplenoteAuthenticationActivity::class.java)
             intent.putExtra(SimplenoteAuthenticationActivity.KEY_IS_MAGIC_LINK, true);
-            intent.putExtra(SimplenoteAuthenticationActivity.KEY_MAGIC_LINK_AUTH_KEY, authKey)
+            intent.putExtra(SimplenoteAuthenticationActivity.KEY_MAGIC_LINK_AUTH_KEY, decodedUsername)
             intent.putExtra(SimplenoteAuthenticationActivity.KEY_MAGIC_LINK_AUTH_CODE, authCode)
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
             startActivity(intent)
@@ -82,7 +95,7 @@ class DeepLinkActivity : AppCompatActivity() {
         private const val LOGIN_SCHEME = "login"
         private const val VERIFIED_WEB_SCHEME = "app.simplenote.com"
 
-        private const val AUTH_KEY_QUERY = "auth_key"
+        private const val USERNAME_KEY_QUERY = "email"
         private const val AUTH_CODE_QUERY = "auth_code"
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/MagicLinkableFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/MagicLinkableFragment.kt
@@ -13,6 +13,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import com.automattic.simplenote.R
+import com.automattic.simplenote.authentication.magiclink.MagicLinkConfirmationFragment
 import com.google.android.material.textfield.TextInputLayout
 import com.simperium.android.ProgressDialogFragment
 
@@ -72,10 +73,18 @@ abstract class MagicLinkableFragment : Fragment() {
     }
 
     protected fun showConfirmationScreen(email: String, isSignUp: Boolean) {
-        val confirmationFragment = ConfirmationFragment.newInstance(email, isSignUp)
-        requireFragmentManager().beginTransaction()
-            .replace(R.id.fragment_container, confirmationFragment, SimplenoteSignupActivity.SIGNUP_FRAGMENT_TAG)
-            .commit()
+        if (isSignUp) {
+            val confirmationFragment = ConfirmationFragment.newInstance(email, isSignUp)
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, confirmationFragment, SimplenoteSignupActivity.SIGNUP_FRAGMENT_TAG)
+                .commit()
+        } else {
+            val magicLinkConfirmationFrag = MagicLinkConfirmationFragment.newInstance(email)
+            parentFragmentManager.beginTransaction()
+                .add(R.id.fragment_container, magicLinkConfirmationFrag, SimplenoteSignupActivity.SIGNUP_FRAGMENT_TAG)
+                .addToBackStack(null)
+                .commit()
+        }
     }
 
     fun showProgressDialog(label: String) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/MagicLinkableFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/MagicLinkableFragment.kt
@@ -88,14 +88,18 @@ abstract class MagicLinkableFragment : Fragment() {
     }
 
     fun showProgressDialog(label: String) {
-        progressDialogFragment =
-            ProgressDialogFragment.newInstance(label)
-        progressDialogFragment?.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Simperium)
-        progressDialogFragment?.show(requireFragmentManager(), ProgressDialogFragment.TAG)
+        val existingProgressFrag = parentFragmentManager.findFragmentByTag(ProgressDialogFragment.TAG)
+        if (existingProgressFrag == null) {
+            progressDialogFragment =
+                ProgressDialogFragment.newInstance(label)
+            progressDialogFragment?.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Simperium)
+            progressDialogFragment?.show(requireFragmentManager(), ProgressDialogFragment.TAG)
+        }
     }
 
     protected fun hideDialogProgress() {
-        progressDialogFragment?.let {
+        val existingProgressFrag = progressDialogFragment ?: (parentFragmentManager.findFragmentByTag(ProgressDialogFragment.TAG) as ProgressDialogFragment?)
+        existingProgressFrag?.let {
             if (!it.isHidden) {
                 it.dismiss()
                 progressDialogFragment = null

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
@@ -127,6 +127,7 @@ class SignInFragment: MagicLinkableFragment() {
                     Toast.makeText(context, getString(state.messageRes), Toast.LENGTH_LONG).show()
                 }
                 is MagicLinkRequestUiState.Success -> {
+                    viewModel.resetState()
                     hideDialogProgress()
                     showConfirmationScreen(state.username, false)
                     AnalyticsTracker.track(
@@ -134,6 +135,10 @@ class SignInFragment: MagicLinkableFragment() {
                         AnalyticsTracker.CATEGORY_USER,
                         "user_requested_login_link"
                     )
+                }
+
+                else -> {
+                    // no-ops
                 }
             }
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
@@ -36,10 +36,7 @@ class SignInFragment: MagicLinkableFragment() {
 
     val viewModel: RequestMagicLinkViewModel by viewModels()
 
-
-    private var loginWithWordpress: Button? = null
-
-    private var mAuthState: String? = null
+    private var authState: String? = null
 
     private var signUpCallback: SignUpCallback? = null
 
@@ -68,7 +65,7 @@ class SignInFragment: MagicLinkableFragment() {
             val authSuccess = WordPressUtils.processAuthResponse(
                 activity?.application as Simplenote?,
                 authorizationResponse,
-                mAuthState,
+                authState,
                 true
             )
             if (!authSuccess) {
@@ -87,19 +84,16 @@ class SignInFragment: MagicLinkableFragment() {
     override fun inflateLayout(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.fragment_login, container, false)
 
-        loginWithWordpress = view.findViewById(R.id.button_login_with_wordpress)
+        val loginWithWordpress: Button? = view.findViewById(R.id.button_login_with_wordpress)
         loginWithWordpress?.setOnClickListener {
-            val ctx = context ?: return@setOnClickListener
             val authRequestBuilder = WordPressUtils.getWordPressAuthorizationRequestBuilder()
 
             // Set unique state value.
-
-            // Set unique state value.
-            mAuthState = "app-" + UUID.randomUUID()
-            authRequestBuilder.setState(mAuthState)
+            authState = "app-" + UUID.randomUUID()
+            authRequestBuilder.setState(authState)
 
             val request = authRequestBuilder.build()
-            authService = AuthorizationService(ctx)
+            authService = AuthorizationService(loginWithWordpress.context)
             authService?.getAuthorizationRequestIntent(request)?.let {
                 resultLauncher.launch(it)
             }
@@ -150,7 +144,7 @@ class SignInFragment: MagicLinkableFragment() {
 
     override fun onActionButtonClicked(view: View, emailEditText: EditText) {
         if (NetworkUtils.isNetworkAvailable(requireContext())) {
-            viewModel?.requestLogin(emailEditText.text.toString())
+            viewModel.requestLogin(emailEditText.text.toString())
         } else {
             showDialogError(getString(R.string.simperium_dialog_message_network))
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
@@ -1,7 +1,6 @@
 package com.automattic.simplenote.authentication
 
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -37,8 +36,6 @@ class SignInFragment: MagicLinkableFragment() {
     val viewModel: RequestMagicLinkViewModel by viewModels()
 
     private var authState: String? = null
-
-    private var signUpCallback: SignUpCallback? = null
 
     private var authService: AuthorizationService? = null
 
@@ -107,13 +104,7 @@ class SignInFragment: MagicLinkableFragment() {
         return view
     }
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        signUpCallback = context as SignUpCallback?
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        signUpCallback?.setTitle(getString(R.string.login_screen_title))
         viewModel.magicLinkRequestUiState.observe(this.viewLifecycleOwner) { state ->
             when (state) {
                 is MagicLinkRequestUiState.Loading -> {

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
@@ -1,49 +1,137 @@
 package com.automattic.simplenote.authentication
 
+import android.app.Activity
+import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.EditText
-import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
 import com.automattic.simplenote.R
+import com.automattic.simplenote.Simplenote
 import com.automattic.simplenote.analytics.AnalyticsTracker
 import com.automattic.simplenote.analytics.AnalyticsTracker.Stat
 import com.automattic.simplenote.utils.NetworkUtils
+import com.automattic.simplenote.utils.StrUtils
+import com.automattic.simplenote.utils.WordPressUtils
 import com.automattic.simplenote.viewmodels.MagicLinkRequestUiState
 import com.automattic.simplenote.viewmodels.RequestMagicLinkViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import net.openid.appauth.AuthorizationException
+import net.openid.appauth.AuthorizationResponse
+import net.openid.appauth.AuthorizationService
+import java.util.UUID
+
+const val TAG = "SignInFragment"
 
 @AndroidEntryPoint
 class SignInFragment: MagicLinkableFragment() {
 
     val viewModel: RequestMagicLinkViewModel by viewModels()
 
-    private var loginWithPassword: TextView? = null
+
+    private var loginWithWordpress: Button? = null
+
+    private var mAuthState: String? = null
+
+    private var signUpCallback: SignUpCallback? = null
+
+    private var authService: AuthorizationService? = null
+
+    private var resultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+
+        val data = result.data
+        if (data == null) {
+            Log.d(TAG, "Result code does not match WordPressUtils.OAUTH_ACTIVITY_CODE, or data was null")
+            return@registerForActivityResult
+        }
+
+        val authorizationResponse = AuthorizationResponse.fromIntent(data)
+        val authorizationException = AuthorizationException.fromIntent(data)
+
+        if (authorizationException != null) {
+            val dataUri: Uri = data.data ?: return@registerForActivityResult
+            if (StrUtils.isSameStr(dataUri.getQueryParameter("code"), "1")) {
+                showDialogError(getString(R.string.wpcom_log_in_error_unverified))
+            } else {
+                showDialogError(getString(R.string.wpcom_log_in_error_generic))
+            }
+        } else if (authorizationResponse != null) {
+            // Save token and finish activity.
+            val authSuccess = WordPressUtils.processAuthResponse(
+                activity?.application as Simplenote?,
+                authorizationResponse,
+                mAuthState,
+                true
+            )
+            if (!authSuccess) {
+                showDialogError(getString(R.string.wpcom_log_in_error_generic))
+            } else {
+                AnalyticsTracker.track(
+                    Stat.WPCC_LOGIN_SUCCEEDED,
+                    AnalyticsTracker.CATEGORY_USER,
+                    "wpcc_login_succeeded_signin_activity"
+                )
+                activity?.finish()
+            }
+        }
+    }
 
     override fun inflateLayout(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.fragment_login, container, false)
-        loginWithPassword = view.findViewById(R.id.login_with_password_button)
-        loginWithPassword?.setOnClickListener { _ ->
-            activity?.let { act ->
-                val intent = Intent(act, SimplenoteCredentialsActivity::class.java)
-                intent.putExtra("EXTRA_IS_LOGIN", true)
-                this.startActivity(intent)
-                act.finish()
+
+        loginWithWordpress = view.findViewById(R.id.button_login_with_wordpress)
+        loginWithWordpress?.setOnClickListener {
+            val ctx = context ?: return@setOnClickListener
+            val authRequestBuilder = WordPressUtils.getWordPressAuthorizationRequestBuilder()
+
+            // Set unique state value.
+
+            // Set unique state value.
+            mAuthState = "app-" + UUID.randomUUID()
+            authRequestBuilder.setState(mAuthState)
+
+            val request = authRequestBuilder.build()
+            authService = AuthorizationService(ctx)
+            authService?.getAuthorizationRequestIntent(request)?.let {
+                resultLauncher.launch(it)
             }
+
+            AnalyticsTracker.track(
+                Stat.WPCC_BUTTON_PRESSED,
+                AnalyticsTracker.CATEGORY_USER,
+                "wpcc_button_press_signin_activity"
+            )
         }
         return view
     }
 
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        signUpCallback = context as SignUpCallback?
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        signUpCallback?.setTitle(getString(R.string.login_screen_title))
         viewModel.magicLinkRequestUiState.observe(this.viewLifecycleOwner) { state ->
             when (state) {
                 is MagicLinkRequestUiState.Loading -> {
                     showProgressDialog(getString(state.messageRes))
                 }
-                is MagicLinkRequestUiState.Error -> hideDialogProgress()
+                is MagicLinkRequestUiState.Error -> {
+                    hideDialogProgress()
+                    if (state.code == 429) {
+                        showLoginWithPassword(activity)
+                    }
+                    Toast.makeText(context, getString(state.messageRes), Toast.LENGTH_LONG).show()
+                }
                 is MagicLinkRequestUiState.Success -> {
                     hideDialogProgress()
                     showConfirmationScreen(state.username, false)
@@ -65,6 +153,23 @@ class SignInFragment: MagicLinkableFragment() {
             viewModel?.requestLogin(emailEditText.text.toString())
         } else {
             showDialogError(getString(R.string.simperium_dialog_message_network))
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        resultLauncher.unregister()
+        authService?.dispose()
+    }
+
+    companion object {
+        fun showLoginWithPassword(activity: Activity?) {
+            activity?.let { act ->
+                val intent = Intent(act, SimplenoteCredentialsActivity::class.java)
+                intent.putExtra("EXTRA_IS_LOGIN", true)
+                activity.startActivity(intent)
+                act.finish()
+            }
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignUpCallback.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignUpCallback.kt
@@ -1,5 +1,0 @@
-package com.automattic.simplenote.authentication
-
-interface SignUpCallback {
-    fun setTitle(title: String?)
-}

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignUpCallback.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignUpCallback.kt
@@ -1,0 +1,5 @@
+package com.automattic.simplenote.authentication
+
+interface SignUpCallback {
+    fun setTitle(title: String?)
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteAuthenticationActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteAuthenticationActivity.java
@@ -16,6 +16,7 @@ import androidx.lifecycle.ViewModelProvider;
 import com.automattic.simplenote.R;
 import com.automattic.simplenote.Simplenote;
 import com.automattic.simplenote.analytics.AnalyticsTracker;
+import com.automattic.simplenote.utils.IntentUtils;
 import com.automattic.simplenote.utils.StrUtils;
 import com.automattic.simplenote.utils.WordPressUtils;
 import com.automattic.simplenote.viewmodels.MagicLinkUiState;
@@ -61,6 +62,17 @@ public class SimplenoteAuthenticationActivity extends AuthenticationActivity {
                 if (state instanceof MagicLinkUiState.Success) {
                     final MagicLinkUiState.Success stateResult = (MagicLinkUiState.Success) state;
                     simplenote.loginWithToken(stateResult.getEmail(), stateResult.getToken());
+
+                    final Intent notesIntent = IntentUtils.maybeAliasedIntent(this.getApplicationContext());
+                    notesIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION & (Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
+                    startActivity(notesIntent);
+
+                    AnalyticsTracker.track(
+                            AnalyticsTracker.Stat.USER_CONFIRMED_LOGIN_LINK,
+                            AnalyticsTracker.CATEGORY_USER,
+                            "user_confirmed_login_link"
+                    );
+
                     finish();
                 } else if (state instanceof MagicLinkUiState.Error) {
                     showDialogError(((MagicLinkUiState.Error) state).getMessageRes());

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteAuthenticationActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteAuthenticationActivity.java
@@ -2,6 +2,7 @@ package com.automattic.simplenote.authentication;
 
 import static com.automattic.simplenote.analytics.AnalyticsTracker.CATEGORY_USER;;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
@@ -46,6 +47,18 @@ public class SimplenoteAuthenticationActivity extends AuthenticationActivity {
     @Nullable
     private CompleteMagicLinkViewModel completeMagicLinkViewModel = null;
 
+    public static void startNotesActivity(final Activity activity) {
+        final Intent notesIntent = IntentUtils.maybeAliasedIntent(activity.getApplicationContext());
+        notesIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION & (Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
+        activity.startActivity(notesIntent);
+        AnalyticsTracker.track(
+                AnalyticsTracker.Stat.USER_CONFIRMED_LOGIN_LINK,
+                CATEGORY_USER,
+                "user_confirmed_login_link"
+        );
+        activity.finish();
+    }
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -56,15 +69,7 @@ public class SimplenoteAuthenticationActivity extends AuthenticationActivity {
             completeMagicLinkViewModel = new ViewModelProvider(this).get(CompleteMagicLinkViewModel.class);
             completeMagicLinkViewModel.getMagicLinkUiState().observe(this, state -> {
                 if (MagicLinkUiState.Success.INSTANCE.equals(state)) {
-                    final Intent notesIntent = IntentUtils.maybeAliasedIntent(this.getApplicationContext());
-                    notesIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION & (Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
-                    startActivity(notesIntent);
-                    AnalyticsTracker.track(
-                            AnalyticsTracker.Stat.USER_CONFIRMED_LOGIN_LINK,
-                            CATEGORY_USER,
-                            "user_confirmed_login_link"
-                    );
-                    finish();
+                    startNotesActivity(this);
                 } else if (state instanceof MagicLinkUiState.Error) {
                     showDialogError(((MagicLinkUiState.Error) state).getMessageRes());
                 }
@@ -133,6 +138,11 @@ public class SimplenoteAuthenticationActivity extends AuthenticationActivity {
         intent.putExtra(SimplenoteSignupActivity.KEY_IS_LOGIN, true);
         startActivity(intent);
         this.finish();
+    }
+
+    @Override
+    protected void buttonLoginClicked() {
+        onLoginSheetEmailClicked();
     }
 
     @Override

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteAuthenticationActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteAuthenticationActivity.java
@@ -29,6 +29,8 @@ import net.openid.appauth.AuthorizationService;
 
 import java.util.UUID;
 
+import javax.inject.Inject;
+
 import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
@@ -44,6 +46,9 @@ public class SimplenoteAuthenticationActivity extends AuthenticationActivity {
     @Nullable
     private AlertDialog mPendingDialog;
 
+    @Inject
+    Simplenote simplenote;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -53,7 +58,9 @@ public class SimplenoteAuthenticationActivity extends AuthenticationActivity {
         if (isMagicLink) {
             CompleteMagicLinkViewModel completeMagicLinkViewModel = new ViewModelProvider(this).get(CompleteMagicLinkViewModel.class);
             completeMagicLinkViewModel.getMagicLinkUiState().observe(this, state -> {
-                if (MagicLinkUiState.Success.INSTANCE.equals(state)) {
+                if (state instanceof MagicLinkUiState.Success) {
+                    final MagicLinkUiState.Success stateResult = (MagicLinkUiState.Success) state;
+                    simplenote.loginWithToken(stateResult.getEmail(), stateResult.getToken());
                     finish();
                 } else if (state instanceof MagicLinkUiState.Error) {
                     showDialogError(((MagicLinkUiState.Error) state).getMessageRes());

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteSignupActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteSignupActivity.java
@@ -39,8 +39,7 @@ public class SimplenoteSignupActivity extends AppCompatActivity implements SignU
             fragment = createFragment(isSignUp);
         }
         getSupportFragmentManager().beginTransaction()
-            .add(R.id.fragment_container, fragment, SIGNUP_FRAGMENT_TAG)
-                .addToBackStack(null)
+            .replace(R.id.fragment_container, fragment, SIGNUP_FRAGMENT_TAG)
             .commit();
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteSignupActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteSignupActivity.java
@@ -2,6 +2,7 @@ package com.automattic.simplenote.authentication;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MenuItem;
 
 import androidx.annotation.Nullable;
@@ -10,15 +11,18 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 
 import com.automattic.simplenote.R;
+import com.automattic.simplenote.authentication.magiclink.MagicLinkConfirmationFragment;
 
 import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
-public class SimplenoteSignupActivity extends AppCompatActivity {
+public class SimplenoteSignupActivity extends AppCompatActivity implements SignUpCallback {
     public final static String SIGNUP_FRAGMENT_TAG = "signup";
 
     // Used to differentiate between sign in and sign up in the sign in activity
     public static final String KEY_IS_LOGIN = "KEY_IS_LOGIN";
+
+    Toolbar mToolbar;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -35,7 +39,8 @@ public class SimplenoteSignupActivity extends AppCompatActivity {
             fragment = createFragment(isSignUp);
         }
         getSupportFragmentManager().beginTransaction()
-            .replace(R.id.fragment_container, fragment, SIGNUP_FRAGMENT_TAG)
+            .add(R.id.fragment_container, fragment, SIGNUP_FRAGMENT_TAG)
+                .addToBackStack(null)
             .commit();
     }
 
@@ -48,13 +53,13 @@ public class SimplenoteSignupActivity extends AppCompatActivity {
     }
 
     private void initToolbar(final boolean isSignUp) {
-        Toolbar toolbar = findViewById(com.simperium.R.id.toolbar);
+        mToolbar = findViewById(com.simperium.R.id.toolbar);
         if (isSignUp) {
-            toolbar.setTitle(R.string.simperium_button_signup);
+            mToolbar.setTitle(R.string.simperium_button_signup);
         } else {
-            toolbar.setTitle(R.string.login_screen_title);
+            mToolbar.setTitle(R.string.login_screen_title);
         }
-        setSupportActionBar(toolbar);
+        setSupportActionBar(mToolbar);
 
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
@@ -74,8 +79,21 @@ public class SimplenoteSignupActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
+        Fragment fragment = getSupportFragmentManager().findFragmentByTag(SIGNUP_FRAGMENT_TAG);
+        if (fragment instanceof MagicLinkConfirmationFragment) {
+            // Old logic doesn't expect a backstack of fragments. This is to fit magic links only.
+            super.onBackPressed();
+            return;
+        }
         // This is weird. But see SimplenoteCredentialsActivity for why this is necessary.
         startActivity(new Intent(this, SimplenoteAuthenticationActivity.class));
         finish();
+    }
+
+    @Override
+    public void setTitle(String title) {
+        if (mToolbar != null) {
+            mToolbar.setTitle(title);
+        }
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteSignupActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteSignupActivity.java
@@ -2,7 +2,6 @@ package com.automattic.simplenote.authentication;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.MenuItem;
 
 import androidx.annotation.Nullable;
@@ -37,10 +36,10 @@ public class SimplenoteSignupActivity extends AppCompatActivity implements SignU
         Fragment fragment = getSupportFragmentManager().findFragmentByTag(SIGNUP_FRAGMENT_TAG);
         if (fragment == null) {
             fragment = createFragment(isSignUp);
+            getSupportFragmentManager().beginTransaction()
+                    .replace(R.id.fragment_container, fragment, SIGNUP_FRAGMENT_TAG)
+                    .commit();
         }
-        getSupportFragmentManager().beginTransaction()
-            .replace(R.id.fragment_container, fragment, SIGNUP_FRAGMENT_TAG)
-            .commit();
     }
 
     private Fragment createFragment(final boolean isSignUp) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteSignupActivity.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SimplenoteSignupActivity.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
 import com.automattic.simplenote.R;
 import com.automattic.simplenote.authentication.magiclink.MagicLinkConfirmationFragment;
@@ -15,13 +16,27 @@ import com.automattic.simplenote.authentication.magiclink.MagicLinkConfirmationF
 import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
-public class SimplenoteSignupActivity extends AppCompatActivity implements SignUpCallback {
+public class SimplenoteSignupActivity extends AppCompatActivity {
     public final static String SIGNUP_FRAGMENT_TAG = "signup";
 
     // Used to differentiate between sign in and sign up in the sign in activity
     public static final String KEY_IS_LOGIN = "KEY_IS_LOGIN";
 
     Toolbar mToolbar;
+
+    FragmentManager.OnBackStackChangedListener mBackstackListener = new FragmentManager.OnBackStackChangedListener() {
+        @Override
+        public void onBackStackChanged() {
+            final Fragment fragment = getSupportFragmentManager().findFragmentByTag(SIGNUP_FRAGMENT_TAG);
+            if (fragment instanceof SignInFragment) {
+                mToolbar.setTitle(R.string.login_screen_title);
+            } else if (fragment instanceof SignupFragment) {
+                mToolbar.setTitle(R.string.simperium_button_signup);
+            } else if (fragment instanceof MagicLinkConfirmationFragment) {
+                mToolbar.setTitle(R.string.magic_link_enter_code_title);
+            }
+        }
+    };
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -48,6 +63,18 @@ public class SimplenoteSignupActivity extends AppCompatActivity implements SignU
         } else {
             return new SignInFragment();
         }
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        getSupportFragmentManager().removeOnBackStackChangedListener(mBackstackListener);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        getSupportFragmentManager().addOnBackStackChangedListener(mBackstackListener);
     }
 
     private void initToolbar(final boolean isSignUp) {
@@ -86,12 +113,5 @@ public class SimplenoteSignupActivity extends AppCompatActivity implements SignU
         // This is weird. But see SimplenoteCredentialsActivity for why this is necessary.
         startActivity(new Intent(this, SimplenoteAuthenticationActivity.class));
         finish();
-    }
-
-    @Override
-    public void setTitle(String title) {
-        if (mToolbar != null) {
-            mToolbar.setTitle(title);
-        }
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
@@ -62,10 +62,12 @@ class MagicLinkConfirmationFragment : Fragment() {
                     showProgressDialog(getString(state.messageRes))
                 }
                 is MagicLinkUiState.Success -> {
+                    completeMagicLinkViewModel.resetState()
                     hideDialogProgress()
                     activity?.finish()
                 }
                 is MagicLinkUiState.Error -> {
+                    completeMagicLinkViewModel.resetState()
                     hideDialogProgress()
                     Toast.makeText(context, getString(state.messageRes), Toast.LENGTH_LONG).show()
                 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
@@ -17,7 +17,7 @@ import androidx.fragment.app.viewModels
 import com.automattic.simplenote.R
 import com.automattic.simplenote.authentication.SignInFragment
 import com.automattic.simplenote.authentication.SignUpCallback
-import com.automattic.simplenote.authentication.SimplenoteAuthenticationActivity
+import com.automattic.simplenote.utils.NetworkUtils
 import com.automattic.simplenote.viewmodels.CompleteMagicLinkViewModel
 import com.automattic.simplenote.viewmodels.MagicLinkUiState
 import com.simperium.android.ProgressDialogFragment
@@ -63,7 +63,7 @@ class MagicLinkConfirmationFragment : Fragment() {
                 }
                 is MagicLinkUiState.Success -> {
                     hideDialogProgress()
-                    SimplenoteAuthenticationActivity.startNotesActivity(activity)
+                    activity?.finish()
                 }
                 is MagicLinkUiState.Error -> {
                     hideDialogProgress()
@@ -82,7 +82,11 @@ class MagicLinkConfirmationFragment : Fragment() {
             val code = codeEditText?.text?.toString()
             val username = arguments?.getString(PARAM_USERNAME)
             if (!code.isNullOrBlank() && !username.isNullOrBlank()) {
-                completeMagicLinkViewModel.completeLogin(username, code)
+                if (NetworkUtils.isNetworkAvailable(view.context)) {
+                    completeMagicLinkViewModel.completeLogin(username, code, true)
+                } else {
+                    Toast.makeText(view.context, getString(R.string.simperium_dialog_message_network), Toast.LENGTH_SHORT).show()
+                }
             }
         }
         codeEditText?.addTextChangedListener(object : TextWatcher {

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.automattic.simplenote.R
+import com.automattic.simplenote.Simplenote
 import com.automattic.simplenote.authentication.SignInFragment
 import com.automattic.simplenote.utils.HtmlCompat
 import com.automattic.simplenote.utils.NetworkUtils
@@ -21,9 +22,12 @@ import com.automattic.simplenote.viewmodels.CompleteMagicLinkViewModel
 import com.automattic.simplenote.viewmodels.MagicLinkUiState
 import com.simperium.android.ProgressDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MagicLinkConfirmationFragment : Fragment() {
+
+    @Inject lateinit var simplenote: Simplenote
 
     private var progressDialogFragment: ProgressDialogFragment? = null
 
@@ -55,7 +59,10 @@ class MagicLinkConfirmationFragment : Fragment() {
                 is MagicLinkUiState.Success -> {
                     completeMagicLinkViewModel.resetState()
                     hideDialogProgress()
-                    activity?.finish()
+                    simplenote?.let {
+                        it.loginWithToken(state.email, state.token)
+                        activity?.finish()
+                    }
                 }
                 is MagicLinkUiState.Error -> {
                     completeMagicLinkViewModel.resetState()

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
@@ -1,0 +1,122 @@
+package com.automattic.simplenote.authentication.magiclink
+
+import android.content.Context
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import android.widget.Toast
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.automattic.simplenote.R
+import com.automattic.simplenote.authentication.SignInFragment
+import com.automattic.simplenote.authentication.SignUpCallback
+import com.automattic.simplenote.authentication.SimplenoteAuthenticationActivity
+import com.automattic.simplenote.viewmodels.CompleteMagicLinkViewModel
+import com.automattic.simplenote.viewmodels.MagicLinkUiState
+import com.simperium.android.ProgressDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MagicLinkConfirmationFragment : Fragment() {
+
+    private var progressDialogFragment: ProgressDialogFragment? = null
+
+    private var codeEditText: EditText? = null
+    private var actionCodeButton: Button? = null
+    private var loginWithPassword: TextView? = null
+
+    private val completeMagicLinkViewModel: CompleteMagicLinkViewModel by viewModels()
+
+    private var signUpCallback: SignUpCallback? = null
+
+    companion object {
+        const val PARAM_USERNAME = "param_username"
+        fun newInstance(username: String) : Fragment {
+            val magicLinkFragment = MagicLinkConfirmationFragment()
+            val bundle = Bundle()
+            bundle.putString(PARAM_USERNAME, username)
+            magicLinkFragment.arguments = bundle
+            return magicLinkFragment
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        signUpCallback = context as SignUpCallback?
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val view = inflater.inflate(R.layout.fragment_magic_link_code, container, false)
+        signUpCallback?.setTitle(getString(R.string.magic_link_enter_code_title))
+        initUi(view)
+        completeMagicLinkViewModel.magicLinkUiState.observe(this.viewLifecycleOwner) { state ->
+            when (state) {
+                is MagicLinkUiState.Loading -> {
+                    showProgressDialog(getString(state.messageRes))
+                }
+                is MagicLinkUiState.Success -> {
+                    hideDialogProgress()
+                    SimplenoteAuthenticationActivity.startNotesActivity(activity)
+                }
+                is MagicLinkUiState.Error -> {
+                    hideDialogProgress()
+                    Toast.makeText(context, getString(state.messageRes), Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+        return view
+    }
+
+    private fun initUi(view: View) {
+        codeEditText = view.findViewById(R.id.confirmation_code_textfield)
+        actionCodeButton = view.findViewById(R.id.confirmation_code_button)
+        actionCodeButton?.isEnabled = false
+        actionCodeButton?.setOnClickListener {
+            val code = codeEditText?.text?.toString()
+            val username = arguments?.getString(PARAM_USERNAME)
+            if (!code.isNullOrBlank() && !username.isNullOrBlank()) {
+                completeMagicLinkViewModel.completeLogin(username, code)
+            }
+        }
+        codeEditText?.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+                // no-ops
+            }
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                // no-ops
+            }
+
+            override fun afterTextChanged(s: Editable?) {
+                actionCodeButton?.isEnabled = s != null && s.length >= 6
+            }
+        })
+        loginWithPassword = view.findViewById(R.id.login_with_password_button)
+        loginWithPassword?.setOnClickListener { _ ->
+            SignInFragment.showLoginWithPassword(activity)
+        }
+    }
+
+    private fun showProgressDialog(label: String) {
+        progressDialogFragment =
+            ProgressDialogFragment.newInstance(label)
+        progressDialogFragment?.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Simperium)
+        progressDialogFragment?.show(requireFragmentManager(), ProgressDialogFragment.TAG)
+    }
+
+    private fun hideDialogProgress() {
+        progressDialogFragment?.let {
+            if (!it.isHidden) {
+                it.dismiss()
+                progressDialogFragment = null
+            }
+        }
+    }
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
@@ -1,6 +1,5 @@
 package com.automattic.simplenote.authentication.magiclink
 
-import android.content.Context
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -16,7 +15,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.automattic.simplenote.R
 import com.automattic.simplenote.authentication.SignInFragment
-import com.automattic.simplenote.authentication.SignUpCallback
+import com.automattic.simplenote.utils.HtmlCompat
 import com.automattic.simplenote.utils.NetworkUtils
 import com.automattic.simplenote.viewmodels.CompleteMagicLinkViewModel
 import com.automattic.simplenote.viewmodels.MagicLinkUiState
@@ -34,8 +33,6 @@ class MagicLinkConfirmationFragment : Fragment() {
 
     private val completeMagicLinkViewModel: CompleteMagicLinkViewModel by viewModels()
 
-    private var signUpCallback: SignUpCallback? = null
-
     companion object {
         const val PARAM_USERNAME = "param_username"
         fun newInstance(username: String) : Fragment {
@@ -47,14 +44,8 @@ class MagicLinkConfirmationFragment : Fragment() {
         }
     }
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        signUpCallback = context as SignUpCallback?
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.fragment_magic_link_code, container, false)
-        signUpCallback?.setTitle(getString(R.string.magic_link_enter_code_title))
         initUi(view)
         completeMagicLinkViewModel.magicLinkUiState.observe(this.viewLifecycleOwner) { state ->
             when (state) {
@@ -77,8 +68,19 @@ class MagicLinkConfirmationFragment : Fragment() {
     }
 
     private fun initUi(view: View) {
+        val textView: TextView = view.findViewById(R.id.magic_link_enter_code_message)
+        arguments?.getString(PARAM_USERNAME)?.let {
+            val bolded = "<br/><b>$it</b>"
+            textView.text = HtmlCompat.fromHtml(
+                String.format(
+                    getString(R.string.magic_link_confirm_code_message),
+                    bolded
+                )
+            )
+        }
         codeEditText = view.findViewById(R.id.confirmation_code_textfield)
         actionCodeButton = view.findViewById(R.id.confirmation_code_button)
+
         actionCodeButton?.isEnabled = false
         actionCodeButton?.setOnClickListener {
             val code = codeEditText?.text?.toString()

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/OkHttpMagicLinkRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/OkHttpMagicLinkRepository.kt
@@ -1,12 +1,18 @@
 package com.automattic.simplenote.authentication.magiclink
 
+import android.util.Log
+import com.automattic.simplenote.R
 import com.automattic.simplenote.networking.SimpleHttp
 import com.automattic.simplenote.repositories.MagicLinkRepository
 import com.automattic.simplenote.repositories.MagicLinkResponseResult
+import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
 import javax.inject.Inject
 
+private const val TAG = "OkHttpMagicLinkRepository"
+
+private const val ERROR_FIELD = "error"
 class OkHttpMagicLinkRepository @Inject constructor(private val simpleHttp: SimpleHttp,) : MagicLinkRepository {
     @Throws(IOException::class)
     override suspend fun completeLogin(username: String, authCode: String): MagicLinkResponseResult {
@@ -14,15 +20,31 @@ class OkHttpMagicLinkRepository @Inject constructor(private val simpleHttp: Simp
             "account/complete-login",
             mapOf(Pair("username", username), Pair("auth_code", authCode))
         ).use { response ->
+            val body = response.body()?.string()
             if (response.isSuccessful) {
-                val body = response.body()?.string()
                 val json = JSONObject(body ?: "")
                 val syncToken = json.getString("sync_token")
-                val username = json.getString("username")
-                return MagicLinkResponseResult.MagicLinkCompleteSuccess(username, syncToken)
+                val user = json.getString("username")
+                return MagicLinkResponseResult.MagicLinkCompleteSuccess(user, syncToken)
             }
-            return MagicLinkResponseResult.MagicLinkError(response.code())
+            Log.d(TAG, "Error completing login: $body")
+            return MagicLinkResponseResult.MagicLinkError(response.code(), handleErrorMessage(body))
         }
+    }
+
+    private fun handleErrorMessage(body: String?): Int  {
+        try {
+            val errorJson = JSONObject(body ?: "")
+            val errorString = errorJson.getString(ERROR_FIELD)
+            if (errorString == "invalid-code") {
+                return R.string.magic_link_complete_login_invalid_code_error_message
+            } else if (errorString == "request-not-found") {
+                return R.string.magic_link_complete_login_expired_code_error_message
+            }
+        } catch (e: JSONException) {
+            Log.e(TAG, "Error parsing unsuccessful response", e)
+        }
+        return R.string.magic_link_general_error
     }
 
     @Throws(IOException::class)

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/OkHttpMagicLinkRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/OkHttpMagicLinkRepository.kt
@@ -9,10 +9,10 @@ import javax.inject.Inject
 
 class OkHttpMagicLinkRepository @Inject constructor(private val simpleHttp: SimpleHttp,) : MagicLinkRepository {
     @Throws(IOException::class)
-    override suspend fun completeLogin(authKey: String, authCode: String): MagicLinkResponseResult {
+    override suspend fun completeLogin(username: String, authCode: String): MagicLinkResponseResult {
         simpleHttp.firePostRequest(
             "account/complete-login",
-            mapOf(Pair("auth_key", authKey), Pair("auth_code", authCode))
+            mapOf(Pair("username", username), Pair("auth_code", authCode))
         ).use { response ->
             if (response.isSuccessful) {
                 val body = response.body()?.string()

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/MagicLinkRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/MagicLinkRepository.kt
@@ -1,7 +1,7 @@
 package com.automattic.simplenote.repositories
 
 interface MagicLinkRepository {
-    suspend fun completeLogin(authKey: String, authCode: String): MagicLinkResponseResult
+    suspend fun completeLogin(username: String, authCode: String): MagicLinkResponseResult
     suspend fun requestLogin(username: String): MagicLinkResponseResult
 }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/MagicLinkRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/MagicLinkRepository.kt
@@ -1,5 +1,7 @@
 package com.automattic.simplenote.repositories
 
+import androidx.annotation.StringRes
+
 interface MagicLinkRepository {
     suspend fun completeLogin(username: String, authCode: String): MagicLinkResponseResult
     suspend fun requestLogin(username: String): MagicLinkResponseResult
@@ -8,5 +10,5 @@ interface MagicLinkRepository {
 sealed class MagicLinkResponseResult {
     data class MagicLinkCompleteSuccess(val username: String, val syncToken: String) : MagicLinkResponseResult()
     data class MagicLinkRequestSuccess(val code: Int) : MagicLinkResponseResult()
-    data class MagicLinkError(val code: Int) : MagicLinkResponseResult()
+    data class MagicLinkError(val code: Int, @StringRes val errorMessage: Int? = null) : MagicLinkResponseResult()
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModel.kt
@@ -24,7 +24,7 @@ class CompleteMagicLinkViewModel @Inject constructor(
     private val magicLinkRepository: MagicLinkRepository,
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
     ) : ViewModel() {
-    private val _magicLinkUiState = MutableLiveData<MagicLinkUiState>()
+    private val _magicLinkUiState = MutableLiveData<MagicLinkUiState>(MagicLinkUiState.Waiting)
     val magicLinkUiState: LiveData<MagicLinkUiState> get() = _magicLinkUiState
 
     private var lastKnownUserName: String? = null
@@ -45,17 +45,17 @@ class CompleteMagicLinkViewModel @Inject constructor(
                     _magicLinkUiState.postValue(MagicLinkUiState.Success)
                 }
                 is MagicLinkResponseResult.MagicLinkError -> {
-                    if (result.code == 400) {
-                        _magicLinkUiState.postValue(MagicLinkUiState.Error(messageRes = R.string.magic_link_complete_login_error_message))
-                    } else {
-                        _magicLinkUiState.postValue(MagicLinkUiState.Error(messageRes = R.string.dialog_message_signup_error))
-                    }
+                    _magicLinkUiState.postValue(MagicLinkUiState.Error(messageRes = result.errorMessage ?: R.string.magic_link_general_error))
                 }
-                else -> _magicLinkUiState.postValue(MagicLinkUiState.Error(messageRes = R.string.dialog_message_signup_error))
+                else -> _magicLinkUiState.postValue(MagicLinkUiState.Error(messageRes = R.string.magic_link_general_error))
             }
         } catch (exception: IOException) {
-            _magicLinkUiState.postValue(MagicLinkUiState.Error(messageRes = R.string.dialog_message_signup_error))
+            _magicLinkUiState.postValue(MagicLinkUiState.Error(messageRes = R.string.magic_link_general_error))
         }
+    }
+
+    fun resetState() {
+        _magicLinkUiState.postValue(MagicLinkUiState.Waiting)
     }
 }
 
@@ -66,4 +66,5 @@ sealed class MagicLinkUiState {
     data class Loading(@StringRes val messageRes: Int): MagicLinkUiState()
     data class Error(@StringRes val messageRes: Int): MagicLinkUiState()
     object Success : MagicLinkUiState()
+    object Waiting : MagicLinkUiState()
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.automattic.simplenote.R
-import com.automattic.simplenote.Simplenote
 import com.automattic.simplenote.di.IO_THREAD
 import com.automattic.simplenote.repositories.MagicLinkRepository
 import com.automattic.simplenote.repositories.MagicLinkResponseResult
@@ -20,7 +19,6 @@ import javax.inject.Named
 
 @HiltViewModel
 class CompleteMagicLinkViewModel @Inject constructor(
-    private val simplenote: Simplenote,
     private val magicLinkRepository: MagicLinkRepository,
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
     ) : ViewModel() {
@@ -41,8 +39,7 @@ class CompleteMagicLinkViewModel @Inject constructor(
         try {
             when (val result = magicLinkRepository.completeLogin(username, authCode)) {
                 is MagicLinkResponseResult.MagicLinkCompleteSuccess -> {
-                    simplenote.loginWithToken(result.username, result.syncToken)
-                    _magicLinkUiState.postValue(MagicLinkUiState.Success)
+                    _magicLinkUiState.postValue(MagicLinkUiState.Success(result.username, result.syncToken))
                 }
                 is MagicLinkResponseResult.MagicLinkError -> {
                     _magicLinkUiState.postValue(MagicLinkUiState.Error(messageRes = result.errorMessage ?: R.string.magic_link_general_error))
@@ -65,6 +62,6 @@ class CompleteMagicLinkViewModel @Inject constructor(
 sealed class MagicLinkUiState {
     data class Loading(@StringRes val messageRes: Int): MagicLinkUiState()
     data class Error(@StringRes val messageRes: Int): MagicLinkUiState()
-    object Success : MagicLinkUiState()
+    data class Success(val email: String, val token: String) : MagicLinkUiState()
     object Waiting : MagicLinkUiState()
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModel.kt
@@ -26,10 +26,10 @@ class CompleteMagicLinkViewModel @Inject constructor(
     private val _magicLinkUiState = MutableLiveData<MagicLinkUiState>()
     val magicLinkUiState: LiveData<MagicLinkUiState> get() = _magicLinkUiState
 
-    fun completeLogin(authKey: String, authCode: String) = viewModelScope.launch(ioDispatcher) {
+    fun completeLogin(username: String, authCode: String) = viewModelScope.launch(ioDispatcher) {
         _magicLinkUiState.postValue(MagicLinkUiState.Loading(messageRes = R.string.magic_link_complete_login_loading_message))
         try {
-            when (val result = magicLinkRepository.completeLogin(authKey, authCode)) {
+            when (val result = magicLinkRepository.completeLogin(username, authCode)) {
                 is MagicLinkResponseResult.MagicLinkCompleteSuccess -> {
                     simplenote.loginWithToken(result.username, result.syncToken)
                     _magicLinkUiState.postValue(MagicLinkUiState.Success)

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/RequestMagicLinkViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/RequestMagicLinkViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.automattic.simplenote.R
 import com.automattic.simplenote.di.IO_THREAD
-import com.automattic.simplenote.networking.SimpleHttp
 import com.automattic.simplenote.repositories.MagicLinkRepository
 import com.automattic.simplenote.repositories.MagicLinkResponseResult
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,7 +24,7 @@ class RequestMagicLinkViewModel @Inject constructor(
     private val magicLinkRepository: MagicLinkRepository,
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
-    private val _magicLinkRequestUiState = MutableLiveData<MagicLinkRequestUiState>()
+    private val _magicLinkRequestUiState = MutableLiveData<MagicLinkRequestUiState>(MagicLinkRequestUiState.Waiting)
     val magicLinkRequestUiState: LiveData<MagicLinkRequestUiState> get() = _magicLinkRequestUiState
 
     fun requestLogin(username: String) = viewModelScope.launch(ioDispatcher) {
@@ -54,10 +53,15 @@ class RequestMagicLinkViewModel @Inject constructor(
         }
     }
 
+    fun resetState() {
+        _magicLinkRequestUiState.postValue(MagicLinkRequestUiState.Waiting)
+    }
+
 }
 
 sealed class MagicLinkRequestUiState {
     data class Loading(@StringRes val messageRes: Int): MagicLinkRequestUiState()
     data class Error(val code: Int? = null, @StringRes val messageRes: Int): MagicLinkRequestUiState()
     data class Success(val username: String) : MagicLinkRequestUiState()
+    object Waiting : MagicLinkRequestUiState()
 }

--- a/Simplenote/src/main/res/color/button_disabled_selector.xml
+++ b/Simplenote/src/main/res/color/button_disabled_selector.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:color="@color/background_button_disabled" android:state_enabled="false"/>
+    <item android:color="@color/text_button_primary" />
+
+</selector>

--- a/Simplenote/src/main/res/layout/authentication_fancy_or.xml
+++ b/Simplenote/src/main/res/layout/authentication_fancy_or.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+android:id="@+id/or_row"
+android:layout_width="match_parent"
+android:layout_height="wrap_content"
+android:orientation="horizontal"
+android:gravity="center_horizontal"
+android:layout_below="@id/button"
+android:layout_marginVertical="10dp">
+<View
+    android:layout_width="match_parent"
+    android:layout_height="1dp"
+    android:background="@color/gray_20"
+    android:layout_gravity="center_vertical"
+    android:layout_weight="1"
+    />
+<TextView
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/magic_link_login_with_wordpress_or_break"
+    android:paddingHorizontal="5dp"
+    />
+<View
+    android:layout_width="match_parent"
+    android:layout_height="1dp"
+    android:background="@color/gray_20"
+    android:layout_gravity="center_vertical"
+    android:layout_weight="1" />
+</LinearLayout>

--- a/Simplenote/src/main/res/layout/fragment_login.xml
+++ b/Simplenote/src/main/res/layout/fragment_login.xml
@@ -31,7 +31,7 @@
 
     </com.google.android.material.textfield.TextInputLayout>
 
-    <androidx.appcompat.widget.AppCompatButton
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/button"
         style="@style/Widget.AppCompat.Button"
         android:layout_width="match_parent"
@@ -47,7 +47,7 @@
 
     <include layout="@layout/authentication_fancy_or" />
 
-    <androidx.appcompat.widget.AppCompatButton
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/button_login_with_wordpress"
         style="@style/Widget.AppCompat.Button"
         android:layout_width="match_parent"

--- a/Simplenote/src/main/res/layout/fragment_login.xml
+++ b/Simplenote/src/main/res/layout/fragment_login.xml
@@ -45,34 +45,7 @@
         android:textAllCaps="true"
         android:textColor="@android:color/white" />
 
-    <LinearLayout
-        android:id="@+id/or_row"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center_horizontal"
-        android:layout_below="@id/button"
-        android:layout_marginVertical="10dp">
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/gray_20"
-            android:layout_gravity="center_vertical"
-            android:layout_weight="1"
-            />
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/magic_link_login_with_wordpress_or_break"
-            android:paddingHorizontal="5dp"
-            />
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/gray_20"
-            android:layout_gravity="center_vertical"
-            android:layout_weight="1" />
-    </LinearLayout>
+    <include layout="@layout/authentication_fancy_or" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/button_login_with_wordpress"

--- a/Simplenote/src/main/res/layout/fragment_login.xml
+++ b/Simplenote/src/main/res/layout/fragment_login.xml
@@ -7,6 +7,7 @@
     android:layout_marginTop="?attr/actionBarSize"
     android:clipToPadding="false"
     android:padding="@dimen/margin_default"
+    android:background="?mainBackgroundColor"
     tools:layout_width="match_parent">
 
     <com.google.android.material.textfield.TextInputLayout
@@ -44,15 +45,47 @@
         android:textAllCaps="true"
         android:textColor="@android:color/white" />
 
-    <TextView
-        android:id="@+id/login_with_password_button"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/or_row"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/login_with_password"
+        android:orientation="horizontal"
+        android:gravity="center_horizontal"
         android:layout_below="@id/button"
-        android:textColor="@color/blue"
-        android:layout_marginTop="10dp"
-        android:layout_centerHorizontal="true"
-        />
+        android:layout_marginVertical="10dp">
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/gray_20"
+            android:layout_gravity="center_vertical"
+            android:layout_weight="1"
+            />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/magic_link_login_with_wordpress_or_break"
+            android:paddingHorizontal="5dp"
+            />
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/gray_20"
+            android:layout_gravity="center_vertical"
+            android:layout_weight="1" />
+    </LinearLayout>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/button_login_with_wordpress"
+        style="@style/Widget.AppCompat.Button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/or_row"
+        android:layout_marginTop="@dimen/margin_default_quarter"
+        android:layout_marginBottom="@dimen/margin_default_quarter"
+        android:backgroundTint="@color/button_secondary_disabled_selector"
+        android:minHeight="@dimen/height_button"
+        android:text="@string/simperium_button_login_other"
+        android:textAllCaps="true"
+        android:textColor="@android:color/white" />
 
 </RelativeLayout>

--- a/Simplenote/src/main/res/layout/fragment_magic_link_code.xml
+++ b/Simplenote/src/main/res/layout/fragment_magic_link_code.xml
@@ -41,16 +41,31 @@
         android:textAllCaps="true"
         android:textColor="@android:color/white" />
 
-    <TextView
-        android:id="@+id/login_with_password_button"
-        android:layout_width="wrap_content"
+    <include
+        layout="@layout/authentication_fancy_or"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/login_with_password"
         app:layout_constraintTop_toBottomOf="@+id/confirmation_code_button"
+        android:layout_marginVertical="10dp"
+        />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/login_with_password_button"
+        style="@style/Widget.AppCompat.Button.Borderless"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/or_row"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textColor="@color/blue"
-        android:layout_marginTop="10dp"
-        android:layout_centerHorizontal="true"
-        />
+        app:rippleColor="?attr/colorControlHighlight"
+        android:backgroundTint="@color/button_disabled_selector"
+        android:layout_marginTop="@dimen/margin_default_quarter"
+        android:layout_marginBottom="@dimen/margin_default_quarter"
+        app:strokeColor="@color/background_dark_black_0"
+        app:strokeWidth="1dp"
+        android:minHeight="@dimen/height_button"
+        android:text="@string/login_with_password"
+        android:textAllCaps="true"
+        android:textColor="@android:color/black"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Simplenote/src/main/res/layout/fragment_magic_link_code.xml
+++ b/Simplenote/src/main/res/layout/fragment_magic_link_code.xml
@@ -47,6 +47,8 @@
         android:layout_height="wrap_content"
         android:text="@string/login_with_password"
         app:layout_constraintTop_toBottomOf="@+id/confirmation_code_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         android:textColor="@color/blue"
         android:layout_marginTop="10dp"
         android:layout_centerHorizontal="true"

--- a/Simplenote/src/main/res/layout/fragment_magic_link_code.xml
+++ b/Simplenote/src/main/res/layout/fragment_magic_link_code.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/margin_default"
+    android:layout_marginTop="?attr/actionBarSize"
+    android:background="?mainBackgroundColor">
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/confirmation_code_input_layout"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginStart="@dimen/margin_default_quarter"
+        android:layout_marginTop="@dimen/margin_default"
+        android:layout_marginEnd="@dimen/margin_default_quarter"
+        android:layout_marginBottom="@dimen/margin_default_quarter"
+        android:hint="@string/magic_link_code_hint"
+        app:errorEnabled="true">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/confirmation_code_textfield"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:inputType="textEmailAddress" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/confirmation_code_button"
+        style="@style/Widget.AppCompat.Button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/confirmation_code_input_layout"
+        android:layout_marginTop="@dimen/margin_default_quarter"
+        android:layout_marginBottom="@dimen/margin_default_quarter"
+        android:backgroundTint="@color/button_primary_disabled_selector"
+        android:minHeight="@dimen/height_button"
+        android:text="@string/login_screen_title"
+        android:textAllCaps="true"
+        android:textColor="@android:color/white" />
+
+    <TextView
+        android:id="@+id/login_with_password_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/login_with_password"
+        app:layout_constraintTop_toBottomOf="@+id/confirmation_code_button"
+        android:textColor="@color/blue"
+        android:layout_marginTop="10dp"
+        android:layout_centerHorizontal="true"
+        />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Simplenote/src/main/res/layout/fragment_magic_link_code.xml
+++ b/Simplenote/src/main/res/layout/fragment_magic_link_code.xml
@@ -1,17 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="@dimen/margin_default"
     android:layout_marginTop="?attr/actionBarSize"
-    android:background="?mainBackgroundColor">
+    android:background="?mainBackgroundColor"
+    android:orientation="vertical"
+    >
+    <TextView
+        android:id="@+id/magic_link_enter_code_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:textColor="?attr/onMainBackgroundColor"
+        android:textSize="18sp"
+        tools:text="We\'ve sent a code to example@email.com. The code will be valid for a few minutes"
+        android:layout_marginVertical="15dp"
+        />
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/confirmation_code_input_layout"
         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
         android:layout_marginStart="@dimen/margin_default_quarter"
         android:layout_marginTop="@dimen/margin_default"
         android:layout_marginEnd="@dimen/margin_default_quarter"
@@ -27,12 +39,11 @@
 
     </com.google.android.material.textfield.TextInputLayout>
 
-    <androidx.appcompat.widget.AppCompatButton
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/confirmation_code_button"
         style="@style/Widget.AppCompat.Button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/confirmation_code_input_layout"
         android:layout_marginTop="@dimen/margin_default_quarter"
         android:layout_marginBottom="@dimen/margin_default_quarter"
         android:backgroundTint="@color/button_primary_disabled_selector"
@@ -45,7 +56,6 @@
         layout="@layout/authentication_fancy_or"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/confirmation_code_button"
         android:layout_marginVertical="10dp"
         />
 
@@ -54,9 +64,6 @@
         style="@style/Widget.AppCompat.Button.Borderless"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/or_row"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
         app:rippleColor="?attr/colorControlHighlight"
         android:backgroundTint="@color/button_disabled_selector"
         android:layout_marginTop="@dimen/margin_default_quarter"
@@ -64,8 +71,8 @@
         app:strokeColor="@color/background_dark_black_0"
         app:strokeWidth="1dp"
         android:minHeight="@dimen/height_button"
-        android:text="@string/login_with_password"
+        android:text="@string/magic_link_confirm_code_enter_pass_label"
         android:textAllCaps="true"
         android:textColor="@android:color/black"/>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/Simplenote/src/main/res/values/attrs.xml
+++ b/Simplenote/src/main/res/values/attrs.xml
@@ -8,6 +8,7 @@
     <attr name="notePreviewColor" format="reference|color"/>
     <attr name="noteEditorTextColor" format="reference|color"/>
     <attr name="mainBackgroundColor" format="reference|color"/>
+    <attr name="onMainBackgroundColor" format="reference|color"/>
     <attr name="sheetBackgroundColor" format="reference|color"/>
     <attr name="dividerColor" format="reference|color"/>
     <attr name="iconTintColor" format="reference|color"/>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -448,4 +448,6 @@
     <string name="magic_link_code_hint">Code</string>
     <string name="magic_link_enter_code_title">Enter Code</string>
     <string name="magic_link_login_with_wordpress_or_break">Or</string>
+    <string name="magic_link_confirm_code_enter_pass_label">Enter password</string>
+    <string name="magic_link_confirm_code_message">We\'ve sent a code to \n%1$s. The code will be valid for a few minutes.</string>
 </resources>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -434,7 +434,7 @@
 
     <string name="magic_link_request_login_dialog_title">Check your email</string>
     <string name="magic_link_request_login_dialog">If an account exists, we\'ve sent an email to %1$s containing a link that\'ll log you in.</string>
-    <string name="magic_link_login">Instantly Log In With Email</string>
+    <string name="magic_link_login">Log in with email</string>
     <string name="login_screen_title">Log In</string>
     <string name="login_with_password">Login With Password</string>
     <string name="magic_link_general_error">We\'re having problems. Please try again soon.</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -437,12 +437,14 @@
     <string name="magic_link_login">Instantly Log In With Email</string>
     <string name="login_screen_title">Log In</string>
     <string name="login_with_password">Login With Password</string>
+    <string name="magic_link_general_error">We\'re having problems. Please try again soon.</string>
     <string name="magic_link_request_login_loading_message">Requesting log in link</string>
     <string name="magic_link_request_error_message">Error requesting Magic Link</string>
     <string name="magic_link_error_too_many_requests_message">Too many requests. Try again later.</string>
     <string name="magic_link_error_too_many_requests_enter_password_message">Log in with email failed, please enter your password.</string>
     <string name="magic_link_complete_login_loading_message">Logging In</string>
-    <string name="magic_link_complete_login_error_message">Link no longer valid</string>
+    <string name="magic_link_complete_login_expired_code_error_message">Link no longer valid</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">Invalid code</string>
     <string name="magic_link_code_hint">Code</string>
     <string name="magic_link_enter_code_title">Enter Code</string>
     <string name="magic_link_login_with_wordpress_or_break">Or</string>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -438,6 +438,12 @@
     <string name="login_screen_title">Log In</string>
     <string name="login_with_password">Login With Password</string>
     <string name="magic_link_request_login_loading_message">Requesting log in link</string>
+    <string name="magic_link_request_error_message">Error requesting Magic Link</string>
+    <string name="magic_link_error_too_many_requests_message">Too many requests. Try again later.</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">Log in with email failed, please enter your password.</string>
     <string name="magic_link_complete_login_loading_message">Logging In</string>
     <string name="magic_link_complete_login_error_message">Link no longer valid</string>
+    <string name="magic_link_code_hint">Code</string>
+    <string name="magic_link_enter_code_title">Enter Code</string>
+    <string name="magic_link_login_with_wordpress_or_break">Or</string>
 </resources>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -592,4 +592,8 @@
         <item name="android:backgroundTint">@color/background_light_sepia</item>
     </style>
 
+    <style name="SignUpOverride" parent="Simperium">
+        <item name="mainBackgroundColor">@color/background_light</item>
+    </style>
+
 </resources>

--- a/Simplenote/src/main/res/values/styles.xml
+++ b/Simplenote/src/main/res/values/styles.xml
@@ -594,6 +594,7 @@
 
     <style name="SignUpOverride" parent="Simperium">
         <item name="mainBackgroundColor">@color/background_light</item>
+        <item name="onMainBackgroundColor">#000000</item>
     </style>
 
 </resources>

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModelTest.kt
@@ -34,7 +34,7 @@ class CompleteMagicLinkViewModelTest {
     @Test
     fun instantiateViewModel() = runBlockingTest {
         val viewModel = CompleteMagicLinkViewModel(app, repository, TestCoroutineDispatcher())
-        assertEquals(null, viewModel.magicLinkUiState.value)
+        assertEquals(MagicLinkUiState.Waiting, viewModel.magicLinkUiState.value)
     }
 
     @Test
@@ -50,8 +50,9 @@ class CompleteMagicLinkViewModelTest {
         }
         viewModel.completeLogin(AUTH_KEY_TEST, AUTH_CODE_TEST)
 
-        assertEquals(MagicLinkUiState.Loading::class.java, states[0]::class.java)
-        assertEquals(MagicLinkUiState.Success, states[1])
+        assertEquals(MagicLinkUiState.Waiting::class.java, states[0]::class.java)
+        assertEquals(MagicLinkUiState.Loading::class.java, states[1]::class.java)
+        assertEquals(MagicLinkUiState.Success, states[2])
     }
 
     @Test
@@ -66,7 +67,8 @@ class CompleteMagicLinkViewModelTest {
             states.add(it)
         }
         viewModel.completeLogin(AUTH_KEY_TEST, AUTH_CODE_TEST)
-        assertEquals(MagicLinkUiState.Loading::class.java, states[0]::class.java)
-        assertEquals(MagicLinkUiState.Error::class.java, states[1]::class.java)
+        assertEquals(MagicLinkUiState.Waiting::class.java, states[0]::class.java)
+        assertEquals(MagicLinkUiState.Loading::class.java, states[1]::class.java)
+        assertEquals(MagicLinkUiState.Error::class.java, states[2]::class.java)
     }
 }

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.automattic.simplenote.viewmodels
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.automattic.simplenote.Simplenote
 import com.automattic.simplenote.repositories.MagicLinkRepository
 import com.automattic.simplenote.repositories.MagicLinkResponseResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -24,7 +23,6 @@ class CompleteMagicLinkViewModelTest {
     val instantExecutorRule = InstantTaskExecutorRule()
 
     private val repository: MagicLinkRepository = Mockito.mock(MagicLinkRepository::class.java)
-    private val app = Mockito.mock(Simplenote::class.java)
 
     @Before
     fun setup() {
@@ -33,7 +31,7 @@ class CompleteMagicLinkViewModelTest {
 
     @Test
     fun instantiateViewModel() = runBlockingTest {
-        val viewModel = CompleteMagicLinkViewModel(app, repository, TestCoroutineDispatcher())
+        val viewModel = CompleteMagicLinkViewModel(repository, TestCoroutineDispatcher())
         assertEquals(MagicLinkUiState.Waiting, viewModel.magicLinkUiState.value)
     }
 
@@ -43,7 +41,7 @@ class CompleteMagicLinkViewModelTest {
             repository.completeLogin(AUTH_KEY_TEST, AUTH_CODE_TEST)
         ).thenReturn(MagicLinkResponseResult.MagicLinkCompleteSuccess(AUTH_KEY_TEST, AUTH_CODE_TEST))
 
-        val viewModel = CompleteMagicLinkViewModel(app, repository, TestCoroutineDispatcher())
+        val viewModel = CompleteMagicLinkViewModel(repository, TestCoroutineDispatcher())
         val states = mutableListOf<MagicLinkUiState>()
         viewModel.magicLinkUiState.observeForever {
             states.add(it)
@@ -52,7 +50,7 @@ class CompleteMagicLinkViewModelTest {
 
         assertEquals(MagicLinkUiState.Waiting::class.java, states[0]::class.java)
         assertEquals(MagicLinkUiState.Loading::class.java, states[1]::class.java)
-        assertEquals(MagicLinkUiState.Success, states[2])
+        assertEquals(MagicLinkUiState.Success::class.java, states[2]::class.java)
     }
 
     @Test
@@ -61,7 +59,7 @@ class CompleteMagicLinkViewModelTest {
             repository.completeLogin(AUTH_KEY_TEST, AUTH_CODE_TEST)
         ).thenReturn(MagicLinkResponseResult.MagicLinkError(code = 400))
 
-        val viewModel = CompleteMagicLinkViewModel(app, repository, TestCoroutineDispatcher())
+        val viewModel = CompleteMagicLinkViewModel(repository, TestCoroutineDispatcher())
         val states = mutableListOf<MagicLinkUiState>()
         viewModel.magicLinkUiState.observeForever {
             states.add(it)

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/RequestMagicLinkViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/RequestMagicLinkViewModelTest.kt
@@ -24,7 +24,7 @@ class RequestMagicLinkViewModelTest {
     @Test
     fun instantiateViewModel() = runBlockingTest {
         val viewModel = RequestMagicLinkViewModel(repository, TestCoroutineDispatcher())
-        assertEquals(null, viewModel.magicLinkRequestUiState.value)
+        assertEquals(MagicLinkRequestUiState.Waiting, viewModel.magicLinkRequestUiState.value)
     }
 
     @Test
@@ -39,8 +39,9 @@ class RequestMagicLinkViewModelTest {
             states.add(it)
         }
         viewModel.requestLogin(email)
-        assertEquals(MagicLinkRequestUiState.Loading::class.java, states[0]::class.java)
-        assertEquals(MagicLinkRequestUiState.Success(username = email), states[1])
+        assertEquals(MagicLinkRequestUiState.Waiting::class.java, states[0]::class.java)
+        assertEquals(MagicLinkRequestUiState.Loading::class.java, states[1]::class.java)
+        assertEquals(MagicLinkRequestUiState.Success(username = email), states[2])
     }
 
     @Test
@@ -55,7 +56,8 @@ class RequestMagicLinkViewModelTest {
             states.add(it)
         }
         viewModel.requestLogin(email)
-        assertEquals(MagicLinkRequestUiState.Loading::class.java, states[0]::class.java)
-        assertEquals(MagicLinkRequestUiState.Error::class.java, states[1]::class.java)
+        assertEquals(MagicLinkRequestUiState.Waiting::class.java, states[0]::class.java)
+        assertEquals(MagicLinkRequestUiState.Loading::class.java, states[1]::class.java)
+        assertEquals(MagicLinkRequestUiState.Error::class.java, states[2]::class.java)
     }
 }


### PR DESCRIPTION
### Fix

This PR makes some updates related to the magic link flow.

* Clicking login now doesn't show a bottom sheet, instead takes you directly to a login screen to enter your email.
* Here you have the option to enter your email and request a magic link. Or you can login with wordpress.
* If you click "Instantly Log In With Email", you will be taken to a screen to enter a code. The code is a backup to the magic link. In case the magic link doesn't work, the user can enter the code.

### Test

**Login with Wordpress**

- [ ] Click Log In.
- [ ] Click Log In with Wordpress.com
- [ ] This will pop up a web browser.
- [ ] Ensure at the end you are logged in.

The main reason to test this is because I update the deprecated `onActivityForResult`. It was just easier to handle it in the fragment.

**Login With Magic Link**

- [ ] Click Log In
- [ ] Enter your email and click "Instantly Log In With Email"
- [ ] Once you are on the "Enter Code" screen, go check your email.
- [ ] In your email, click the "Log In" button to deeplink into the app so you are auto logged in.
- [ ] You should be logged in.

**Login With Magic Link Code**

- [ ] Click Log In
- [ ] Enter your email and click "Instantly Log In With Email"
- [ ] Once you are on the "Enter Code" screen, go check your email.
- [ ] Copy the code from the email and go back to the app.
- [ ] Enter the code in the textfield and submit the code.
- [ ] This should login you in.


### Release

No Additional release update needed.