### PR TITLE
Go back one screen when confirming a code response says it expired.

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkAuthError.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkAuthError.kt
@@ -1,0 +1,7 @@
+package com.automattic.simplenote.authentication.magiclink
+
+enum class MagicLinkAuthError(val str: String) {
+    INVALID_CODE("invalid-code"),
+    REQUEST_NOT_FOUND("request-not-found"),
+    UNKNOWN_ERROR("")
+}

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
@@ -59,15 +59,16 @@ class MagicLinkConfirmationFragment : Fragment() {
                 is MagicLinkUiState.Success -> {
                     completeMagicLinkViewModel.resetState()
                     hideDialogProgress()
-                    simplenote?.let {
-                        it.loginWithToken(state.email, state.token)
-                        activity?.finish()
-                    }
+                    simplenote.loginWithToken(state.email, state.token)
+                    activity?.finish()
                 }
                 is MagicLinkUiState.Error -> {
                     completeMagicLinkViewModel.resetState()
                     hideDialogProgress()
                     Toast.makeText(context, getString(state.messageRes), Toast.LENGTH_LONG).show()
+                    if (state.authError == MagicLinkAuthError.INVALID_CODE && !isRemoving) {
+                        parentFragmentManager.popBackStack()
+                    }
                 }
             }
         }

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/MagicLinkRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/MagicLinkRepository.kt
@@ -1,6 +1,7 @@
 package com.automattic.simplenote.repositories
 
 import androidx.annotation.StringRes
+import com.automattic.simplenote.authentication.magiclink.MagicLinkAuthError
 
 interface MagicLinkRepository {
     suspend fun completeLogin(username: String, authCode: String): MagicLinkResponseResult
@@ -10,5 +11,5 @@ interface MagicLinkRepository {
 sealed class MagicLinkResponseResult {
     data class MagicLinkCompleteSuccess(val username: String, val syncToken: String) : MagicLinkResponseResult()
     data class MagicLinkRequestSuccess(val code: Int) : MagicLinkResponseResult()
-    data class MagicLinkError(val code: Int, @StringRes val errorMessage: Int? = null) : MagicLinkResponseResult()
+    data class MagicLinkError(val code: Int, val authError: MagicLinkAuthError = MagicLinkAuthError.UNKNOWN_ERROR, @StringRes val errorMessage: Int? = null) : MagicLinkResponseResult()
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.automattic.simplenote.R
+import com.automattic.simplenote.authentication.magiclink.MagicLinkAuthError
 import com.automattic.simplenote.di.IO_THREAD
 import com.automattic.simplenote.repositories.MagicLinkRepository
 import com.automattic.simplenote.repositories.MagicLinkResponseResult
@@ -42,7 +43,7 @@ class CompleteMagicLinkViewModel @Inject constructor(
                     _magicLinkUiState.postValue(MagicLinkUiState.Success(result.username, result.syncToken))
                 }
                 is MagicLinkResponseResult.MagicLinkError -> {
-                    _magicLinkUiState.postValue(MagicLinkUiState.Error(messageRes = result.errorMessage ?: R.string.magic_link_general_error))
+                    _magicLinkUiState.postValue(MagicLinkUiState.Error(result.authError, messageRes = result.errorMessage ?: R.string.magic_link_general_error))
                 }
                 else -> _magicLinkUiState.postValue(MagicLinkUiState.Error(messageRes = R.string.magic_link_general_error))
             }
@@ -61,7 +62,7 @@ class CompleteMagicLinkViewModel @Inject constructor(
  */
 sealed class MagicLinkUiState {
     data class Loading(@StringRes val messageRes: Int): MagicLinkUiState()
-    data class Error(@StringRes val messageRes: Int): MagicLinkUiState()
+    data class Error(val authError: MagicLinkAuthError = MagicLinkAuthError.UNKNOWN_ERROR, @StringRes val messageRes: Int): MagicLinkUiState()
     data class Success(val email: String, val token: String) : MagicLinkUiState()
     object Waiting : MagicLinkUiState()
 }


### PR DESCRIPTION
### Fix

During the magic link code confirmation and the server returns a 400 with `invalid-code`, we want to go back one screen. Basically so the user can request another magic link.

### Test

- [ ] Request a magic link.
- [ ] Wait 10 -15 minutes so it expires.
- [ ] Or request another magic link.
- [ ] In the code confirmation screen enter the invalid code.
- [ ] You should see a toast and be taken back a screen so you can submit another magic link.

### Review

Note: The invalid code has to be a previously valid one I think.

### Release

n/a
