### PR TITLE
Update strings for translation - version 2.33

### DIFF
--- a/Simplenote/metadata/PlayStoreStrings.pot
+++ b/Simplenote/metadata/PlayStoreStrings.pot
@@ -11,18 +11,18 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_0233"
+msgid ""
+"2.33:\n"
+"* Added support for logging in with magic links for a passwordless experience.\n"
+"\n"
+msgstr ""
+
 msgctxt "release_note_0232"
 msgid ""
 "2.32:\n"
 "• Added adaptive app icon\n"
 "• Removed Sustainer plan information and upgrade UI\n"
-msgstr ""
-
-msgctxt "release_note_0231"
-msgid ""
-"2.31:\n"
-"* Fixed the app from becoming unresponsive at launch with a large amount of notes.\n"
-"\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -282,9 +282,9 @@ platform :android do
   # bundle exec fastlane build_pre_releases create_release:true
   #####################################################################################
   desc 'Builds and updates for distribution'
-  lane :build_pre_releases do |options|
+  lane :build_pre_releases do |skip_confirm: false, create_release: true|
     android_build_prechecks(
-      skip_confirm: options[:skip_confirm],
+      skip_confirm: skip_confirm,
       alpha: false,
       beta: true,
       final: false
@@ -292,8 +292,8 @@ platform :android do
     android_build_preflight
     build_and_upload_beta(
       skip_prechecks: true,
-      skip_confirm: options[:skip_confirm],
-      create_release: options[:create_release]
+      skip_confirm: skip_confirm,
+      create_release: create_release
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -283,12 +283,44 @@ platform :android do
   #####################################################################################
   desc 'Builds and updates for distribution'
   lane :build_pre_releases do |skip_confirm: false, create_release: true|
-    android_build_prechecks(
-      skip_confirm: skip_confirm,
-      alpha: false,
-      beta: true,
-      final: false
-    )
+    # android_build_prechecks(
+    #   skip_confirm: skip_confirm,
+    #   alpha: false,
+    #   beta: true,
+    #   final: false
+    # )
+    #
+    # ^ Disabled because fails with the following (regardless of the values of skip_confirm)
+    #
+    # [20:36:39]: -------------------------------------
+    # [20:36:39]: --- Step: android_build_prechecks ---
+    # [20:36:39]: -------------------------------------
+    # [20:36:39]: $ git symbolic-ref -q HEAD
+    # [20:36:39]: ▸ refs/heads/release/2.33
+    # [20:36:39]: DEPRECATED: The PROJECT_ROOT_FOLDER environment variable and config item are deprecated and will be removed in a future version of the Release Toolkit...
+    # [20:36:39]: DEPRECATED: The PROJECT_NAME environment variable and config item are deprecated and will be removed in a future version of the Release Toolkit...
+    # [20:36:39]: Building version 2.33-rc-1(167) (for upload to Beta Channel)
+    #
+    # [20:36:39]: Unknown method 'options'
+    # +-----------------------------------------------+
+    # |                 Lane Context                  |
+    # +------------------+----------------------------+
+    # | DEFAULT_PLATFORM | android                    |
+    # | PLATFORM_NAME    | android                    |
+    # | LANE_NAME        | android build_pre_releases |
+    # +------------------+----------------------------+
+    # [20:36:39]: Called from Fastfile at line 286
+    # [20:36:39]: ```
+    # [20:36:39]:     284:	  desc 'Builds and updates for distribution'
+    # [20:36:39]:     285:	  lane :build_pre_releases do |skip_confirm: false, create_release: true|
+    # [20:36:39]:  => 286:	    android_build_prechecks(
+    # [20:36:39]:     287:	      skip_confirm: skip_confirm,
+    # [20:36:39]:     288:	      alpha: false,
+    # [20:36:39]: ```
+    # [20:36:39]: To call another action from an action use `other_action.options` instead
+    # [20:36:39]: fastlane finished with errors
+    #
+    # [!] To call another action from an action use `other_action.options` instead
     android_build_preflight
     build_and_upload_beta(
       skip_prechecks: true,


### PR DESCRIPTION
The code freeze commits accidentally landed on `trunk` and, to avoid a mess like the one in Simplenote iOS for the 4.52 code freeze, I decided to leave them there without reverting.

These are the last steps of the code freeze process: Updating the strings for localization.

Like https://github.com/Automattic/simplenote-ios/pull/1634, I'll admin-merge this. All the same considerations on retroactive review and follow ups on my part apply. 