### PR TITLE
[Lang] Update magic link string localizations.

### DIFF
--- a/Simplenote/src/main/res/values-ar/strings.xml
+++ b/Simplenote/src/main/res/values-ar/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-22 20:54:02+0000
+Translation-Revision-Date: 2024-07-31 18:54:11+0000
 Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;
 Generator: GlotPress/2.4.0-alpha
 Language: ar
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">لقد أرسلنا كودًا إلى \n%1$s. سيكون هذا الكود صالحًا لبضع دقائق.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">إدخال كلمة المرور</string>
+    <string name="magic_link_login_with_wordpress_or_break">أو</string>
+    <string name="magic_link_enter_code_title">إدخال الكود</string>
+    <string name="magic_link_code_hint">الكود</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">كود غير صالح</string>
+    <string name="magic_link_complete_login_expired_code_error_message">الرابط ليس صالحًا بعد الآن</string>
+    <string name="magic_link_complete_login_loading_message">تسجيل الدخول</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">فشل تسجل الدخول باستخدام البريد الإلكتروني، يرجى إدخال كلمة مرورك.</string>
+    <string name="magic_link_error_too_many_requests_message">توجد طلبات كثيرة للغاية. حاول مرة أخرى لاحقًا.</string>
+    <string name="magic_link_request_error_message">خطأ في أثناء طلب رابط سحري</string>
+    <string name="magic_link_request_login_loading_message">طلب رابط تسجيل الدخول</string>
+    <string name="magic_link_general_error">لدينا مشكلات. ترجى المحاولة مرة أخرى لاحقًا.</string>
+    <string name="login_with_password">تسجيل الدخول باستخدام كلمة المرور</string>
+    <string name="login_screen_title">تسجيل الدخول</string>
+    <string name="magic_link_login">تسجيل الدخول باستخدام البريد الإلكتروني</string>
+    <string name="magic_link_request_login_dialog">في حال وجود حساب، نرسل رسالة عبر البريد الإلكتروني إلى ⁦%1$s⁩ تحتوي على رابط سيؤدي إلى تسجيل دخولك.</string>
+    <string name="magic_link_request_login_dialog_title">التحقق من بريدك الإلكتروني</string>
     <string name="sustainer_app_icon">أيقونة تطبيق Sustainer</string>
     <string name="simperium_too_many_attempts">محاولات تسجيل دخول كثيرة للغاية. حاول مرة أخرى لاحقًا.</string>
     <string name="simperium_change_password">تغيير كلمة المرور</string>
@@ -66,11 +84,11 @@ Language: ar
     <string name="toast_email_sent">تم إرسال رسالة عبر البريد الإلكتروني</string>
     <string name="fullscreen_verify_email_button_secondary">إعادة إرسال بريد إلكتروني</string>
     <string name="fullscreen_verify_email_title">التحقُّق من بريدك الإلكتروني</string>
-    <string name="fullscreen_verify_email_subtitle">أرسلنا رسالة بريد إلكتروني خاصة بالتحقق إلى &lt;b&gt;%1$s&lt;/b&gt;. يرجى التحقُّق من علبة الوارد لديك واتباع الإرشادات.</string>
+    <string name="fullscreen_verify_email_subtitle">أرسلنا رسالة بريد إلكتروني خاصة بالتحقق إلى &lt;b>%1$s&lt;/b>. يرجى التحقُّق من علبة الوارد لديك واتباع الإرشادات.</string>
     <string name="fullscreen_review_account_button_secondary">تغيير البريد الإلكتروني</string>
     <string name="fullscreen_review_account_button_primary">تأكيد</string>
     <string name="fullscreen_review_account_title">مراجعة حسابك</string>
-    <string name="fullscreen_review_account_subtitle">لقد قمت بالتسجيل في Simplenote باستخدام البريد الإلكتروني &lt;b&gt;%1$s&lt;/b&gt;.&lt;br&gt;&lt;br&gt;قد تؤدي التحسينات التي يتم إجراؤها على أمان الحساب إلى فقدان الحساب إذا لم يعد لديك حق الوصول إلى عنوان البريد الإلكتروني هذا.</string>
+    <string name="fullscreen_review_account_subtitle">لقد قمت بالتسجيل في Simplenote باستخدام البريد الإلكتروني &lt;b>%1$s&lt;/b>.&lt;br>&lt;br>قد تؤدي التحسينات التي يتم إجراؤها على أمان الحساب إلى فقدان الحساب إذا لم يعد لديك حق الوصول إلى عنوان البريد الإلكتروني هذا.</string>
     <string name="description_warning">تحذير</string>
     <string name="description_mail">البريد الإلكتروني</string>
     <string name="description_close">إغلاق</string>
@@ -111,7 +129,7 @@ Language: ar
     <string name="empty">فارغ</string>
     <string name="back">رجوع</string>
     <string name="empty_notes_untagged">لا توجد أي ملاحظات غير موسومة</string>
-    <string name="unpublishing">جارٍ إلغاء نشر الملحوظة…</string>
+    <string name="unpublishing">جارٍ إلغاء نشر الملحوظة...</string>
     <string name="unpublish_successful">تم إلغاء نشر الملحوظة.</string>
     <string name="web_view_error_button">الانتقال إلى تطبيق WebView</string>
     <string name="web_view_error">يجب تثبيت عرض الويب على جهازك لمعاينة الضبط.</string>
@@ -186,7 +204,7 @@ Language: ar
     <string name="search">البحث عن الملحوظات أو الوسوم</string>
     <string name="empty_tags_search">لم يتم العثور على وسوم</string>
     <string name="empty_notes_widget">لا توجد ملحوظات</string>
-    <string name="loading_notes">جارٍ تحميل الملحوظات…</string>
+    <string name="loading_notes">جارٍ تحميل الملحوظات...</string>
     <string name="note_widget_light">ملحوظة (فاتح)</string>
     <string name="note_widget_dark">ملحوظة (غامق)</string>
     <string name="note_list_widget_light">قائمة الملحوظات (فاتح)</string>
@@ -222,7 +240,7 @@ Language: ar
     <string name="description_sort">فرز</string>
     <string name="description_down">أسفل</string>
     <string name="description_delete_item">حذف العنصر</string>
-    <string name="welcome_note">مرحبًا بك في Simplenote Android!\nافتح هذه الملحوظة للحصول على الإرشادات.\n\nلإنشاء ملاحظة جديدة، انقر على زر \"ملاحظة جديدة\" الذي يتضمن أيقونة زائد.\n\nللبحث عن ملحوظاتك، انقر على زر \"بحث\" مع أيقونة العدسة المكبِّرة وأدخل أي نص. سيعرض برنامج Simplenote مبدئيًا عمليات البحث الأخيرة وعمليات البحث المقترحة عند إدخال نص. ستظهر الملحوظات التي تتطابق مع النص الذي تم إدخاله بمجرد إرسال البحث.\n\nهل حصلتَ على ملحوظة مهمة بالفعل؟ قم بتثبيتها في الجزء العلوي من قائمة الملحوظات. يمكنك تثبيت الملحوظة بطريقتين. اضغط ضغطًا مطولاً على الملحوظة الموجودة في القائمة وانقر على زر \"تثبيت في الأعلى\" مع أيقونة التثبيت. اضغط على زر \"مزيد من الخيارات\" المتمثِّل في أيقونة النقاط الرأسية الثلاث في أثناء عرض ملحوظة، وحدِّد مربع \"التثبيت\".\n\nاستخدم الوسوم للمساعدة على تنظيم ملحوظاتك. يمكنك إنشاء وسم إما في شاشة \"تحرير الوسوم\" باستخدام زر \"إضافة وسم\" أو حقل \"إضافة وسم…\" الموجود في الجزء السفلي للملاحظة. يمكنك أيضًا إضافة عنوان بريد إلكتروني كوسم لمشاركة ملحوظة مع شخص ما.\n\nشارك الملحوظات بسهولة مع تطبيقات Android الأخرى عن طريق الضغط على \"مشاركة\" في قائمة \"مزيد من الخيارات\" في أثناء عرض الملحوظة.\n\nتظهر الملحوظات المحذوفة في سلة المهملات. يمكنك استعادتها إذا كنت ترغب في ذلك، أو إفراغ سلة المهملات للتخلص منها نهائيًا.\n\nيمكنك الوصول إلى ملحوظاتك على الويب وعلى أجهزتك الأخرى. انتقل إلى http://simplenote.com للبدء.\n\nنأمل أن تستمتع باستخدام Simplenote!</string>
+    <string name="welcome_note">مرحبًا بك في Simplenote Android!\nافتح هذه الملحوظة للحصول على الإرشادات.\n\nلإنشاء ملاحظة جديدة، انقر على زر \"ملاحظة جديدة\" الذي يتضمن أيقونة زائد.\n\nللبحث عن ملحوظاتك، انقر على زر \"بحث\" مع أيقونة العدسة المكبِّرة وأدخل أي نص. سيعرض برنامج Simplenote مبدئيًا عمليات البحث الأخيرة وعمليات البحث المقترحة عند إدخال نص. ستظهر الملحوظات التي تتطابق مع النص الذي تم إدخاله بمجرد إرسال البحث.\n\nهل حصلتَ على ملحوظة مهمة بالفعل؟ قم بتثبيتها في الجزء العلوي من قائمة الملحوظات. يمكنك تثبيت الملحوظة بطريقتين. اضغط ضغطًا مطولاً على الملحوظة الموجودة في القائمة وانقر على زر \"تثبيت في الأعلى\" مع أيقونة التثبيت. اضغط على زر \"مزيد من الخيارات\" المتمثِّل في أيقونة النقاط الرأسية الثلاث في أثناء عرض ملحوظة، وحدِّد مربع \"التثبيت\".\n\nاستخدم الوسوم للمساعدة على تنظيم ملحوظاتك. يمكنك إنشاء وسم إما في شاشة \"تحرير الوسوم\" باستخدام زر \"إضافة وسم\" أو حقل \"إضافة وسم...\" الموجود في الجزء السفلي للملاحظة. يمكنك أيضًا إضافة عنوان بريد إلكتروني كوسم لمشاركة ملحوظة مع شخص ما.\n\nشارك الملحوظات بسهولة مع تطبيقات Android الأخرى عن طريق الضغط على \"مشاركة\" في قائمة \"مزيد من الخيارات\" في أثناء عرض الملحوظة.\n\nتظهر الملحوظات المحذوفة في سلة المهملات. يمكنك استعادتها إذا كنت ترغب في ذلك، أو إفراغ سلة المهملات للتخلص منها نهائيًا.\n\nيمكنك الوصول إلى ملحوظاتك على الويب وعلى أجهزتك الأخرى. انتقل إلى http://simplenote.com للبدء.\n\nنأمل أن تستمتع باستخدام Simplenote!</string>
     <string name="search_hint">البحث عن الملحوظات أو الوسوم</string>
     <string name="log_out">تسجيل الخروج</string>
     <string name="log_in">تسجيل الدخول</string>
@@ -236,7 +254,7 @@ Language: ar
     <string name="simperium_error_password">كلمة المرور غير صالحة</string>
     <string name="simperium_error_email">البريد الإلكتروني غير صالح</string>
     <string name="simperium_dialog_title_error">خطأ</string>
-    <string name="simperium_dialog_progress_signing_up">جارٍ التسجيل…</string>
+    <string name="simperium_dialog_progress_signing_up">جارٍ التسجيل...</string>
     <string name="simperium_dialog_progress_logging_in">جارٍ تسجيل الدخول…</string>
     <string name="simperium_dialog_message_signup_existing">عنوان البريد الإلكتروني الذي أدخلته مرتبط بالفعل بحساب Simplenote.</string>
     <string name="simperium_dialog_message_signup">يتعذر التسجيل باستخدام عنوان البريد الإلكتروني وكلمة المرور اللذين تم إدخالهما.</string>
@@ -252,7 +270,7 @@ Language: ar
     <string name="log_in_add_widget">تسجيل الدخول لإضافة هذا المربع الجانبي</string>
     <string name="select_note">تحديد ملحوظة</string>
     <string name="note_not_found">الملحوظة غير موجودة</string>
-    <string name="loading_note">جارٍ تحميل الملحوظة…</string>
+    <string name="loading_note">جارٍ تحميل الملحوظة...</string>
     <string name="passcode_summary">تُعرض لقطات الشاشة عندما يكون قفل رمز المرور قيد التشغيل</string>
     <string name="all_notes">كل الملاحظات</string>
     <string name="appearance">المظهر</string>
@@ -334,7 +352,7 @@ Language: ar
     <string name="open_drawer">فتح ساحب القائمة</string>
     <string name="condensed_note_list">قائمة الملاحظات الموجزة</string>
     <string name="rename_tag">إعادة تسمية الوسم</string>
-    <string name="new_note_list">ملاحظة جديدة…</string>
+    <string name="new_note_list">ملاحظة جديدة...</string>
     <string name="confirm_delete_tag">هل أنت متأكد من رغبتك في حذف هذا الوسم؟</string>
     <string name="note_deleted">تم وضع الملاحظة بسلة المهملات.</string>
     <string name="undo">تراجع</string>

--- a/Simplenote/src/main/res/values-de/strings.xml
+++ b/Simplenote/src/main/res/values-de/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-23 11:54:05+0000
+Translation-Revision-Date: 2024-08-01 09:54:03+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: de
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">Wir haben einen Code gesendet an: \n%1$s. Der Code ist einige Minuten gültig.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">Passwort eingeben</string>
+    <string name="magic_link_login_with_wordpress_or_break">Oder</string>
+    <string name="magic_link_enter_code_title">Code eingeben</string>
+    <string name="magic_link_code_hint">Code</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">Ungültiger Code</string>
+    <string name="magic_link_complete_login_expired_code_error_message">Link nicht länger gültig</string>
+    <string name="magic_link_complete_login_loading_message">Du wirst angemeldet</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">Die Anmeldung per E-Mail ist fehlgeschlagen, bitte gib dein Passwort ein.</string>
+    <string name="magic_link_error_too_many_requests_message">Zu viele Anfragen. Versuche es später erneut.</string>
+    <string name="magic_link_request_error_message">Fehler beim Anfordern des magischen Links</string>
+    <string name="magic_link_request_login_loading_message">Anmeldelink wird angefordert</string>
+    <string name="magic_link_general_error">Momentan gibt es ein paar Probleme. Bitte versuche es später erneut.</string>
+    <string name="login_with_password">Mit Passwort anmelden</string>
+    <string name="login_screen_title">Anmelden</string>
+    <string name="magic_link_login">Mit E-Mail-Adresse anmelden</string>
+    <string name="magic_link_request_login_dialog">Wenn ein Konto existiert, haben wir eine E-Mail mit einem Anmeldelink an %1$s gesendet.</string>
+    <string name="magic_link_request_login_dialog_title">Überprüfe deinen Posteingang</string>
     <string name="sustainer_app_icon">Unterstützer-App-Icon</string>
     <string name="simperium_too_many_attempts">Zu viele Anmeldeversuche. Versuche es später erneut.</string>
     <string name="simperium_change_password">Passwort ändern</string>
@@ -66,11 +84,11 @@ Language: de
     <string name="toast_email_sent">E-Mail gesendet</string>
     <string name="fullscreen_verify_email_button_secondary">E-Mail erneut senden</string>
     <string name="fullscreen_verify_email_title">E-Mail-Adresse bestätigen</string>
-    <string name="fullscreen_verify_email_subtitle">Wir haben an &lt;b&gt;%1$s&lt;/b&gt; eine Verifizierungs-E-Mail gesendet. Sieh bitte in deinem Posteingang nach und befolge die Anweisungen.</string>
+    <string name="fullscreen_verify_email_subtitle">Wir haben an &lt;b>%1$s&lt;/b> eine Verifizierungs-E-Mail gesendet. Sieh bitte in deinem Posteingang nach und befolge die Anweisungen.</string>
     <string name="fullscreen_review_account_button_secondary">E-Mail-Adresse ändern</string>
     <string name="fullscreen_review_account_button_primary">Bestätigen</string>
     <string name="fullscreen_review_account_title">Konto prüfen</string>
-    <string name="fullscreen_review_account_subtitle">Du bist mit der E-Mail-Adresse &lt;b&gt;%1$s&lt;/b&gt; bei Simplenote registriert.&lt;br&gt;&lt;br&gt;Verbesserungen der Kontosicherheit können zum Verlust des Kontos führen, wenn du keinen Zugriff mehr auf diese E-Mail-Adresse hast.</string>
+    <string name="fullscreen_review_account_subtitle">Du bist mit der E-Mail-Adresse &lt;b>%1$s&lt;/b> bei Simplenote registriert.&lt;br>&lt;br>Verbesserungen der Kontosicherheit können zum Verlust des Kontos führen, wenn du keinen Zugriff mehr auf diese E-Mail-Adresse hast.</string>
     <string name="description_warning">Warnung</string>
     <string name="description_mail">E-Mail</string>
     <string name="description_close">Schließen</string>
@@ -186,7 +204,7 @@ Language: de
     <string name="search">Notizen oder Schlagwörter durchsuchen</string>
     <string name="empty_tags_search">Keine Schlagwörter gefunden</string>
     <string name="empty_notes_widget">Keine Notizen</string>
-    <string name="loading_notes">Notizen werden geladen …</string>
+    <string name="loading_notes">Notizen werden geladen ...</string>
     <string name="note_widget_light">Notiz (hell)</string>
     <string name="note_widget_dark">Notiz (dunkel)</string>
     <string name="note_list_widget_light">Notizenliste (hell)</string>
@@ -222,7 +240,7 @@ Language: de
     <string name="description_sort">Sortieren</string>
     <string name="description_down">Ab</string>
     <string name="description_delete_item">Element löschen</string>
-    <string name="welcome_note">Willkommen bei Simplenote Android!\nIn dieser Notiz findest du Anweisungen.\n\nTippe zum Erstellen einer neuen Notiz auf den Button „Neue Notiz“ mit dem Plus-Icon.\n\nWenn du deine Notizen durchsuchen willst, tippe auf den Button „Suchen“ mit dem Lupensymbol und gib einen Text ein. Simplenote zeigt dir anfangs die letzten Suchen an und macht Suchvorschläge, wenn du Text eingibst. Notizen, die mit dem eingegebenen Text übereinstimmen, werden nach dem Absenden der Suche angezeigt.\n\nHast du eine äußerst wichtige Notiz? Hefte sie an den Anfang der Notizenliste. Zum Anheften von Notizen gibt es zwei Möglichkeiten. Halte die Notiz in der Liste lange gedrückt und tippe auf den Button „An Anfang heften“ mit dem Anheften-Icon. Tippe in der Notiz auf den Button „Weitere Optionen“ mit dem Icon mit drei vertikalen Punkten und aktiviere das Kontrollkästchen „Anheften“.\n\nMit Schlagwörtern kannst du die Notizen ordnen. Erstelle ein Schlagwort entweder auf dem Bildschirm „Schlagwörter bearbeiten“ mithilfe des Buttons „Schlagwort hinzufügen“ oder verwende das Feld „Schlagwort hinzufügen…“ am Ende einer Notiz. Du kannst auch eine E-Mail-Adresse als Schlagwort hinzufügen, wenn du eine Notiz mit jemandem teilen willst.\n\nDu kannst deine Notizen ganz einfach mit anderen Android-Apps teilen, indem du in der Notiz im Menü „Weitere Optionen“ auf „Teilen“ tippst.\n\nGelöschte Notizen werden in den Papierkorb verschoben. Du kannst sie bei Bedarf wiederherstellen oder den Papierkorb leeren, um sie unwiderruflich zu löschen.\n\nDu hast im Internet und auf deinen anderen Geräten Zugriff auf deine Notizen. Rufe zum Starten http://simplenote.com auf.\n\nViel Spaß mit Simplenote!</string>
+    <string name="welcome_note">Willkommen bei Simplenote Android!\nIn dieser Notiz findest du Anweisungen.\n\nTippe zum Erstellen einer neuen Notiz auf den Button „Neue Notiz“ mit dem Plus-Icon.\n\nWenn du deine Notizen durchsuchen willst, tippe auf den Button „Suchen“ mit dem Lupensymbol und gib einen Text ein. Simplenote zeigt dir anfangs die letzten Suchen an und macht Suchvorschläge, wenn du Text eingibst. Notizen, die mit dem eingegebenen Text übereinstimmen, werden nach dem Absenden der Suche angezeigt.\n\nHast du eine äußerst wichtige Notiz? Hefte sie an den Anfang der Notizenliste. Zum Anheften von Notizen gibt es zwei Möglichkeiten. Halte die Notiz in der Liste lange gedrückt und tippe auf den Button „An Anfang heften“ mit dem Anheften-Icon. Tippe in der Notiz auf den Button „Weitere Optionen“ mit dem Icon mit drei vertikalen Punkten und aktiviere das Kontrollkästchen „Anheften“.\n\nMit Schlagwörtern kannst du die Notizen ordnen. Erstelle ein Schlagwort entweder auf dem Bildschirm „Schlagwörter bearbeiten“ mithilfe des Buttons „Schlagwort hinzufügen“ oder verwende das Feld „Schlagwort hinzufügen...“ am Ende einer Notiz. Du kannst auch eine E-Mail-Adresse als Schlagwort hinzufügen, wenn du eine Notiz mit jemandem teilen willst.\n\nDu kannst deine Notizen ganz einfach mit anderen Android-Apps teilen, indem du in der Notiz im Menü „Weitere Optionen“ auf „Teilen“ tippst.\n\nGelöschte Notizen werden in den Papierkorb verschoben. Du kannst sie bei Bedarf wiederherstellen oder den Papierkorb leeren, um sie unwiderruflich zu löschen.\n\nDu hast im Internet und auf deinen anderen Geräten Zugriff auf deine Notizen. Rufe zum Starten http://simplenote.com auf.\n\nViel Spaß mit Simplenote!</string>
     <string name="search_hint">Notizen oder Schlagwörter suchen</string>
     <string name="log_out">Abmelden</string>
     <string name="log_in">Anmelden</string>
@@ -237,7 +255,7 @@ Language: de
     <string name="simperium_error_email">Ungültige E-Mail-Adresse</string>
     <string name="simperium_dialog_title_error">Fehler</string>
     <string name="simperium_dialog_progress_signing_up">Registrierung läuft …</string>
-    <string name="simperium_dialog_progress_logging_in">Anmelden …</string>
+    <string name="simperium_dialog_progress_logging_in">Anmelden ...</string>
     <string name="simperium_dialog_message_signup_existing">Die eingegebene E-Mail-Adresse ist mit einem Simplenote-Konto verknüpft.</string>
     <string name="simperium_dialog_message_signup">Registrierung mit der angegebenen E-Mail-Adresse und dem Passwort nicht möglich.</string>
     <string name="simperium_dialog_message_network">Es steht kein Netzwerk zur Verfügung. Stelle bitte eine Verbindung mit einem Netzwerk her und versuche es erneut.</string>
@@ -252,7 +270,7 @@ Language: de
     <string name="log_in_add_widget">Anmelden, um dieses Widget hinzuzufügen</string>
     <string name="select_note">Notiz auswählen</string>
     <string name="note_not_found">Notiz nicht gefunden</string>
-    <string name="loading_note">Notiz wird geladen…</string>
+    <string name="loading_note">Notiz wird geladen...</string>
     <string name="passcode_summary">Wenn die Zugangscode-Sperre aktiv ist, sind Screenshots deaktiviert.</string>
     <string name="all_notes">Alle Notizen</string>
     <string name="appearance">Design</string>

--- a/Simplenote/src/main/res/values-es/strings.xml
+++ b/Simplenote/src/main/res/values-es/strings.xml
@@ -1,12 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-23 09:54:03+0000
+Translation-Revision-Date: 2024-08-01 15:54:04+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: es
 -->
 <resources>
-    <string name="sustainer_app_icon">Icono de aplicación Sustainer</string>
+    <string name="magic_link_confirm_code_message">Hemos enviado un código a \n%1$s. El código será válido durante unos minutos.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">Introduce la contraseña</string>
+    <string name="magic_link_login_with_wordpress_or_break">O</string>
+    <string name="magic_link_enter_code_title">Introduce el código</string>
+    <string name="magic_link_code_hint">Código</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">Código no válido</string>
+    <string name="magic_link_complete_login_expired_code_error_message">El enlace ya no es válido</string>
+    <string name="magic_link_complete_login_loading_message">Acceso</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">No se ha podido acceder con el correo electrónico; introduce tu contraseña.</string>
+    <string name="magic_link_error_too_many_requests_message">Demasiadas solicitudes. Inténtalo de nuevo más tarde.</string>
+    <string name="magic_link_request_error_message">Error al solicitar el enlace mágico</string>
+    <string name="magic_link_request_login_loading_message">Solicitud de enlace de acceso</string>
+    <string name="magic_link_general_error">Estamos teniendo algunos problemas. Inténtalo de nuevo pronto.</string>
+    <string name="login_with_password">Accede con la contraseña</string>
+    <string name="login_screen_title">Acceder</string>
+    <string name="magic_link_login">Accede con el correo electrónico</string>
+    <string name="magic_link_request_login_dialog">Si existe una cuenta, hemos enviado un correo electrónico a %1$s con un enlace que te permitirá acceder.</string>
+    <string name="magic_link_request_login_dialog_title">Comprueba tu correo electrónico</string>
+    <string name="sustainer_app_icon">Icono de aplicación de Sustainer</string>
     <string name="simperium_too_many_attempts">Demasiados intentos de inicio de sesión. Inténtalo de nuevo más tarde.</string>
     <string name="simperium_change_password">Cambiar contraseña</string>
     <string name="simperium_not_now">Cancelar</string>
@@ -23,7 +41,7 @@ Language: es
     <string name="remove">Eliminar</string>
     <string name="collaborators">Colaboradores</string>
     <string name="remove_collaborator">Eliminar colaborador</string>
-    <string name="loading_collaborators">Cargando…</string>
+    <string name="loading_collaborators">Cargando...</string>
     <string name="add_email_collaborator_message">Añade una dirección de correo electrónico para compartir esta nota con alguien. Así, ambos podréis modificarla. Cuando añadas un colaborador, se le enviará un aviso por correo electrónico.</string>
     <string name="add_collaborator">Añadir colaborador</string>
     <string name="note_shared">Nota compartida</string>
@@ -66,11 +84,11 @@ Language: es
     <string name="toast_email_sent">Correo electrónico enviado</string>
     <string name="fullscreen_verify_email_button_secondary">Reenviar correo electrónico</string>
     <string name="fullscreen_verify_email_title">Verifica tu correo electrónico</string>
-    <string name="fullscreen_verify_email_subtitle">Hemos enviado un correo electrónico de verificación a &lt;b&gt;%1$s&lt;/b&gt;. Revisa tu bandeja de entrada y sigue las instrucciones.</string>
+    <string name="fullscreen_verify_email_subtitle">Hemos enviado un correo electrónico de verificación a &lt;b>%1$s&lt;/b>. Revisa tu bandeja de entrada y sigue las instrucciones.</string>
     <string name="fullscreen_review_account_button_secondary">Cambiar correo electrónico</string>
     <string name="fullscreen_review_account_button_primary">Confirmar</string>
     <string name="fullscreen_review_account_title">Revisa tu cuenta</string>
-    <string name="fullscreen_review_account_subtitle">Tienes una cuenta registrada en Simplenote con el correo electrónico &lt;b&gt;%1$s&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Puede que pierdas el acceso a la cuenta debido a las mejoras en la seguridad si ya no tienes acceso a esa dirección de correo electrónico.</string>
+    <string name="fullscreen_review_account_subtitle">Tienes una cuenta registrada en Simplenote con el correo electrónico &lt;b>%1$s&lt;/b>.&lt;br>&lt;br>Puede que pierdas el acceso a la cuenta debido a las mejoras en la seguridad si ya no tienes acceso a esa dirección de correo electrónico.</string>
     <string name="description_warning">Advertencia</string>
     <string name="description_mail">Correo</string>
     <string name="description_close">Cerrar</string>
@@ -237,7 +255,7 @@ Language: es
     <string name="simperium_error_email">Correo electrónico no válido</string>
     <string name="simperium_dialog_title_error">Error</string>
     <string name="simperium_dialog_progress_signing_up">Procesando el registro…</string>
-    <string name="simperium_dialog_progress_logging_in">Accediendo…</string>
+    <string name="simperium_dialog_progress_logging_in">Accediendo...</string>
     <string name="simperium_dialog_message_signup_existing">La dirección de correo electrónico que has introducido ya está asociada a una cuenta de Simplenote.</string>
     <string name="simperium_dialog_message_signup">No se ha podido llevar a cabo el registro con la dirección de correo electrónico y la contraseña facilitadas.</string>
     <string name="simperium_dialog_message_network">No hay ninguna red disponible. Conéctate a una red e inténtalo de nuevo.</string>
@@ -252,7 +270,7 @@ Language: es
     <string name="log_in_add_widget">Accede para usar este widget</string>
     <string name="select_note">Elegir nota</string>
     <string name="note_not_found">No se ha encontrado la nota</string>
-    <string name="loading_note">Cargando nota…</string>
+    <string name="loading_note">Cargando nota...</string>
     <string name="passcode_summary">Las capturas de pantalla están desactivadas mientras el bloqueo con contraseña está activado</string>
     <string name="all_notes">Todas las notas</string>
     <string name="appearance">Apariencia</string>
@@ -334,7 +352,7 @@ Language: es
     <string name="open_drawer">Abrir barra lateral</string>
     <string name="condensed_note_list">Lista de notas condensada</string>
     <string name="rename_tag">Renombrar etiqueta</string>
-    <string name="new_note_list">Nueva nota…</string>
+    <string name="new_note_list">Nueva nota...</string>
     <string name="confirm_delete_tag">¿Estás seguro de borrar esta etiqueta?</string>
     <string name="note_deleted">Nota movida a la papelera.</string>
     <string name="undo">Deshacer</string>
@@ -360,5 +378,5 @@ Language: es
     <string name="new_note">Nueva nota</string>
     <string name="share">Compartir</string>
     <string name="settings">Ajustes</string>
-    <string name="tag_hint">Añadir una etiqueta…</string>
+    <string name="tag_hint">Añadir una etiqueta...</string>
 </resources>

--- a/Simplenote/src/main/res/values-fr/strings.xml
+++ b/Simplenote/src/main/res/values-fr/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-23 09:54:03+0000
+Translation-Revision-Date: 2024-08-01 09:54:03+0000
 Plural-Forms: nplurals=2; plural=n > 1;
 Generator: GlotPress/2.4.0-alpha
 Language: fr
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">Nous avons envoyé un code à \n%1$s. Ce code sera valide pendant quelques minutes.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">Saisir le mot de passe</string>
+    <string name="magic_link_login_with_wordpress_or_break">Ou</string>
+    <string name="magic_link_enter_code_title">Saisir le code</string>
+    <string name="magic_link_code_hint">Code</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">Code non valide</string>
+    <string name="magic_link_complete_login_expired_code_error_message">Le lien n’est plus valide</string>
+    <string name="magic_link_complete_login_loading_message">Connexion</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">Échec de la connexion avec l’adresse e-mail, saisissez votre mot de passe.</string>
+    <string name="magic_link_error_too_many_requests_message">Trop de requêtes. Réessayez plus tard.</string>
+    <string name="magic_link_request_error_message">Erreur lors de la demande de Magic Link</string>
+    <string name="magic_link_request_login_loading_message">Demander un lien de connexion</string>
+    <string name="magic_link_general_error">Nous rencontrons des problèmes. Veuillez réessayer un peu plus tard.</string>
+    <string name="login_with_password">Se connecter avec le mot de passe</string>
+    <string name="login_screen_title">Se connecter</string>
+    <string name="magic_link_login">Se connecter avec une adresse e-mail</string>
+    <string name="magic_link_request_login_dialog">Si un compte existe, un e-mail a été envoyé à %1$s et il contient un lien de connexion.</string>
+    <string name="magic_link_request_login_dialog_title">Vérifier votre adresse e-mail</string>
     <string name="sustainer_app_icon">Icône de l’application Sustainer</string>
     <string name="simperium_too_many_attempts">Nombre excessif de tentatives de connexion. Réessayez plus tard.</string>
     <string name="simperium_change_password">Changer le mot de passe</string>
@@ -66,11 +84,11 @@ Language: fr
     <string name="toast_email_sent">E-mail envoyé</string>
     <string name="fullscreen_verify_email_button_secondary">Renvoyer l’e-mail</string>
     <string name="fullscreen_verify_email_title">Vérifiez votre messagerie</string>
-    <string name="fullscreen_verify_email_subtitle">Nous avons envoyé un e-mail de vérification à &lt;b&gt;%1$s&lt;/b&gt;. Consultez votre boîte de réception et suivez les instructions.</string>
+    <string name="fullscreen_verify_email_subtitle">Nous avons envoyé un e-mail de vérification à &lt;b>%1$s&lt;/b>. Consultez votre boîte de réception et suivez les instructions.</string>
     <string name="fullscreen_review_account_button_secondary">Changez d’adresse e-mail</string>
     <string name="fullscreen_review_account_button_primary">Confirmer</string>
     <string name="fullscreen_review_account_title">Passez en revue votre compte</string>
-    <string name="fullscreen_review_account_subtitle">Vous êtes enregistré sur Simplenote avec l’adresse e-mail &lt;b&gt;%1$s&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Les améliorations apportées à la sécurité de votre compte peuvent entraîner la perte de votre compte si vous n’avez plus accès à cette adresse e-mail.</string>
+    <string name="fullscreen_review_account_subtitle">Vous êtes enregistré sur Simplenote avec l’adresse e-mail &lt;b>%1$s&lt;/b>.&lt;br>&lt;br>Les améliorations apportées à la sécurité de votre compte peuvent entraîner la perte de votre compte si vous n’avez plus accès à cette adresse e-mail.</string>
     <string name="description_warning">Avertissement</string>
     <string name="description_mail">E-mail</string>
     <string name="description_close">Fermer</string>
@@ -111,7 +129,7 @@ Language: fr
     <string name="empty">Vider</string>
     <string name="back">Retour</string>
     <string name="empty_notes_untagged">Aucune note sans étiquette</string>
-    <string name="unpublishing">Annulation de la publication de la note en cours…</string>
+    <string name="unpublishing">Annulation de la publication de la note en cours...</string>
     <string name="unpublish_successful">Publication de la note annulée.</string>
     <string name="web_view_error_button">Accéder à l’application WebView</string>
     <string name="web_view_error">Un affichage Web doit être installé sur votre appareil pour afficher l’aperçu de la note.</string>
@@ -236,8 +254,8 @@ Language: fr
     <string name="simperium_error_password">Mot de passe invalide</string>
     <string name="simperium_error_email">E-mail non valide</string>
     <string name="simperium_dialog_title_error">Erreur</string>
-    <string name="simperium_dialog_progress_signing_up">Inscription en cours…</string>
-    <string name="simperium_dialog_progress_logging_in">Connexion en cours…</string>
+    <string name="simperium_dialog_progress_signing_up">Inscription en cours...</string>
+    <string name="simperium_dialog_progress_logging_in">Connexion en cours...</string>
     <string name="simperium_dialog_message_signup_existing">L\'adresse e-mail saisie est déjà associée à un compte Simplenote.</string>
     <string name="simperium_dialog_message_signup">Impossible de s\'inscrire avec l\'adresse e-mail et le mot de passe fournis.</string>
     <string name="simperium_dialog_message_network">Aucun réseau disponible. Connectez-vous à un réseau et essayez de nouveau.</string>
@@ -285,7 +303,7 @@ Language: fr
     <string name="wpcom_log_in_error_generic">Impossible de se connecter à WordPress.com. Veuillez réessayer.</string>
     <string name="collaborate_message">Ajoutez un e-mail dans le champ des balises pour collaborer avec d’autres utilisateurs.</string>
     <string name="collaborate">Collaborer</string>
-    <string name="publishing">Publication de la note en cours…</string>
+    <string name="publishing">Publication de la note en cours...</string>
     <string name="unpublish">Supprimer le lien public</string>
     <string name="no_browser_available">« Impossible d’ouvrir le site web. Aucun navigateur disponible. »</string>
     <string name="blog">Blog</string>
@@ -334,7 +352,7 @@ Language: fr
     <string name="open_drawer">Ouvrir le tiroir</string>
     <string name="condensed_note_list">Vue condensée</string>
     <string name="rename_tag">Renommer tag</string>
-    <string name="new_note_list">Nouvelle note…</string>
+    <string name="new_note_list">Nouvelle note...</string>
     <string name="confirm_delete_tag">Êtes-vous sûr de vouloir supprimer ce tag ?</string>
     <string name="note_deleted">Note placée dans la corbeille</string>
     <string name="undo">Défaire</string>
@@ -360,5 +378,5 @@ Language: fr
     <string name="new_note">Nouvelle note</string>
     <string name="share">Partager</string>
     <string name="settings">Paramètres</string>
-    <string name="tag_hint">Ajouter un tag…</string>
+    <string name="tag_hint">Ajouter un tag...</string>
 </resources>

--- a/Simplenote/src/main/res/values-he/strings.xml
+++ b/Simplenote/src/main/res/values-he/strings.xml
@@ -1,11 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-11-30 09:54:03+0000
+Translation-Revision-Date: 2024-08-01 15:54:03+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: he_IL
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">שלחנו קוד אל \n%1$s. הקוד הזה יהיה בתוקף למשך מספר דקות.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">להזין סיסמה</string>
+    <string name="magic_link_login_with_wordpress_or_break">או</string>
+    <string name="magic_link_enter_code_title">להזין קוד</string>
+    <string name="magic_link_code_hint">קוד</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">קוד לא חוקי</string>
+    <string name="magic_link_complete_login_expired_code_error_message">הקישור כבר לא תקף</string>
+    <string name="magic_link_complete_login_loading_message">מתחבר</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">ההתחברות באמצעות האימייל נכשלה, יש להזין סיסמה.</string>
+    <string name="magic_link_error_too_many_requests_message">יותר מדי בקשות. יש לנסות שוב מאוחר יותר.</string>
+    <string name="magic_link_request_error_message">אירעה שגיאה בשליחת הבקשה לקבלת קישור ישיר</string>
+    <string name="magic_link_request_login_loading_message">נשלחת בקשה לקבלת קישור להתחברות</string>
+    <string name="magic_link_general_error">נתקלנו בכמה בעיות. יש לנסות שוב בקרוב.</string>
+    <string name="login_with_password">התחברות באמצעות סיסמה</string>
+    <string name="login_screen_title">להתחבר</string>
+    <string name="magic_link_login">התחברות באמצעות אימייל</string>
+    <string name="magic_link_request_login_dialog">אם קיים חשבון, שלחנו הודעה לאימייל ⁦%1$s⁩ עם קישור שדרכו ניתן להתחבר.</string>
+    <string name="magic_link_request_login_dialog_title">יש לבדוק אימייל</string>
+    <string name="sustainer_app_icon">סמל האפליקציה של Sustainer</string>
     <string name="simperium_too_many_attempts">מספר ניסיונות התחברות גבוה מדי. יש לנסות שוב מאוחר יותר.</string>
     <string name="simperium_change_password">לשנות סיסמה</string>
     <string name="simperium_not_now">ביטול</string>
@@ -22,7 +41,7 @@ Language: he_IL
     <string name="remove">הסרה</string>
     <string name="collaborators">שותפי עריכה</string>
     <string name="remove_collaborator">להסיר שותף עריכה</string>
-    <string name="loading_collaborators">טוען…</string>
+    <string name="loading_collaborators">טוען...</string>
     <string name="add_email_collaborator_message">יש להוסיף כתובת אימייל כדי לשתף פתק זה עם מישהו. לאחר מכן תוכלו שניכם לערוך בו שינויים. כאשר מוסיפים שותף עריכה, תישלח אליו הודעה לאימייל.</string>
     <string name="add_collaborator">להוסיף שותף עריכה</string>
     <string name="note_shared">הפתק שותף</string>
@@ -39,7 +58,7 @@ Language: he_IL
     <string name="import_message_success">הנתונים נטענו</string>
     <string name="import_error_parse">לא ניתן לנתח את הקובץ</string>
     <string name="import_error_file">לא ניתן לקרוא את הקובץ</string>
-    <string name="requesting_message">שולח בקשה…</string>
+    <string name="requesting_message">שולח בקשה...</string>
     <string name="error_ocurred_message">אירעה שגיאה. יש לנסות שוב. אם הבעיה ממשיכה, ניתן ליצור איתנו קשר בכתובת ⁦%1$s⁩%2$s%3$s%4$s⁦%5$s⁩ לעזרה.</string>
     <string name="account_deletion_message">הודעת אימייל נשלחה אל ⁦%1$s⁩. יש לבדוק את תיבת הדואר הנכנס ולפעול לפי ההוראות לאישור המחיקה של החשבון.\n\nהחשבון שלך לא יימחק עד שנקבל את אישורך.</string>
     <string name="request_received">הבקשה התקבלה</string>
@@ -65,11 +84,11 @@ Language: he_IL
     <string name="toast_email_sent">האימייל נשלח</string>
     <string name="fullscreen_verify_email_button_secondary">לשלוח אימייל מחדש</string>
     <string name="fullscreen_verify_email_title">לאמת את כתובת האימייל שלך</string>
-    <string name="fullscreen_verify_email_subtitle">שלחנו אימייל לאימות אל &lt;b&gt;%1$s&lt;/b&gt;. יש לבדוק בתיבת הדואר הנכנס ולפעול לפי ההוראות.</string>
+    <string name="fullscreen_verify_email_subtitle">שלחנו אימייל לאימות אל &lt;b>%1$s&lt;/b>. יש לבדוק בתיבת הדואר הנכנס ולפעול לפי ההוראות.</string>
     <string name="fullscreen_review_account_button_secondary">לשנות כתובת אימייל</string>
     <string name="fullscreen_review_account_button_primary">אישור</string>
     <string name="fullscreen_review_account_title">לבדוק את החשבון שלך</string>
-    <string name="fullscreen_review_account_subtitle">החשבון שלך רשום עם Simplenote באמצעות האימייל &lt;b&gt;%1$s&lt;/b&gt;.&lt;br&gt;&lt;br&gt;שיפורים באבטחת החשבון עלולים לגרום לאבדן החשבון אם אין לך עוד גישה לכתובת האימייל הזאת.</string>
+    <string name="fullscreen_review_account_subtitle">החשבון שלך רשום עם Simplenote באמצעות האימייל &lt;b>%1$s&lt;/b>.&lt;br>&lt;br>שיפורים באבטחת החשבון עלולים לגרום לאבדן החשבון אם אין לך עוד גישה לכתובת האימייל הזאת.</string>
     <string name="description_warning">אזהרה</string>
     <string name="description_mail">דואר</string>
     <string name="description_close">לסגור</string>
@@ -110,7 +129,7 @@ Language: he_IL
     <string name="empty">לרוקן</string>
     <string name="back">חזרה</string>
     <string name="empty_notes_untagged">אין פתקים ללא תגיות</string>
-    <string name="unpublishing">מבטל את פרסום פתק…</string>
+    <string name="unpublishing">מבטל את פרסום פתק...</string>
     <string name="unpublish_successful">פרסום הפתק בוטל.</string>
     <string name="web_view_error_button">לעבור אל האפליקציה WebView</string>
     <string name="web_view_error">לשם תצוגה מקדימה של Markdown יש להתקין תצוגת אינטרנט במכשיר.</string>
@@ -185,7 +204,7 @@ Language: he_IL
     <string name="search">לחפש פתקים או תגיות</string>
     <string name="empty_tags_search">לא נמצאו תגיות</string>
     <string name="empty_notes_widget">אין פתקים</string>
-    <string name="loading_notes">טוען פתקים…</string>
+    <string name="loading_notes">טוען פתקים...</string>
     <string name="note_widget_light">פתק (בהיר)</string>
     <string name="note_widget_dark">פתק (כהה)</string>
     <string name="note_list_widget_light">רשימת פתקים (בהירה)</string>
@@ -221,7 +240,7 @@ Language: he_IL
     <string name="description_sort">מיון</string>
     <string name="description_down">למטה</string>
     <string name="description_delete_item">למחוק את הפריט</string>
-    <string name="welcome_note">ברוכים הבאים אל Simplenote Android!\nיש לפתוח את הפתק להוראות.\n\nכדי ליצור פתק חדש, יש להקיש על הכפתור \'להוסיף פתק\' עם הסמל \'+\'.\n\nכדי לבצע חיפוש בפתקים שלך, יש להקיש על הכפתור \'חיפוש\' עם הסמל של זכוכית המגדלת ולהזין טקסט. השירות של Simplenote יציג לך את החיפושים האחרונים שביצעת תחילה והצעות לחיפושים בעת ההקלדה. פתקים שתואמים לטקסט שהוזן יוצגו לאחר שהבקשה לחיפוש נשלחה.\n\nיש לך פתק חשוב? ניתן לנעוץ אותו בראש הרשימה של הפתקים. אפשר לנעוץ פתק בשתי דרכים. על ידי לחיצה ארוכה על הפתק ברשימה והקשה על הכפתור \'הצמדה לראש העמוד\' עם סמל הנעץ. על ידי הקשה על הכפתור \'אפשרויות נוספות\' עם הסמל של שלוש הנקודות האנכיות כאשר צופים בפתק ולסמן את התיבה \'לנעוץ\'.\n\nניתן להשתמש בתגיות כדי לארגן את הפתקים שלך ביעילות. ניתן ליצור פתק במסך \'לערוך תגיות\' באמצעות הכפתור \'להוסיף תגית\' או באמצעות השדה \'להוסיף תגית…\' בתחתית הפתק. אפשר גם להוסיף כתובת אימייל כתגית כדי לשתף פתק עם מישהו.\n\nאפשר לשתף פתקים באפליקציות אחרות של Android על ידי הקשה על הכפתור \'שיתוף\' בתפריט \'אפשרויות נוספות\' כאשר צופים בפתק.\n\nפתקים שנמחקו מועברים לפח. אפשר לשחזר את הפריטים כרצונך או לרוקן את הפח כדי למחוק אותם לצמיתות.\n\nאפשר לגשת לפתקים שלך ברשת ובמכשירים האחרים שלך. יש לעבור לכתובת http://simplenote.com כדי להתחיל.\n\nאנחנו מקווים שהשירות של Simplenote מוצא חן בעינך!</string>
+    <string name="welcome_note">ברוכים הבאים אל Simplenote Android!\nיש לפתוח את הפתק להוראות.\n\nכדי ליצור פתק חדש, יש להקיש על הכפתור \'להוסיף פתק\' עם הסמל \'+\'.\n\nכדי לבצע חיפוש בפתקים שלך, יש להקיש על הכפתור \'חיפוש\' עם הסמל של זכוכית המגדלת ולהזין טקסט. השירות של Simplenote יציג לך את החיפושים האחרונים שביצעת תחילה והצעות לחיפושים בעת ההקלדה. פתקים שתואמים לטקסט שהוזן יוצגו לאחר שהבקשה לחיפוש נשלחה.\n\nיש לך פתק חשוב? ניתן לנעוץ אותו בראש הרשימה של הפתקים. אפשר לנעוץ פתק בשתי דרכים. על ידי לחיצה ארוכה על הפתק ברשימה והקשה על הכפתור \'הצמדה לראש העמוד\' עם סמל הנעץ. על ידי הקשה על הכפתור \'אפשרויות נוספות\' עם הסמל של שלוש הנקודות האנכיות כאשר צופים בפתק ולסמן את התיבה \'לנעוץ\'.\n\nניתן להשתמש בתגיות כדי לארגן את הפתקים שלך ביעילות. ניתן ליצור פתק במסך \'לערוך תגיות\' באמצעות הכפתור \'להוסיף תגית\' או באמצעות השדה \'להוסיף תגית...\' בתחתית הפתק. אפשר גם להוסיף כתובת אימייל כתגית כדי לשתף פתק עם מישהו.\n\nאפשר לשתף פתקים באפליקציות אחרות של Android על ידי הקשה על הכפתור \'שיתוף\' בתפריט \'אפשרויות נוספות\' כאשר צופים בפתק.\n\nפתקים שנמחקו מועברים לפח. אפשר לשחזר את הפריטים כרצונך או לרוקן את הפח כדי למחוק אותם לצמיתות.\n\nאפשר לגשת לפתקים שלך ברשת ובמכשירים האחרים שלך. יש לעבור לכתובת http://simplenote.com כדי להתחיל.\n\nאנחנו מקווים שהשירות של Simplenote מוצא חן בעינך!</string>
     <string name="search_hint">לחפש פתקים או תגיות</string>
     <string name="log_out">התנתקות</string>
     <string name="log_in">התחברות</string>
@@ -235,8 +254,8 @@ Language: he_IL
     <string name="simperium_error_password">סיסמה לא תקפה</string>
     <string name="simperium_error_email">אימייל לא תקף</string>
     <string name="simperium_dialog_title_error">שגיאה</string>
-    <string name="simperium_dialog_progress_signing_up">נרשם למערכת…</string>
-    <string name="simperium_dialog_progress_logging_in">נכנס…</string>
+    <string name="simperium_dialog_progress_signing_up">נרשם למערכת...</string>
+    <string name="simperium_dialog_progress_logging_in">נכנס...</string>
     <string name="simperium_dialog_message_signup_existing">כתובת האימייל שהזנת כבר משויכת לחשבון Simplenote.</string>
     <string name="simperium_dialog_message_signup">לא ניתן ליצור חשבון באמצעות כתובת האימייל והסיסמה שסופקו.</string>
     <string name="simperium_dialog_message_network">אין רשת זמינה. יש להתחבר לרשת ולנסות שנית.</string>
@@ -251,7 +270,7 @@ Language: he_IL
     <string name="log_in_add_widget">יש להתחבר כדי להוסיף את הווידג\'ט</string>
     <string name="select_note">יש לבחור פתק</string>
     <string name="note_not_found">פתק לא נמצא</string>
-    <string name="loading_note">טוען את הפתק…</string>
+    <string name="loading_note">טוען את הפתק...</string>
     <string name="passcode_summary">צילומי המסך מושבתים כאשר מופעלת הנעילה של קוד הסיסמה</string>
     <string name="all_notes">כל הפתקים</string>
     <string name="appearance">מראה</string>
@@ -284,7 +303,7 @@ Language: he_IL
     <string name="wpcom_log_in_error_generic">לא ניתן היה להתחבר עם WordPress.com. יש לנסות שוב.</string>
     <string name="collaborate_message">הוספת אימייל בשדה \'תגית\' לצורך שיתוף פעולה בעריכה עם משתמשים אחרים.</string>
     <string name="collaborate">שיתוף פעולה בעריכה</string>
-    <string name="publishing">מפרסם פתק…</string>
+    <string name="publishing">מפרסם פתק...</string>
     <string name="unpublish">הסרת קישור ציבורי</string>
     <string name="no_browser_available">\"לא ניתן היה לפתוח את אתר האינטרנט. אין דפדפן זמין.\"</string>
     <string name="blog">בלוג</string>
@@ -333,7 +352,7 @@ Language: he_IL
     <string name="open_drawer">פתיחת מגירה</string>
     <string name="condensed_note_list">רשימה מכווצת</string>
     <string name="rename_tag">שינוי שם תגית</string>
-    <string name="new_note_list">פתק חדש…</string>
+    <string name="new_note_list">פתק חדש...</string>
     <string name="confirm_delete_tag">בטוח שברצונך למחוק תגית זו?</string>
     <string name="note_deleted">הפתק הועבר לאשפה.</string>
     <string name="undo">ביטול</string>
@@ -359,5 +378,5 @@ Language: he_IL
     <string name="new_note">פתק חדש</string>
     <string name="share">שיתוף</string>
     <string name="settings">הגדרות</string>
-    <string name="tag_hint">להוסיף תגית…</string>
+    <string name="tag_hint">להוסיף תגית...</string>
 </resources>

--- a/Simplenote/src/main/res/values-id/strings.xml
+++ b/Simplenote/src/main/res/values-id/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-23 11:54:03+0000
+Translation-Revision-Date: 2024-08-01 09:54:03+0000
 Plural-Forms: nplurals=2; plural=n > 1;
 Generator: GlotPress/2.4.0-alpha
 Language: id
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">Kami telah mengirimkan kode ke \n%1$s. Kode ini valid selama beberapa menit.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">Masukkan kata sandi</string>
+    <string name="magic_link_login_with_wordpress_or_break">Atau</string>
+    <string name="magic_link_enter_code_title">Masukkan Kode</string>
+    <string name="magic_link_code_hint">Kode</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">Kode tidak valid</string>
+    <string name="magic_link_complete_login_expired_code_error_message">Tautan tidak lagi valid</string>
+    <string name="magic_link_complete_login_loading_message">Sedang Login</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">Login dengan email gagal, masukkan kata sandi.</string>
+    <string name="magic_link_error_too_many_requests_message">Terlalu banyak permintaan. Coba lagi nanti.</string>
+    <string name="magic_link_request_error_message">Error terjadi saat meminta Tautan Ajaib</string>
+    <string name="magic_link_request_login_loading_message">Meminta tautan login</string>
+    <string name="magic_link_general_error">Terjadi masalah. Coba lagi nanti.</string>
+    <string name="login_with_password">Login dengan Kata Sandi</string>
+    <string name="login_screen_title">Login</string>
+    <string name="magic_link_login">Login dengan email</string>
+    <string name="magic_link_request_login_dialog">Jika akun valid, Anda akan menerima tautan untuk login di %1$s.</string>
+    <string name="magic_link_request_login_dialog_title">Periksa email Anda</string>
     <string name="sustainer_app_icon">Ikon aplikasi Sustainer</string>
     <string name="simperium_too_many_attempts">Terlalu banyak upaya login. Coba lagi nanti.</string>
     <string name="simperium_change_password">Ganti Kata Sandi</string>
@@ -23,7 +41,7 @@ Language: id
     <string name="remove">Buang</string>
     <string name="collaborators">Kolaborator</string>
     <string name="remove_collaborator">Hapus Kolaborator</string>
-    <string name="loading_collaborators">Memuat…</string>
+    <string name="loading_collaborators">Memuat...</string>
     <string name="add_email_collaborator_message">Tambahkan alamat email untuk berbagi catatan ini dengan seseorang sehingga Anda dan orang yang Anda bagi catatan tersebut dapat melakukan perubahan. Ketika Anda menambahkan kolaborator, mereka akan menerima email pemberitahuan.</string>
     <string name="add_collaborator">Tambahkan Kolaborator</string>
     <string name="note_shared">Catatan Dibagikan</string>
@@ -40,7 +58,7 @@ Language: id
     <string name="import_message_success">Data dimuat</string>
     <string name="import_error_parse">Tidak dapat mengurai file</string>
     <string name="import_error_file">Tidak dapat membaca file</string>
-    <string name="requesting_message">Meminta…</string>
+    <string name="requesting_message">Meminta...</string>
     <string name="error_ocurred_message">Terjadi error. Harap coba lagi. Jika masalah berlanjut, hubungi kami di %1$s%2$s%3$s%4$s%5$s untuk mendapatkan bantuan.</string>
     <string name="account_deletion_message">Email dikirim ke %1$s. Periksa kotak masuk Anda dan ikuti petunjuk untuk mengonfirmasi penghapusan akun.\n\nAkun tidak akan dihapus hingga kami menerima konfirmasi Anda.</string>
     <string name="request_received">Permintaan Diterima</string>
@@ -66,11 +84,11 @@ Language: id
     <string name="toast_email_sent">Email terkirim</string>
     <string name="fullscreen_verify_email_button_secondary">Kirim ulang email</string>
     <string name="fullscreen_verify_email_title">Verifikasi Email Anda</string>
-    <string name="fullscreen_verify_email_subtitle">Kami telah mengirimkan email verifikasi ke &lt;b&gt;%1$s&lt;/b&gt;. Harap periksa kotak masuk Anda dan ikuti instruksi berikut.</string>
+    <string name="fullscreen_verify_email_subtitle">Kami telah mengirimkan email verifikasi ke &lt;b>%1$s&lt;/b>. Harap periksa kotak masuk Anda dan ikuti instruksi berikut.</string>
     <string name="fullscreen_review_account_button_secondary">Ubah email</string>
     <string name="fullscreen_review_account_button_primary">Konfirmasi</string>
     <string name="fullscreen_review_account_title">Tinjau Akun Anda</string>
-    <string name="fullscreen_review_account_subtitle">Anda terdaftar pada SImplenote menggunakan email &lt;b&gt;%1$s&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Peningkatan keamanan akun dapat menyebabkan akun hilang jika Anda tidak lagi memiliki akses ke alamat email ini.</string>
+    <string name="fullscreen_review_account_subtitle">Anda terdaftar pada SImplenote menggunakan email &lt;b>%1$s&lt;/b>.&lt;br>&lt;br>Peningkatan keamanan akun dapat menyebabkan akun hilang jika Anda tidak lagi memiliki akses ke alamat email ini.</string>
     <string name="description_warning">Peringatan</string>
     <string name="description_mail">Surat</string>
     <string name="description_close">Tutup</string>
@@ -111,7 +129,7 @@ Language: id
     <string name="empty">Kosong</string>
     <string name="back">Kembali</string>
     <string name="empty_notes_untagged">Tidak ada catatan tanpa tag</string>
-    <string name="unpublishing">Membatalkan penerbitan catatan…</string>
+    <string name="unpublishing">Membatalkan penerbitan catatan...</string>
     <string name="unpublish_successful">Catatan tidak diterbitkan.</string>
     <string name="web_view_error_button">Buka aplikasi WebView</string>
     <string name="web_view_error">Tampilan web harus terpasang pada perangkat Anda untuk pratinjau markdown.</string>
@@ -222,7 +240,7 @@ Language: id
     <string name="description_sort">Urutkan</string>
     <string name="description_down">Bawah</string>
     <string name="description_delete_item">Hapus item</string>
-    <string name="welcome_note">Selamat datang di Simplenote Android!\nBuka catatan ini untuk melihat instruksi.\n\nUntuk membuat catatan baru, ketuk tombol \"Catatan Baru\" dengan ikon tambah.\n\nUntuk mencari catatan, ketuk tombol \"Cari\" dengan ikon kaca pembesar dan ketik apa yang ingin dicari. Simplenote akan menunjukkan pencarian terkini yang pertama kali serta pencarian yang disarankan saat mengetik kata-kata. Catatan yang cocok dengan kata yang dimasukkan akan ditampilkan setelah pencarian dikirim.\n\nAda catatan yang sangat penting? Sematkan di bagian atas daftar catatan. Anda dapat menyematkan catatan dengan dua cara. Tekan lama catatan di daftar, lalu tombol \"Sematkan ke atas\" dengan ikon pin. Ketuk tombol \"Pilihan Lainnya\" dengan ikon tiga titik vertikal ketika melihat catatan dan centang kotak \"Sematkan\".\n\nGunakan tag untuk membantu menata catatan. Buat tag pada layar \"Edit Tag\" menggunakan tombol \"Tambah Tag\" atau kolom \"Tambah tag…\" di bagian bawah catatan. Anda juga dapat menambahkan alamat email sebagai tag untuk membagikan catatan kepada seseorang.\n\nBagikan catatan dengan mudah ke aplikasi Android lainnya dengan mengetuk tombol \"Bagikan\" di menu \"Pilihan Lainnya\" ketika melihat catatan.\n\nCatatan yang dihapus berada di tempat sampah. Anda dapat memulihkannya jika mau, atau kosongkan tempat sampah untuk membuang catatan selamanya.\n\nAnda dapat mengakses catatan di web dan perangkat lainnya. Buka http://simplenote.com untuk memulai.\n\nSemoga Anda suka Simplenote!</string>
+    <string name="welcome_note">Selamat datang di Simplenote Android!\nBuka catatan ini untuk melihat instruksi.\n\nUntuk membuat catatan baru, ketuk tombol \"Catatan Baru\" dengan ikon tambah.\n\nUntuk mencari catatan, ketuk tombol \"Cari\" dengan ikon kaca pembesar dan ketik apa yang ingin dicari. Simplenote akan menunjukkan pencarian terkini yang pertama kali serta pencarian yang disarankan saat mengetik kata-kata. Catatan yang cocok dengan kata yang dimasukkan akan ditampilkan setelah pencarian dikirim.\n\nAda catatan yang sangat penting? Sematkan di bagian atas daftar catatan. Anda dapat menyematkan catatan dengan dua cara. Tekan lama catatan di daftar, lalu tombol \"Sematkan ke atas\" dengan ikon pin. Ketuk tombol \"Pilihan Lainnya\" dengan ikon tiga titik vertikal ketika melihat catatan dan centang kotak \"Sematkan\".\n\nGunakan tag untuk membantu menata catatan. Buat tag pada layar \"Edit Tag\" menggunakan tombol \"Tambah Tag\" atau kolom \"Tambah tag...\" di bagian bawah catatan. Anda juga dapat menambahkan alamat email sebagai tag untuk membagikan catatan kepada seseorang.\n\nBagikan catatan dengan mudah ke aplikasi Android lainnya dengan mengetuk tombol \"Bagikan\" di menu \"Pilihan Lainnya\" ketika melihat catatan.\n\nCatatan yang dihapus berada di tempat sampah. Anda dapat memulihkannya jika mau, atau kosongkan tempat sampah untuk membuang catatan selamanya.\n\nAnda dapat mengakses catatan di web dan perangkat lainnya. Buka http://simplenote.com untuk memulai.\n\nSemoga Anda suka Simplenote!</string>
     <string name="search_hint">Cari catatan atau tag</string>
     <string name="log_out">Logout</string>
     <string name="log_in">Login</string>
@@ -285,7 +303,7 @@ Language: id
     <string name="wpcom_log_in_error_generic">Tidak dapat login dengan WordPress.com. Coba lagi.</string>
     <string name="collaborate_message">Tambahkan email di bidang tag untuk berkolaborasi dengan pengguna lain.</string>
     <string name="collaborate">Kolaborasi</string>
-    <string name="publishing">Menerbitkan catatan…</string>
+    <string name="publishing">Menerbitkan catatan...</string>
     <string name="unpublish">Hapus tautan publik</string>
     <string name="no_browser_available">\"Tidak dapat membuka situs web. Browser tidak tersedia.\"</string>
     <string name="blog">Blog</string>

--- a/Simplenote/src/main/res/values-it/strings.xml
+++ b/Simplenote/src/main/res/values-it/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-23 11:54:04+0000
+Translation-Revision-Date: 2024-08-01 11:54:03+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: it
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">Abbiamo inviato un codice a \n%1$s. Il codice sarà valido per pochi minuti.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">Inserisci password</string>
+    <string name="magic_link_login_with_wordpress_or_break">Oppure</string>
+    <string name="magic_link_enter_code_title">Inserisci codice</string>
+    <string name="magic_link_code_hint">Codice</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">Codice non valido</string>
+    <string name="magic_link_complete_login_expired_code_error_message">Link non più valido</string>
+    <string name="magic_link_complete_login_loading_message">Accesso in corso</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">Accesso con e-mail non riuscito, inserisci la tua password.</string>
+    <string name="magic_link_error_too_many_requests_message">Troppe richieste. Riprova più tardi.</string>
+    <string name="magic_link_request_error_message">Errore nella richiesta del link magico</string>
+    <string name="magic_link_request_login_loading_message">Richiesta del link di accesso</string>
+    <string name="magic_link_general_error">Stiamo riscontrando dei problemi. Riprova tra poco.</string>
+    <string name="login_with_password">Accedi con la password</string>
+    <string name="login_screen_title">Accedi</string>
+    <string name="magic_link_login">Accedi con l\'e-mail</string>
+    <string name="magic_link_request_login_dialog">Se un account esiste, abbiamo mandato un\'e-mail a %1$s contenente un link che permetterà l\'accesso.</string>
+    <string name="magic_link_request_login_dialog_title">Controlla la tua e-mail</string>
     <string name="sustainer_app_icon">Icona app sostenitore</string>
     <string name="simperium_too_many_attempts">Troppi tentativi di accesso. Riprova più tardi.</string>
     <string name="simperium_change_password">Modifica la password</string>
@@ -40,7 +58,7 @@ Language: it
     <string name="import_message_success">Dati caricati</string>
     <string name="import_error_parse">Impossibile analizzare il file</string>
     <string name="import_error_file">Impossibile leggere il file</string>
-    <string name="requesting_message">Richiesta in corso…</string>
+    <string name="requesting_message">Richiesta in corso...</string>
     <string name="error_ocurred_message">Si è verificato un errore. Riprova. Se il problema persiste, contattaci all\'indirizzo %1$s%2$s%3$s%4$s%5$s per ricevere supporto.</string>
     <string name="account_deletion_message">È stata inviata un\'e-mail a %1$s. Controlla la posta in arrivo e segui le istruzioni per confermare l\'eliminazione dell\'account.\n\nIl tuo account non verrà eliminato fino alla ricezione della conferma.</string>
     <string name="request_received">Richiesta ricevuta</string>
@@ -66,11 +84,11 @@ Language: it
     <string name="toast_email_sent">E-mail inviata</string>
     <string name="fullscreen_verify_email_button_secondary">Invia di nuovo l\'e-mail</string>
     <string name="fullscreen_verify_email_title">Verifica la tua e-mail</string>
-    <string name="fullscreen_verify_email_subtitle">Abbiamo inviato un\'e-mail di verifica a &lt;b&gt;%1$s&lt;/b&gt;. Controlla la tua casella di posta in arrivo e segui le istruzioni.</string>
+    <string name="fullscreen_verify_email_subtitle">Abbiamo inviato un\'e-mail di verifica a &lt;b>%1$s&lt;/b>. Controlla la tua casella di posta in arrivo e segui le istruzioni.</string>
     <string name="fullscreen_review_account_button_secondary">Cambia e-mail</string>
     <string name="fullscreen_review_account_button_primary">Conferma</string>
     <string name="fullscreen_review_account_title">Verifica il tuo account</string>
-    <string name="fullscreen_review_account_subtitle">Sei registrato su Simplenote con l\'e-mail &lt;b&gt;%1$s&lt;/b&gt;.&lt;br&gt;&lt;br&gt;I miglioramenti alla sicurezza dell\'account possono comportare la perdita dell\'account se non hai più accesso a questo indirizzo e-mail.</string>
+    <string name="fullscreen_review_account_subtitle">Sei registrato su Simplenote con l\'e-mail &lt;b>%1$s&lt;/b>.&lt;br>&lt;br>I miglioramenti alla sicurezza dell\'account possono comportare la perdita dell\'account se non hai più accesso a questo indirizzo e-mail.</string>
     <string name="description_warning">Attenzione</string>
     <string name="description_mail">E-mail</string>
     <string name="description_close">Chiudi</string>
@@ -111,7 +129,7 @@ Language: it
     <string name="empty">Vuota</string>
     <string name="back">Indietro</string>
     <string name="empty_notes_untagged">Nessuna nota senza tag</string>
-    <string name="unpublishing">Annullamento della pubblicazione della nota in corso…</string>
+    <string name="unpublishing">Annullamento della pubblicazione della nota in corso...</string>
     <string name="unpublish_successful">Pubblicazione della nota annullata.</string>
     <string name="web_view_error_button">Vai all\'app di visualizzazione web</string>
     <string name="web_view_error">Per visualizzare in anteprima il markdown, è necessaria l\'installazione sul dispositivo di una funzionalità di visualizzazione web.</string>
@@ -285,7 +303,7 @@ Language: it
     <string name="wpcom_log_in_error_generic">Non è stato possibile accedere con WordPress.com. Riprova.</string>
     <string name="collaborate_message">Aggiungi un\'e-mail nel campo di tag per collaborare con altri utenti.</string>
     <string name="collaborate">Collabora</string>
-    <string name="publishing">Pubblicazione della nota in corso…</string>
+    <string name="publishing">Pubblicazione della nota in corso...</string>
     <string name="unpublish">Rimuovi link pubblico</string>
     <string name="no_browser_available">\"Impossibile aprire il sito web. Nessun browser disponibile.\"</string>
     <string name="blog">Blog</string>
@@ -334,7 +352,7 @@ Language: it
     <string name="open_drawer">Apri menu</string>
     <string name="condensed_note_list">Formato lista note ridotta</string>
     <string name="rename_tag">Rinomina il tag</string>
-    <string name="new_note_list">Nuova nota…</string>
+    <string name="new_note_list">Nuova nota...</string>
     <string name="confirm_delete_tag">Sei sicuro di voler cancellare questo tag?</string>
     <string name="note_deleted">Nota eliminata.</string>
     <string name="undo">Annulla</string>
@@ -360,5 +378,5 @@ Language: it
     <string name="new_note">Nuova nota</string>
     <string name="share">Condividi</string>
     <string name="settings">Impostazioni</string>
-    <string name="tag_hint">Aggiungi tag…</string>
+    <string name="tag_hint">Aggiungi tag...</string>
 </resources>

--- a/Simplenote/src/main/res/values-ja/strings.xml
+++ b/Simplenote/src/main/res/values-ja/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-23 09:54:03+0000
+Translation-Revision-Date: 2024-08-01 09:54:03+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/2.4.0-alpha
 Language: ja_JP
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">コードを \n に送信しました%1$s。 コードは数分間有効です。</string>
+    <string name="magic_link_confirm_code_enter_pass_label">パスワードを入力</string>
+    <string name="magic_link_login_with_wordpress_or_break">または</string>
+    <string name="magic_link_enter_code_title">コードを入力</string>
+    <string name="magic_link_code_hint">コード</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">無効なコード</string>
+    <string name="magic_link_complete_login_expired_code_error_message">リンクはすでに無効です</string>
+    <string name="magic_link_complete_login_loading_message">ログイン</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">メールアドレスでのログインに失敗しました。パスワードを入力してください。</string>
+    <string name="magic_link_error_too_many_requests_message">リクエスト数が多すぎます。 後ほど、もう一度お試しください。</string>
+    <string name="magic_link_request_error_message">マジックリンクのリクエスト中にエラーが発生しました</string>
+    <string name="magic_link_request_login_loading_message">ログインリンクをリクエスト中</string>
+    <string name="magic_link_general_error">問題が発生しました。 すぐにもう一度実行してください。</string>
+    <string name="login_with_password">パスワードでログイン</string>
+    <string name="login_screen_title">ログイン</string>
+    <string name="magic_link_login">メールアドレスでログイン</string>
+    <string name="magic_link_request_login_dialog">アカウントが存在する場合は、ログインするためのリンクを記載したメールを %1$s に送信しました。</string>
+    <string name="magic_link_request_login_dialog_title">メールをご確認ください</string>
     <string name="sustainer_app_icon">Sustainer アプリアイコン</string>
     <string name="simperium_too_many_attempts">ログイン試行の回数が多すぎます。 後ほど、もう一度お試しください。</string>
     <string name="simperium_change_password">パスワードを変更</string>
@@ -40,7 +58,7 @@ Language: ja_JP
     <string name="import_message_success">データを読み込みました</string>
     <string name="import_error_parse">ファイルを解析できません</string>
     <string name="import_error_file">ファイルを読み取れません</string>
-    <string name="requesting_message">リクエストしています…</string>
+    <string name="requesting_message">リクエストしています...</string>
     <string name="error_ocurred_message">エラーが発生しました。 もう一度お試しください。 問題が解決しない場合は、%1$s%2$s%3$s%4$s%5$s までお問い合わせください。</string>
     <string name="account_deletion_message">%1$s にメールが送信されました。 受信トレイを確認し、手順に従ってアカウントの削除を確定してください。\n\n当社がお客様から確認を得るまでアカウントは削除されません。</string>
     <string name="request_received">リクエストを受信しました</string>
@@ -66,11 +84,11 @@ Language: ja_JP
     <string name="toast_email_sent">メールを送信しました</string>
     <string name="fullscreen_verify_email_button_secondary">メールを再送信</string>
     <string name="fullscreen_verify_email_title">メールアドレスを確認</string>
-    <string name="fullscreen_verify_email_subtitle">&lt;b&gt;%1$s&lt;/b&gt; に確認メールを送信しました。 受信箱を確認して手順に従ってください。</string>
+    <string name="fullscreen_verify_email_subtitle">&lt;b>%1$s&lt;/b> に確認メールを送信しました。 受信箱を確認して手順に従ってください。</string>
     <string name="fullscreen_review_account_button_secondary">メールアドレスを変更</string>
     <string name="fullscreen_review_account_button_primary">確認</string>
     <string name="fullscreen_review_account_title">アカウントの設定を確認</string>
-    <string name="fullscreen_review_account_subtitle">メールアドレス &lt;b&gt;%1$s&lt;/b&gt; で Simplenote に登録されました。&lt;br&gt;&lt;br&gt;アカウントのセキュリティ強化により、このメールアドレスにアクセスできなくなった場合にはアカウントを喪失する可能性があります。</string>
+    <string name="fullscreen_review_account_subtitle">メールアドレス &lt;b>%1$s&lt;/b> で Simplenote に登録されました。&lt;br>&lt;br>アカウントのセキュリティ強化により、このメールアドレスにアクセスできなくなった場合にはアカウントを喪失する可能性があります。</string>
     <string name="description_warning">警告</string>
     <string name="description_mail">メール</string>
     <string name="description_close">閉じる</string>
@@ -111,7 +129,7 @@ Language: ja_JP
     <string name="empty">空</string>
     <string name="back">戻る</string>
     <string name="empty_notes_untagged">タグが付けられていないメモはありません</string>
-    <string name="unpublishing">ノートを非公開にしています…</string>
+    <string name="unpublishing">ノートを非公開にしています...</string>
     <string name="unpublish_successful">ノートが非公開になりました。</string>
     <string name="web_view_error_button">WebView アプリに移動</string>
     <string name="web_view_error">マークダウンをプレビューするには、WebView がデバイスにインストールされている必要があります。</string>
@@ -186,7 +204,7 @@ Language: ja_JP
     <string name="search">メモまたはタグを検索</string>
     <string name="empty_tags_search">タグが見つかりません</string>
     <string name="empty_notes_widget">メモがありません</string>
-    <string name="loading_notes">メモを読み込んでいます…</string>
+    <string name="loading_notes">メモを読み込んでいます...</string>
     <string name="note_widget_light">メモ (ライト)</string>
     <string name="note_widget_dark">メモ (ダーク)</string>
     <string name="note_list_widget_light">メモリスト (ライト)</string>
@@ -222,7 +240,7 @@ Language: ja_JP
     <string name="description_sort">並べ替え</string>
     <string name="description_down">下に</string>
     <string name="description_delete_item">項目を削除</string>
-    <string name="welcome_note">Simplenote Android へようこそ !\n手順についてはこのメモを開いてください。\n\n新しいメモを作成するには、「+」アイコンのついた「新しいメモ」ボタンをタップします。\n\nメモを検索するには、虫眼鏡アイコンの「検索」ボタンをタップして、テキストを入力します。 Simplenote では、最初に最近の検索が表示され、テキストを入力すると検索候補が表示されます。 検索を実行すると、入力したテキストに一致するメモが表示されます。\n\nとても重要なメモですか ? メモリストの最上部にピンできます。 メモのピンには2つの方法があります。 リスト内のメモを長押しして、ピンアイコンの「上部に固定」ボタンをタップします。 メモの表示中に3つのドットの「More Options」ボタンをタップして、「Pin」ボックスにチェックマークを入れます。\n\nメモを整理するにはタグを利用します。 タグを作成するには、「タグを編集」画面で「タグを追加」ボタンを使用するか、メモの最下部にある「タグを追加…」フィールドで作成します。 メモを他の人と共有するために、メールアドレスをタグとして追加することもできます。\n\nメモを表示するとき、「その他のオプション」メニューの「共有」をタップすると、簡単に他の Android アプリとメモを共有できます。\n\n削除したメモはゴミ箱に入ります。 ゴミ箱内のメモは必要に応じて復元できます。完全にメモを削除するには、ゴミ箱を空にします。\n\nメモは Web を通じてさまざまな端末でアクセスできます。 開始するには、http://simplenote.com に移動します。\n\nSimplenote をお楽しみください !</string>
+    <string name="welcome_note">Simplenote Android へようこそ !\n手順についてはこのメモを開いてください。\n\n新しいメモを作成するには、「+」アイコンのついた「新しいメモ」ボタンをタップします。\n\nメモを検索するには、虫眼鏡アイコンの「検索」ボタンをタップして、テキストを入力します。 Simplenote では、最初に最近の検索が表示され、テキストを入力すると検索候補が表示されます。 検索を実行すると、入力したテキストに一致するメモが表示されます。\n\nとても重要なメモですか ? メモリストの最上部にピンできます。 メモのピンには2つの方法があります。 リスト内のメモを長押しして、ピンアイコンの「上部に固定」ボタンをタップします。 メモの表示中に3つのドットの「More Options」ボタンをタップして、「Pin」ボックスにチェックマークを入れます。\n\nメモを整理するにはタグを利用します。 タグを作成するには、「タグを編集」画面で「タグを追加」ボタンを使用するか、メモの最下部にある「タグを追加...」フィールドで作成します。 メモを他の人と共有するために、メールアドレスをタグとして追加することもできます。\n\nメモを表示するとき、「その他のオプション」メニューの「共有」をタップすると、簡単に他の Android アプリとメモを共有できます。\n\n削除したメモはゴミ箱に入ります。 ゴミ箱内のメモは必要に応じて復元できます。完全にメモを削除するには、ゴミ箱を空にします。\n\nメモは Web を通じてさまざまな端末でアクセスできます。 開始するには、http://simplenote.com に移動します。\n\nSimplenote をお楽しみください !</string>
     <string name="search_hint">メモまたはタグを検索</string>
     <string name="log_out">ログアウト</string>
     <string name="log_in">ログイン</string>
@@ -252,7 +270,7 @@ Language: ja_JP
     <string name="log_in_add_widget">ログインしてこのウィジェットを追加</string>
     <string name="select_note">メモを選択</string>
     <string name="note_not_found">メモが見つかりませんでした</string>
-    <string name="loading_note">メモを読み込み中…</string>
+    <string name="loading_note">メモを読み込み中...</string>
     <string name="passcode_summary">パスコードロックが有効な間はスクリーンショットが無効になります</string>
     <string name="all_notes">すべてのノート</string>
     <string name="appearance">外観</string>
@@ -285,7 +303,7 @@ Language: ja_JP
     <string name="wpcom_log_in_error_generic">WordPress.com にログインできませんでした。もう一度お試しください。</string>
     <string name="collaborate_message">メールアドレスをタグフィールドに追加すると、他のユーザーと共同作業できます。</string>
     <string name="collaborate">共同編集</string>
-    <string name="publishing">ノートを公開しています…</string>
+    <string name="publishing">ノートを公開しています...</string>
     <string name="unpublish">公開リンクを削除</string>
     <string name="no_browser_available">「サイトを開けません。使用可能なブラウザーがありません。」</string>
     <string name="blog">ブログ</string>

--- a/Simplenote/src/main/res/values-ko/strings.xml
+++ b/Simplenote/src/main/res/values-ko/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-23 09:54:03+0000
+Translation-Revision-Date: 2024-08-01 09:54:03+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/2.4.0-alpha
 Language: ko_KR
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">다음으로 코드를 보냈습니다: \n%1$s 코드는 몇 분 동안 유효합니다.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">비밀번호 입력</string>
+    <string name="magic_link_login_with_wordpress_or_break">또는</string>
+    <string name="magic_link_enter_code_title">코드 입력</string>
+    <string name="magic_link_code_hint">코드</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">유효하지 않은 코드</string>
+    <string name="magic_link_complete_login_expired_code_error_message">링크가 더 이상 유효하지 않음</string>
+    <string name="magic_link_complete_login_loading_message">로그인 중</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">이메일로 로그인하지 못했습니다. 비밀번호를 입력해 주세요.</string>
+    <string name="magic_link_error_too_many_requests_message">요청이 너무 많습니다. 나중에 다시 시도하세요.</string>
+    <string name="magic_link_request_error_message">매직 링크 요청 중 오류 발생</string>
+    <string name="magic_link_request_login_loading_message">로그인 링크 요청 중</string>
+    <string name="magic_link_general_error">문제가 발생했습니다. 잠시 후 다시 시도해 주세요.</string>
+    <string name="login_with_password">비밀번호로 로그인</string>
+    <string name="login_screen_title">로그인</string>
+    <string name="magic_link_login">이메일로 로그인</string>
+    <string name="magic_link_request_login_dialog">계정이 있다면 %1$s 주소로 로그인용 링크가 포함된 이메일이 전송되었을 것입니다.</string>
+    <string name="magic_link_request_login_dialog_title">이메일을 확인하세요</string>
     <string name="sustainer_app_icon">지지자 앱 아이콘</string>
     <string name="simperium_too_many_attempts">로그인을 너무 많이 시도했습니다. 나중에 다시 시도하세요.</string>
     <string name="simperium_change_password">비밀번호 변경</string>
@@ -23,7 +41,7 @@ Language: ko_KR
     <string name="remove">제거</string>
     <string name="collaborators">공동 작업자</string>
     <string name="remove_collaborator">공동 작업자 제거</string>
-    <string name="loading_collaborators">로드 중…</string>
+    <string name="loading_collaborators">로드 중...</string>
     <string name="add_email_collaborator_message">이메일 주소를 추가하여 이 메모를 다른 사람과 공유하면 두 사람 모두 내용을 변경할 수 있습니다. 공동 작업자를 추가하면 공동 작업자에게 이메일로 통보됩니다.</string>
     <string name="add_collaborator">공동 작업자 추가</string>
     <string name="note_shared">메모 공유됨</string>
@@ -66,11 +84,11 @@ Language: ko_KR
     <string name="toast_email_sent">이메일 보냄</string>
     <string name="fullscreen_verify_email_button_secondary">이메일 다시 보내기</string>
     <string name="fullscreen_verify_email_title">이메일 확인</string>
-    <string name="fullscreen_verify_email_subtitle">&lt;b&gt;%1$s&lt;/b&gt;(으)로 인증 이메일을 보내드렸습니다. 받은 편지함을 확인하고 지침에 따라 주세요.</string>
+    <string name="fullscreen_verify_email_subtitle">&lt;b>%1$s&lt;/b>(으)로 인증 이메일을 보내드렸습니다. 받은 편지함을 확인하고 지침에 따라 주세요.</string>
     <string name="fullscreen_review_account_button_secondary">이메일 변경</string>
     <string name="fullscreen_review_account_button_primary">확인</string>
     <string name="fullscreen_review_account_title">계정 검토</string>
-    <string name="fullscreen_review_account_subtitle">이메일 &lt;b&gt;%1$s&lt;/b&gt;을(를) 사용하여 Simplenote에 등록하셨습니다.&lt;br&gt;&lt;br&gt;더는 이 이메일 주소에 액세스하는 권한이 없는 경우 계정 보안 향상으로 인해 계정을 상실하실 수 있습니다.</string>
+    <string name="fullscreen_review_account_subtitle">이메일 &lt;b>%1$s&lt;/b>을(를) 사용하여 Simplenote에 등록하셨습니다.&lt;br>&lt;br>더는 이 이메일 주소에 액세스하는 권한이 없는 경우 계정 보안 향상으로 인해 계정을 상실하실 수 있습니다.</string>
     <string name="description_warning">경고</string>
     <string name="description_mail">메일</string>
     <string name="description_close">닫기</string>
@@ -111,7 +129,7 @@ Language: ko_KR
     <string name="empty">비었음</string>
     <string name="back">뒤로</string>
     <string name="empty_notes_untagged">태그 없는 메모 없음</string>
-    <string name="unpublishing">메모 공개 취소 중…</string>
+    <string name="unpublishing">메모 공개 취소 중...</string>
     <string name="unpublish_successful">메모 공개가 취소되었습니다.</string>
     <string name="web_view_error_button">WebView 앱으로 이동</string>
     <string name="web_view_error">마크다운을 미리 보려면 기기에 웹 보기를 설치해야 합니다.</string>
@@ -236,8 +254,8 @@ Language: ko_KR
     <string name="simperium_error_password">잘못된 비밀번호</string>
     <string name="simperium_error_email">잘못된 이메일</string>
     <string name="simperium_dialog_title_error">오류</string>
-    <string name="simperium_dialog_progress_signing_up">가입 중…</string>
-    <string name="simperium_dialog_progress_logging_in">로그인 중…</string>
+    <string name="simperium_dialog_progress_signing_up">가입 중...</string>
+    <string name="simperium_dialog_progress_logging_in">로그인 중...</string>
     <string name="simperium_dialog_message_signup_existing">입력한 이메일 주소가 이미 Simplenote 계정과 연결되어 있습니다.</string>
     <string name="simperium_dialog_message_signup">입력한 이메일 주소와 비밀번호로 가입할 수 없습니다.</string>
     <string name="simperium_dialog_message_network">지원되는 네트워크가 없습니다. 네트워크에 연결한 후 다시 시도해 주세요.</string>
@@ -334,7 +352,7 @@ Language: ko_KR
     <string name="open_drawer">보관함 열기</string>
     <string name="condensed_note_list">메모 요약 목록</string>
     <string name="rename_tag">태그 이름 변경</string>
-    <string name="new_note_list">새 메모…</string>
+    <string name="new_note_list">새 메모...</string>
     <string name="confirm_delete_tag">이 태그를 삭제하시겠습니까?</string>
     <string name="note_deleted">메모가 삭제되었습니다.</string>
     <string name="undo">실행 취소</string>
@@ -360,5 +378,5 @@ Language: ko_KR
     <string name="new_note">새 메모</string>
     <string name="share">공유</string>
     <string name="settings">설정</string>
-    <string name="tag_hint">태그 추가…</string>
+    <string name="tag_hint">태그 추가...</string>
 </resources>

--- a/Simplenote/src/main/res/values-nl/strings.xml
+++ b/Simplenote/src/main/res/values-nl/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-23 13:54:02+0000
+Translation-Revision-Date: 2024-07-31 15:54:09+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: nl
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">We hebben een code gestuurd naar \n%1$s. De code is een paar minuten geldig.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">Voer wachtwoord in</string>
+    <string name="magic_link_login_with_wordpress_or_break">Of</string>
+    <string name="magic_link_enter_code_title">Voer code in</string>
+    <string name="magic_link_code_hint">Code</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">Ongeldige code</string>
+    <string name="magic_link_complete_login_expired_code_error_message">Link is niet meer geldig</string>
+    <string name="magic_link_complete_login_loading_message">Inloggen</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">Inloggen met e-mail is mislukt. Vul je wachtwoord in.</string>
+    <string name="magic_link_error_too_many_requests_message">Te veel verzoeken. Probeer het later nog eens.</string>
+    <string name="magic_link_request_error_message">Fout bij aanvragen van magische link</string>
+    <string name="magic_link_request_login_loading_message">Inloglink wordt aangevraagd</string>
+    <string name="magic_link_general_error">We ondervinden wat problemen. Probeer het later opnieuw.</string>
+    <string name="login_with_password">Inloggen met wachtwoord</string>
+    <string name="login_screen_title">Inloggen</string>
+    <string name="magic_link_login">Inloggen met e-mail</string>
+    <string name="magic_link_request_login_dialog">Als er een account bestaat, hebben we een e-mail naar %1$s gestuurd met een link waarmee je kan inloggen.</string>
+    <string name="magic_link_request_login_dialog_title">Controleer je e-mail</string>
     <string name="sustainer_app_icon">Sustainer-app-pictogram</string>
     <string name="simperium_too_many_attempts">Te veel aanmeldpogingen. Probeer het later nog eens.</string>
     <string name="simperium_change_password">Wijzig wachtwoord</string>
@@ -23,7 +41,7 @@ Language: nl
     <string name="remove">Verwijderen</string>
     <string name="collaborators">Samenwerkers</string>
     <string name="remove_collaborator">Samenwerker verwijderen</string>
-    <string name="loading_collaborators">Laden…</string>
+    <string name="loading_collaborators">Laden...</string>
     <string name="add_email_collaborator_message">Voeg een e-mailadres toe om deze notitie met iemand te delen. Dan kunnen jullie deze beide wijzigen. Als je een samenwerker toevoegt, ontvangen ze een bericht per mail.</string>
     <string name="add_collaborator">Samenwerker toevoegen</string>
     <string name="note_shared">Notitie gedeeld</string>
@@ -40,7 +58,7 @@ Language: nl
     <string name="import_message_success">Gegevens geladen</string>
     <string name="import_error_parse">Kan bestand niet analyseren</string>
     <string name="import_error_file">Kan bestand niet lezen</string>
-    <string name="requesting_message">Aanvragen…</string>
+    <string name="requesting_message">Aanvragen...</string>
     <string name="error_ocurred_message">Er is een fout opgetreden. Probeer het opnieuw. Neem contact met ons op via %1$s%2$s%3$s%4$s%5$s voor hulp als het probleem niet is opgelost.</string>
     <string name="account_deletion_message">Er is een e-mail verzonden naar %1$s. Controleer je inbox en volg de instructies om het verwijderen van je account te bevestigen.\n\nJe account zal niet worden verwijderd totdat we je bevestiging hebben ontvangen.</string>
     <string name="request_received">Verzoek ontvangen</string>
@@ -66,11 +84,11 @@ Language: nl
     <string name="toast_email_sent">E-mail verzonden</string>
     <string name="fullscreen_verify_email_button_secondary">E-mail opnieuw verzenden</string>
     <string name="fullscreen_verify_email_title">Verifieer je e-mail</string>
-    <string name="fullscreen_verify_email_subtitle">We hebben een verificatiemail verzonden naar &lt;b&gt;%1$s&lt;/b&gt;. Controleer je postvak IN en volg de instructies.</string>
+    <string name="fullscreen_verify_email_subtitle">We hebben een verificatiemail verzonden naar &lt;b>%1$s&lt;/b>. Controleer je postvak IN en volg de instructies.</string>
     <string name="fullscreen_review_account_button_secondary">E-mail wijzigen</string>
     <string name="fullscreen_review_account_button_primary">Bevestigen</string>
     <string name="fullscreen_review_account_title">Controleer je account</string>
-    <string name="fullscreen_review_account_subtitle">Je staat geregistreerd bij Simplenote met het e-mailadres &lt;b&gt;%1$s&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Verbeteringen aan accountbeveiliging kunnen leiden tot accountverlies als je geen toegang meer hebt tot dit e-mailadres.</string>
+    <string name="fullscreen_review_account_subtitle">Je staat geregistreerd bij Simplenote met het e-mailadres &lt;b>%1$s&lt;/b>.&lt;br>&lt;br>Verbeteringen aan accountbeveiliging kunnen leiden tot accountverlies als je geen toegang meer hebt tot dit e-mailadres.</string>
     <string name="description_warning">Waarschuwing</string>
     <string name="description_mail">Mail</string>
     <string name="description_close">Sluiten</string>
@@ -237,7 +255,7 @@ Language: nl
     <string name="simperium_error_email">Ongeldig e-mailadres</string>
     <string name="simperium_dialog_title_error">Fout</string>
     <string name="simperium_dialog_progress_signing_up">Registreren …</string>
-    <string name="simperium_dialog_progress_logging_in">Inloggen …</string>
+    <string name="simperium_dialog_progress_logging_in">Inloggen ...</string>
     <string name="simperium_dialog_message_signup_existing">Het e-mailadres dat je hebt ingevoerd, is al gekoppeld aan een Simplenote-account.</string>
     <string name="simperium_dialog_message_signup">Kan niet aanmelden met het opgegeven e-mailadres en wachtwoord.</string>
     <string name="simperium_dialog_message_network">Er is geen netwerk beschikbaar. Maak verbinding met een netwerk en probeer het nogmaals.</string>

--- a/Simplenote/src/main/res/values-pt-rBR/strings.xml
+++ b/Simplenote/src/main/res/values-pt-rBR/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-22 16:54:02+0000
+Translation-Revision-Date: 2024-08-01 15:54:03+0000
 Plural-Forms: nplurals=2; plural=(n > 1);
 Generator: GlotPress/2.4.0-alpha
 Language: pt_BR
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">Enviamos um código para \n%1$s. O código será válido por alguns minutos.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">Digite a senha</string>
+    <string name="magic_link_login_with_wordpress_or_break">Ou</string>
+    <string name="magic_link_enter_code_title">Digite o código</string>
+    <string name="magic_link_code_hint">Código</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">Código inválido</string>
+    <string name="magic_link_complete_login_expired_code_error_message">O link não é mais válido</string>
+    <string name="magic_link_complete_login_loading_message">Fazendo login</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">Falha no login com o e-mail. Insira sua senha.</string>
+    <string name="magic_link_error_too_many_requests_message">Excesso de solicitações. Tente novamente mais tarde.</string>
+    <string name="magic_link_request_error_message">Erro ao solicitar o link mágico</string>
+    <string name="magic_link_request_login_loading_message">Solicitando link de login</string>
+    <string name="magic_link_general_error">Estamos com problemas. Tente novamente em alguns instantes.</string>
+    <string name="login_with_password">Login com senha</string>
+    <string name="login_screen_title">Fazer login</string>
+    <string name="magic_link_login">Login com e-mail</string>
+    <string name="magic_link_request_login_dialog">Um e-mail foi enviado para %1$s com um link de login se esse endereço está associado a uma conta.</string>
+    <string name="magic_link_request_login_dialog_title">Verifique seu e-mail</string>
     <string name="sustainer_app_icon">Ícone do aplicativo Sustainer</string>
     <string name="simperium_too_many_attempts">Muitas tentativas de login. Tente novamente mais tarde.</string>
     <string name="simperium_change_password">Alterar senha</string>
@@ -23,7 +41,7 @@ Language: pt_BR
     <string name="remove">Remover</string>
     <string name="collaborators">Colaboradores</string>
     <string name="remove_collaborator">Remover colaborador</string>
-    <string name="loading_collaborators">Carregando…</string>
+    <string name="loading_collaborators">Carregando...</string>
     <string name="add_email_collaborator_message">Adicione um endereço de e-mail para compartilhar esta anotação com alguém. Assim, ambos poderão fazer alterações. Quando você adiciona um colaborador, ele é notificado por e-mail.</string>
     <string name="add_collaborator">Adicionar colaborador</string>
     <string name="note_shared">Anotação compartilhada</string>
@@ -40,7 +58,7 @@ Language: pt_BR
     <string name="import_message_success">Dados carregados</string>
     <string name="import_error_parse">Não é possível analisar o arquivo</string>
     <string name="import_error_file">Não é possível ler o arquivo</string>
-    <string name="requesting_message">Solicitando…</string>
+    <string name="requesting_message">Solicitando...</string>
     <string name="error_ocurred_message">Ocorreu um erro. Tente novamente. Se o problema continuar, entre em contato conosco em %1$s%2$s%3$s%4$s%5$s para obter ajuda.</string>
     <string name="account_deletion_message">Um e-mail foi enviado para %1$s. Verifique sua caixa de entrada e siga as instruções para confirmar a exclusão da conta.\n\nSua conta não será excluída até recebermos sua confirmação.</string>
     <string name="request_received">Solicitação recebida</string>
@@ -66,11 +84,11 @@ Language: pt_BR
     <string name="toast_email_sent">E-mail enviado</string>
     <string name="fullscreen_verify_email_button_secondary">Reenviar e-mail</string>
     <string name="fullscreen_verify_email_title">Verificar seu e-mail</string>
-    <string name="fullscreen_verify_email_subtitle">Enviamos um e-mail de verificação para &lt;b&gt;%1$s&lt;/b&gt;. Confira sua caixa de entrada e siga as instruções.</string>
+    <string name="fullscreen_verify_email_subtitle">Enviamos um e-mail de verificação para &lt;b>%1$s&lt;/b>. Confira sua caixa de entrada e siga as instruções.</string>
     <string name="fullscreen_review_account_button_secondary">Alterar e-mail</string>
     <string name="fullscreen_review_account_button_primary">Confirmar</string>
     <string name="fullscreen_review_account_title">Revisar sua conta</string>
-    <string name="fullscreen_review_account_subtitle">Você está registrado no Simplenote com o e-mail &lt;b&gt;%1$s&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Com as melhorias de segurança, você poderá perder sua conta se não tiver mais acesso a esse endereço de e-mail.</string>
+    <string name="fullscreen_review_account_subtitle">Você está registrado no Simplenote com o e-mail &lt;b>%1$s&lt;/b>.&lt;br>&lt;br>Com as melhorias de segurança, você poderá perder sua conta se não tiver mais acesso a esse endereço de e-mail.</string>
     <string name="description_warning">Atenção</string>
     <string name="description_mail">E-mail</string>
     <string name="description_close">Fechar</string>
@@ -111,7 +129,7 @@ Language: pt_BR
     <string name="empty">Vazia</string>
     <string name="back">Voltar</string>
     <string name="empty_notes_untagged">Nenhuma nota sem tags</string>
-    <string name="unpublishing">Desfazendo publicação de anotação…</string>
+    <string name="unpublishing">Desfazendo publicação de anotação...</string>
     <string name="unpublish_successful">Anotação não publicada.</string>
     <string name="web_view_error_button">Acessar aplicativo WebView</string>
     <string name="web_view_error">Uma visualização da Web deve estar instalada no seu dispositivo para exibir um markdown.</string>
@@ -186,7 +204,7 @@ Language: pt_BR
     <string name="search">Pesquisar anotações ou tags</string>
     <string name="empty_tags_search">Nenhuma tag encontrada</string>
     <string name="empty_notes_widget">Nenhuma anotação</string>
-    <string name="loading_notes">Carregando anotações…</string>
+    <string name="loading_notes">Carregando anotações...</string>
     <string name="note_widget_light">Anotação (Clara)</string>
     <string name="note_widget_dark">Anotação (Escura)</string>
     <string name="note_list_widget_light">Lista de anotações (Clara)</string>
@@ -222,7 +240,7 @@ Language: pt_BR
     <string name="description_sort">Ordenar</string>
     <string name="description_down">Para baixo</string>
     <string name="description_delete_item">Excluir o item</string>
-    <string name="welcome_note">Boas-vindas ao Simplenote para Android!\nAbra esta anotação para ver as instruções.\n\nPara criar uma anotação, toque no botão \"Nova anotação\" com o ícone de adição.\n\nPara pesquisar suas anotações, toque no botão \"Pesquisar\" com o ícone de lupa e insira algum texto. O Simplenote mostra inicialmente pesquisas recentes e pesquisas sugeridas enquanto você digita. As anotações correspondentes ao texto inserido serão mostradas após o envio da pesquisa.\n\nRecebeu uma anotação muito importante? Fixe-a no topo da lista de anotações. Há duas maneiras de fixar as anotações: pressione e segure a anotação na lista e toque no botão \"Fixar no topo\" com o ícone de alfinete ou toque no botão \"Mais opções\" com o ícone de três pontos verticais ao visualizar uma anotação e marque a caixa \"Fixar\".\n\nUse tags para ajudar a organizar suas anotações. Crie uma tag na tela \"Editar tags\" usando o botão \"Adicionar tag\" ou no campo \"Adicionar tag…\" na parte inferior de uma anotação. Você também pode incluir um endereço de e-mail como tag para compartilhar uma anotação com alguém.\n\nÉ muito fácil compartilhar anotações com outros aplicativos Android. Basta tocar em \"Compartilhar\" no menu \"Mais opções\" ao visualizar uma anotação.\n\nAs anotações excluídas vão para a lixeira. Você pode restaurá-las, se desejar, ou esvaziar a lixeira para eliminá-las permanentemente.\n\nVocê pode acessar suas anotações na Web e em outros dispositivos. Acesse http://simplenote.com para começar.\n\nEsperamos que você goste de usar o Simplenote!</string>
+    <string name="welcome_note">Boas-vindas ao Simplenote para Android!\nAbra esta anotação para ver as instruções.\n\nPara criar uma anotação, toque no botão \"Nova anotação\" com o ícone de adição.\n\nPara pesquisar suas anotações, toque no botão \"Pesquisar\" com o ícone de lupa e insira algum texto. O Simplenote mostra inicialmente pesquisas recentes e pesquisas sugeridas enquanto você digita. As anotações correspondentes ao texto inserido serão mostradas após o envio da pesquisa.\n\nRecebeu uma anotação muito importante? Fixe-a no topo da lista de anotações. Há duas maneiras de fixar as anotações: pressione e segure a anotação na lista e toque no botão \"Fixar no topo\" com o ícone de alfinete ou toque no botão \"Mais opções\" com o ícone de três pontos verticais ao visualizar uma anotação e marque a caixa \"Fixar\".\n\nUse tags para ajudar a organizar suas anotações. Crie uma tag na tela \"Editar tags\" usando o botão \"Adicionar tag\" ou no campo \"Adicionar tag...\" na parte inferior de uma anotação. Você também pode incluir um endereço de e-mail como tag para compartilhar uma anotação com alguém.\n\nÉ muito fácil compartilhar anotações com outros aplicativos Android. Basta tocar em \"Compartilhar\" no menu \"Mais opções\" ao visualizar uma anotação.\n\nAs anotações excluídas vão para a lixeira. Você pode restaurá-las, se desejar, ou esvaziar a lixeira para eliminá-las permanentemente.\n\nVocê pode acessar suas anotações na Web e em outros dispositivos. Acesse http://simplenote.com para começar.\n\nEsperamos que você goste de usar o Simplenote!</string>
     <string name="search_hint">Pesquisar anotações ou tags</string>
     <string name="log_out">Fazer logout</string>
     <string name="log_in">Fazer login</string>
@@ -252,7 +270,7 @@ Language: pt_BR
     <string name="log_in_add_widget">Fazer login para adicionar este widget</string>
     <string name="select_note">Selecione a anotação</string>
     <string name="note_not_found">Nenhuma anotação encontrada</string>
-    <string name="loading_note">Carregando anotação…</string>
+    <string name="loading_note">Carregando anotação...</string>
     <string name="passcode_summary">As capturas de tela serão desativadas quando o bloqueio por senha estiver ativado</string>
     <string name="all_notes">Todas as anotações</string>
     <string name="appearance">Aparência</string>
@@ -285,7 +303,7 @@ Language: pt_BR
     <string name="wpcom_log_in_error_generic">Não foi possível fazer login usando o WordPress.com. Tente novamente.</string>
     <string name="collaborate_message">Adicione um email ao campo da tag para colaborar com outros usuários.</string>
     <string name="collaborate">Colaborar</string>
-    <string name="publishing">Publicando anotação…</string>
+    <string name="publishing">Publicando anotação...</string>
     <string name="unpublish">Remover link público</string>
     <string name="no_browser_available">\"Não foi possível abrir o site. Nenhum navegador disponível.\"</string>
     <string name="blog">Blog</string>
@@ -334,7 +352,7 @@ Language: pt_BR
     <string name="open_drawer">Abrir gaveta</string>
     <string name="condensed_note_list">Lista de anotações condensada</string>
     <string name="rename_tag">Renomear tag</string>
-    <string name="new_note_list">Nova anotação…</string>
+    <string name="new_note_list">Nova anotação...</string>
     <string name="confirm_delete_tag">Tem certeza que deseja excluir esta tag?</string>
     <string name="note_deleted">Anotação enviada para a lixeira.</string>
     <string name="undo">Desfazer</string>
@@ -360,5 +378,5 @@ Language: pt_BR
     <string name="new_note">Nova anotação</string>
     <string name="share">Compartilhar</string>
     <string name="settings">Configurações</string>
-    <string name="tag_hint">Adicionar tag…</string>
+    <string name="tag_hint">Adicionar tag...</string>
 </resources>

--- a/Simplenote/src/main/res/values-ru/strings.xml
+++ b/Simplenote/src/main/res/values-ru/strings.xml
@@ -1,11 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2022-11-29 08:54:03+0000
+Translation-Revision-Date: 2024-08-01 15:54:03+0000
 Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
 Generator: GlotPress/2.4.0-alpha
 Language: ru
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">Код отправлен на адрес \n%1$s. Код будет действителен в течение нескольких минут.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">Введите пароль</string>
+    <string name="magic_link_login_with_wordpress_or_break">или</string>
+    <string name="magic_link_enter_code_title">Введите код</string>
+    <string name="magic_link_code_hint">Код</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">Неверный код</string>
+    <string name="magic_link_complete_login_expired_code_error_message">Ссылка недействительна</string>
+    <string name="magic_link_complete_login_loading_message">Выполняется вход</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">Не удалось войти с адресом эл. почты. Введите пароль.</string>
+    <string name="magic_link_error_too_many_requests_message">Слишком много запросов. Повторите попытку позже.</string>
+    <string name="magic_link_request_error_message">Ошибка при запросе волшебной ссылки</string>
+    <string name="magic_link_request_login_loading_message">Выполняется запрос ссылки на вход</string>
+    <string name="magic_link_general_error">Произошла ошибка. Повторите попытку позже.</string>
+    <string name="login_with_password">Войти с помощью пароля</string>
+    <string name="login_screen_title">Вход</string>
+    <string name="magic_link_login">Войти с помощью эл. почты</string>
+    <string name="magic_link_request_login_dialog">Если учётная запись существует, то на адрес %1$s будет отправлено письмо со ссылкой, по которой вы сможете войти.</string>
+    <string name="magic_link_request_login_dialog_title">Проверьте электронную почту</string>
+    <string name="sustainer_app_icon">Значок приложения Sustainer</string>
     <string name="simperium_too_many_attempts">Вы пробовали войти слишком много раз. Повторите попытку позже.</string>
     <string name="simperium_change_password">Изменить пароль</string>
     <string name="simperium_not_now">Отмена</string>
@@ -65,11 +84,11 @@ Language: ru
     <string name="toast_email_sent">Электронное письмо отправлено</string>
     <string name="fullscreen_verify_email_button_secondary">Отправить письмо ещё раз</string>
     <string name="fullscreen_verify_email_title">Проверить адрес электронной почты</string>
-    <string name="fullscreen_verify_email_subtitle">На адрес &lt;b&gt;%1$s&lt;/b&gt; отправлено письмо с подтверждением. Проверьте свой почтовый ящик и следуйте инструкциям.</string>
+    <string name="fullscreen_verify_email_subtitle">На адрес &lt;b>%1$s&lt;/b> отправлено письмо с подтверждением. Проверьте свой почтовый ящик и следуйте инструкциям.</string>
     <string name="fullscreen_review_account_button_secondary">Изменить адрес электронной почты</string>
     <string name="fullscreen_review_account_button_primary">Подтвердить</string>
     <string name="fullscreen_review_account_title">Проверить учётную запись</string>
-    <string name="fullscreen_review_account_subtitle">Вы зарегистрированы в Simplenote с адресом электронной почты &lt;b&gt;%1$s&lt;/b&gt;.&lt;br&gt;&lt;br&gt;В результате повышения безопасности учётной записи вы можете её потерять, если лишитесь доступа к этому адресу электронной почты.</string>
+    <string name="fullscreen_review_account_subtitle">Вы зарегистрированы в Simplenote с адресом электронной почты &lt;b>%1$s&lt;/b>.&lt;br>&lt;br>В результате повышения безопасности учётной записи вы можете её потерять, если лишитесь доступа к этому адресу электронной почты.</string>
     <string name="description_warning">Предупреждение</string>
     <string name="description_mail">Почта</string>
     <string name="description_close">Закрыть</string>
@@ -110,7 +129,7 @@ Language: ru
     <string name="empty">Пусто</string>
     <string name="back">Назад</string>
     <string name="empty_notes_untagged">Нет заметок без тегов</string>
-    <string name="unpublishing">Отмена публикации заметки…</string>
+    <string name="unpublishing">Отмена публикации заметки...</string>
     <string name="unpublish_successful">Публикация заметки отменена.</string>
     <string name="web_view_error_button">Перейти в приложение WebView</string>
     <string name="web_view_error">Для просмотра разметки необходимо установить WebView на вашем устройстве.</string>
@@ -235,7 +254,7 @@ Language: ru
     <string name="simperium_error_password">Неверный пароль</string>
     <string name="simperium_error_email">Неверный адрес электронной почты</string>
     <string name="simperium_dialog_title_error">Ошибка</string>
-    <string name="simperium_dialog_progress_signing_up">Регистрация…</string>
+    <string name="simperium_dialog_progress_signing_up">Регистрация...</string>
     <string name="simperium_dialog_progress_logging_in">Вход…</string>
     <string name="simperium_dialog_message_signup_existing">Введённый адрес эл. почты уже связан с учетной записью Simplenote.</string>
     <string name="simperium_dialog_message_signup">Не удалось зарегистрировать с указанным адресом эл. почты и паролем.</string>
@@ -284,7 +303,7 @@ Language: ru
     <string name="wpcom_log_in_error_generic">Не удалось войти в систему WordPress.com. Повторите попытку.</string>
     <string name="collaborate_message">Для совместной работы с другими пользователями укажите адрес электронной почты в поле меток.</string>
     <string name="collaborate">Совместная работа</string>
-    <string name="publishing">Публикация заметки…</string>
+    <string name="publishing">Публикация заметки...</string>
     <string name="unpublish">Удалить общедоступную ссылку</string>
     <string name="no_browser_available">\"Не удалось открыть веб-сайт. Браузер недоступен\".</string>
     <string name="blog">Блог</string>
@@ -333,7 +352,7 @@ Language: ru
     <string name="open_drawer">Открыть боковую панель</string>
     <string name="condensed_note_list">Компактный вид</string>
     <string name="rename_tag">Переименовать метку</string>
-    <string name="new_note_list">Новая заметка…</string>
+    <string name="new_note_list">Новая заметка...</string>
     <string name="confirm_delete_tag">Вы действительно хотите удалить эту метку?</string>
     <string name="note_deleted">Заметка перемещена в корзину.</string>
     <string name="undo">Отменить</string>
@@ -359,5 +378,5 @@ Language: ru
     <string name="new_note">Новая заметка</string>
     <string name="share">Поделиться</string>
     <string name="settings">Настройки</string>
-    <string name="tag_hint">Добавить метку…</string>
+    <string name="tag_hint">Добавить метку...</string>
 </resources>

--- a/Simplenote/src/main/res/values-sv/strings.xml
+++ b/Simplenote/src/main/res/values-sv/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-23 13:54:03+0000
+Translation-Revision-Date: 2024-07-31 17:17:02+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: sv_SE
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">Vi har skickat en kod till \n%1$s. Koden kommer vara giltig i några minuter.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">Ange lösenord</string>
+    <string name="magic_link_login_with_wordpress_or_break">Eller</string>
+    <string name="magic_link_enter_code_title">Ange kod</string>
+    <string name="magic_link_code_hint">Kod</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">Ogiltig kod</string>
+    <string name="magic_link_complete_login_expired_code_error_message">Länk är inte längre giltig</string>
+    <string name="magic_link_complete_login_loading_message">Loggar in</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">Inloggning med e-post misslyckades, ange ditt lösenord.</string>
+    <string name="magic_link_error_too_many_requests_message">För många förfrågningar. Försök igen senare.</string>
+    <string name="magic_link_request_error_message">Fel vid begäran om magisk länk</string>
+    <string name="magic_link_request_login_loading_message">Begär inloggningslänk</string>
+    <string name="magic_link_general_error">Vi har problem. Försök igen om en stund.</string>
+    <string name="login_with_password">Logga in med lösenord</string>
+    <string name="login_screen_title">Logga in</string>
+    <string name="magic_link_login">Logga in med e-post</string>
+    <string name="magic_link_request_login_dialog">Om det finns ett konto har vi skickat ett e-postmeddelande till %1$s med en länk som loggar in dig.</string>
+    <string name="magic_link_request_login_dialog_title">Kolla din e-post</string>
     <string name="sustainer_app_icon">Sustainer-appikon</string>
     <string name="simperium_too_many_attempts">För många inloggningsförsök. Försök igen senare.</string>
     <string name="simperium_change_password">Ändra lösenord</string>
@@ -40,7 +58,7 @@ Language: sv_SE
     <string name="import_message_success">Data laddat</string>
     <string name="import_error_parse">Kan inte analysera fil</string>
     <string name="import_error_file">Kan inte läsa fil</string>
-    <string name="requesting_message">Begär…</string>
+    <string name="requesting_message">Begär...</string>
     <string name="error_ocurred_message">Ett okänt fel uppstod. Försök igen. Om problemet fortsätter, kontakta oss på %1$s%2$s%3$s%4$s%5$s för hjälp.</string>
     <string name="account_deletion_message">Ett e-postmeddelande har skickats till %1$s. Kolla din inkorg och följ instruktionerna för att bekräfta kontoborttagningen.\n\nDitt konto kommer inte att tas bort förrän vi har mottagit din bekräftelse.</string>
     <string name="request_received">Begäran mottagen</string>
@@ -66,11 +84,11 @@ Language: sv_SE
     <string name="toast_email_sent">E-post skickad</string>
     <string name="fullscreen_verify_email_button_secondary">Skicka e-post igen</string>
     <string name="fullscreen_verify_email_title">Verifiera din e-post</string>
-    <string name="fullscreen_verify_email_subtitle">Vi har skickat en e-postverifiering till &lt;b&gt;%1$s&lt;/b&gt;.  Kontrollera din inkorg och följ instruktionerna.</string>
+    <string name="fullscreen_verify_email_subtitle">Vi har skickat en e-postverifiering till &lt;b>%1$s&lt;/b>.  Kontrollera din inkorg och följ instruktionerna.</string>
     <string name="fullscreen_review_account_button_secondary">Ändra e-post</string>
     <string name="fullscreen_review_account_button_primary">Bekräfta</string>
     <string name="fullscreen_review_account_title">Granska ditt konto</string>
-    <string name="fullscreen_review_account_subtitle">Du är registrerad hos Simplenote med e-postadressen &lt;b&gt;%1$s&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Förbättringar av kontosäkerhet kan leda till kontoförlust om du inte längre har tillgång till den här e-postadressen.</string>
+    <string name="fullscreen_review_account_subtitle">Du är registrerad hos Simplenote med e-postadressen &lt;b>%1$s&lt;/b>.&lt;br>&lt;br>Förbättringar av kontosäkerhet kan leda till kontoförlust om du inte längre har tillgång till den här e-postadressen.</string>
     <string name="description_warning">Varning</string>
     <string name="description_mail">E-post</string>
     <string name="description_close">Stäng</string>
@@ -236,8 +254,8 @@ Language: sv_SE
     <string name="simperium_error_password">Ogiltigt lösenord</string>
     <string name="simperium_error_email">Ogiltig e-post</string>
     <string name="simperium_dialog_title_error">Fel</string>
-    <string name="simperium_dialog_progress_signing_up">Skapar konto…</string>
-    <string name="simperium_dialog_progress_logging_in">Loggar in…</string>
+    <string name="simperium_dialog_progress_signing_up">Skapar konto...</string>
+    <string name="simperium_dialog_progress_logging_in">Loggar in...</string>
     <string name="simperium_dialog_message_signup_existing">Den angivna e-postadressen är redan associerad med ett Simplenote-konto.</string>
     <string name="simperium_dialog_message_signup">Det gick inte att skapa kontot med den angivna e-postadressen eller lösenordet.</string>
     <string name="simperium_dialog_message_network">Det finns inget tillgängligt nätverk. Anslut till ett nätverk och försök igen.</string>
@@ -334,7 +352,7 @@ Language: sv_SE
     <string name="open_drawer">Öppna låda</string>
     <string name="condensed_note_list">Enkel lista</string>
     <string name="rename_tag">Döp om etikett</string>
-    <string name="new_note_list">Ny anteckning…</string>
+    <string name="new_note_list">Ny anteckning...</string>
     <string name="confirm_delete_tag">Är du säker på att du vill ta bort etiketten?</string>
     <string name="note_deleted">Anteckning borttagen.</string>
     <string name="undo">Ångra</string>
@@ -360,5 +378,5 @@ Language: sv_SE
     <string name="new_note">Ny anteckning</string>
     <string name="share">Dela</string>
     <string name="settings">Inställningar</string>
-    <string name="tag_hint">Lägg till etikett…</string>
+    <string name="tag_hint">Lägg till etikett...</string>
 </resources>

--- a/Simplenote/src/main/res/values-tr/strings.xml
+++ b/Simplenote/src/main/res/values-tr/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-22 12:54:02+0000
+Translation-Revision-Date: 2024-08-01 15:54:03+0000
 Plural-Forms: nplurals=2; plural=(n > 1);
 Generator: GlotPress/2.4.0-alpha
 Language: tr
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">Şuraya bir kod gönderildi: \n%1$s. Kod birkaç dakikalığına geçerli olacak.</string>
+    <string name="magic_link_confirm_code_enter_pass_label">Şifre girin</string>
+    <string name="magic_link_login_with_wordpress_or_break">Veya</string>
+    <string name="magic_link_enter_code_title">Kod Girin</string>
+    <string name="magic_link_code_hint">Kod</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">Geçersiz kod</string>
+    <string name="magic_link_complete_login_expired_code_error_message">Bağlantı artık geçerli değil</string>
+    <string name="magic_link_complete_login_loading_message">Oturum Açılıyor</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">E-postayla oturum açma başarısız oldu, lütfen şifrenizi girin.</string>
+    <string name="magic_link_error_too_many_requests_message">Çok fazla istek var. Daha sonra yeniden deneyin.</string>
+    <string name="magic_link_request_error_message">Sihirli Bağlantı istenirken hata oluştu</string>
+    <string name="magic_link_request_login_loading_message">Oturum açma bağlantısı isteniyor</string>
+    <string name="magic_link_general_error">Sorun yaşanıyor. Lütfen kısa bir süre sonra tekrar deneyin.</string>
+    <string name="login_with_password">Şifreyle Oturum Aç</string>
+    <string name="login_screen_title">Oturum Aç</string>
+    <string name="magic_link_login">E-postayla oturum aç</string>
+    <string name="magic_link_request_login_dialog">Bir hesap varsa oturumunuzu açacak bir bağlantı içeren %1$s adresine bir e-posta gönderildi.</string>
+    <string name="magic_link_request_login_dialog_title">E-postanızı kontrol edin</string>
     <string name="sustainer_app_icon">Sustainer uygulaması simgesi</string>
     <string name="simperium_too_many_attempts">Çok fazla oturum açma denemesi. Daha sonra yeniden deneyin.</string>
     <string name="simperium_change_password">Parola değiştir</string>
@@ -23,7 +41,7 @@ Language: tr
     <string name="remove">Kaldır</string>
     <string name="collaborators">Çalışma Arkadaşları</string>
     <string name="remove_collaborator">Çalışma Arkadaşını Kaldır</string>
-    <string name="loading_collaborators">Yükleniyor…</string>
+    <string name="loading_collaborators">Yükleniyor...</string>
     <string name="add_email_collaborator_message">Bu notu birisiyle paylaşmak için bir e-posta adresi ekleyin, ardından ikiniz de not üzerinde değişiklik yapabilirsiniz. Bir çalışma arkadaşı eklediğinizde, kendisi e-posta ile bilgilendirilecektir.</string>
     <string name="add_collaborator">Çalışma Arkadaşı Ekle </string>
     <string name="note_shared">Not Paylaşıldı</string>
@@ -66,11 +84,11 @@ Language: tr
     <string name="toast_email_sent">E-posta gönderildi</string>
     <string name="fullscreen_verify_email_button_secondary">E-postayı tekrar gönder</string>
     <string name="fullscreen_verify_email_title">E-posta Adresinizi Doğrulayın</string>
-    <string name="fullscreen_verify_email_subtitle">&lt;b&gt;%1$s&lt;/b&gt; adresine bir doğrulama e-postası gönderdik. Lütfen gelen kutunuzu kontrol edip talimatları izleyin.</string>
+    <string name="fullscreen_verify_email_subtitle">&lt;b>%1$s&lt;/b> adresine bir doğrulama e-postası gönderdik. Lütfen gelen kutunuzu kontrol edip talimatları izleyin.</string>
     <string name="fullscreen_review_account_button_secondary">E-posta değiştir</string>
     <string name="fullscreen_review_account_button_primary">Onayla</string>
     <string name="fullscreen_review_account_title">Hesabınızı İnceleyin</string>
-    <string name="fullscreen_review_account_subtitle">&lt;b&gt;%1$s&lt;/b&gt; e-postasını kullanarak Simplenote\'a kayıt oldunuz.&lt;br&gt;&lt;br&gt;Bu e-posta adresine artık erişiminiz yoksa, hesap güvenliğindeki iyileştirmeler hesap kaybına neden olabilir.</string>
+    <string name="fullscreen_review_account_subtitle">&lt;b>%1$s&lt;/b> e-postasını kullanarak Simplenote\'a kayıt oldunuz.&lt;br>&lt;br>Bu e-posta adresine artık erişiminiz yoksa, hesap güvenliğindeki iyileştirmeler hesap kaybına neden olabilir.</string>
     <string name="description_warning">Uyarı</string>
     <string name="description_mail">Posta</string>
     <string name="description_close">Kapat</string>
@@ -111,7 +129,7 @@ Language: tr
     <string name="empty">Boş</string>
     <string name="back">Geri</string>
     <string name="empty_notes_untagged">Etiketsiz not yok</string>
-    <string name="unpublishing">Not yayından kaldırılıyor…</string>
+    <string name="unpublishing">Not yayından kaldırılıyor...</string>
     <string name="unpublish_successful">Not yayından kaldırıldı.</string>
     <string name="web_view_error_button">WebView uygulamasına git</string>
     <string name="web_view_error">Markdown’ı önizlemek için cihazınızda bir web görünümü kurulu olmalıdır.</string>
@@ -285,7 +303,7 @@ Language: tr
     <string name="wpcom_log_in_error_generic">WordPress.com ile giriş yapılamadı. Lütfen yeniden deneyin.</string>
     <string name="collaborate_message">Diğer kullanıcılarla iş birliği yapmak için etiket alanına bir e-posta girin.</string>
     <string name="collaborate">İşbirliği Yap</string>
-    <string name="publishing">Not yayınlanıyor…</string>
+    <string name="publishing">Not yayınlanıyor...</string>
     <string name="unpublish">Herkese açık bağlantıyı kaldır</string>
     <string name="no_browser_available">\"Web sitesi açılamıyor. Kullanılabilir tarayıcı yok.\"</string>
     <string name="blog">Blog</string>

--- a/Simplenote/src/main/res/values-zh-rCN/strings.xml
+++ b/Simplenote/src/main/res/values-zh-rCN/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-23 09:54:03+0000
+Translation-Revision-Date: 2024-08-01 11:54:03+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/2.4.0-alpha
 Language: zh_CN
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">我们已向 \n 发送代码%1$s。 此代码将在几分钟后失效。</string>
+    <string name="magic_link_confirm_code_enter_pass_label">输入密码</string>
+    <string name="magic_link_login_with_wordpress_or_break">或</string>
+    <string name="magic_link_enter_code_title">输入代码</string>
+    <string name="magic_link_code_hint">代码</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">代码无效</string>
+    <string name="magic_link_complete_login_expired_code_error_message">链接已失效</string>
+    <string name="magic_link_complete_login_loading_message">正在登录</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">使用电子邮件登录失败，请输入您的密码。</string>
+    <string name="magic_link_error_too_many_requests_message">请求过多。 请稍后重试。</string>
+    <string name="magic_link_request_error_message">请求免密链接时出错</string>
+    <string name="magic_link_request_login_loading_message">正在请求登录链接</string>
+    <string name="magic_link_general_error">我们遇到了问题。 请稍后重试。</string>
+    <string name="login_with_password">使用密码登录</string>
+    <string name="login_screen_title">登录</string>
+    <string name="magic_link_login">使用电子邮件登录</string>
+    <string name="magic_link_request_login_dialog">如果您已有账户，我们会向 %1$s 发送一封电子邮件，其中包含一个登录链接。</string>
+    <string name="magic_link_request_login_dialog_title">检查您的电子邮件</string>
     <string name="sustainer_app_icon">Sustainer 应用程序图标</string>
     <string name="simperium_too_many_attempts">尝试登录次数过多。 请稍后重试。</string>
     <string name="simperium_change_password">修改密码</string>
@@ -66,11 +84,11 @@ Language: zh_CN
     <string name="toast_email_sent">电子邮件已发送</string>
     <string name="fullscreen_verify_email_button_secondary">重发电子邮件</string>
     <string name="fullscreen_verify_email_title">验证您的电子邮件</string>
-    <string name="fullscreen_verify_email_subtitle">我们已向 &lt;b&gt;%1$s&lt;/b&gt; 发送了一封验证电子邮件。 请检查您的收件箱并按照说明执行操作。</string>
+    <string name="fullscreen_verify_email_subtitle">我们已向 &lt;b>%1$s&lt;/b> 发送了一封验证电子邮件。 请检查您的收件箱并按照说明执行操作。</string>
     <string name="fullscreen_review_account_button_secondary">更改电子邮件地址</string>
     <string name="fullscreen_review_account_button_primary">确认</string>
     <string name="fullscreen_review_account_title">检查您的帐户</string>
-    <string name="fullscreen_review_account_subtitle">您已使用电子邮件 &lt;b&gt;%1$s&lt;/b&gt; 注册 Simplenote。&lt;br&gt;&lt;br&gt;如果您无法再访问此电子邮件地址，那么帐户安全性的改进可能会导致您无法找回帐户。</string>
+    <string name="fullscreen_review_account_subtitle">您已使用电子邮件 &lt;b>%1$s&lt;/b> 注册 Simplenote。&lt;br>&lt;br>如果您无法再访问此电子邮件地址，那么帐户安全性的改进可能会导致您无法找回帐户。</string>
     <string name="description_warning">警告</string>
     <string name="description_mail">邮件</string>
     <string name="description_close">关闭</string>
@@ -111,7 +129,7 @@ Language: zh_CN
     <string name="empty">空</string>
     <string name="back">返回</string>
     <string name="empty_notes_untagged">没有未标记的笔记</string>
-    <string name="unpublishing">正在取消发布笔记…</string>
+    <string name="unpublishing">正在取消发布笔记...</string>
     <string name="unpublish_successful">已取消发布笔记。</string>
     <string name="web_view_error_button">转到 WebView 应用</string>
     <string name="web_view_error">必须在设备上安装 Web 视图才能预览 markdown。</string>
@@ -285,7 +303,7 @@ Language: zh_CN
     <string name="wpcom_log_in_error_generic">无法登录 WordPress.com。请重试。</string>
     <string name="collaborate_message">在标签中添加邮箱地址即可与其他用户协作。</string>
     <string name="collaborate">协作</string>
-    <string name="publishing">正在发布笔记…</string>
+    <string name="publishing">正在发布笔记...</string>
     <string name="unpublish">删除公开链接</string>
     <string name="no_browser_available">“无法打开网站。没有可用的浏览器。”</string>
     <string name="blog">博客</string>

--- a/Simplenote/src/main/res/values-zh-rTW/strings.xml
+++ b/Simplenote/src/main/res/values-zh-rTW/strings.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Translation-Revision-Date: 2024-04-23 09:54:03+0000
+Translation-Revision-Date: 2024-08-01 15:54:03+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/2.4.0-alpha
 Language: zh_TW
 -->
 <resources>
+    <string name="magic_link_confirm_code_message">我們已傳送驗證碼到 \n%1$s。 此驗證碼在幾分鐘內有效。</string>
+    <string name="magic_link_confirm_code_enter_pass_label">輸入密碼</string>
+    <string name="magic_link_login_with_wordpress_or_break">或</string>
+    <string name="magic_link_enter_code_title">輸入驗證碼</string>
+    <string name="magic_link_code_hint">驗證碼</string>
+    <string name="magic_link_complete_login_invalid_code_error_message">無效的驗證碼</string>
+    <string name="magic_link_complete_login_expired_code_error_message">連結失效</string>
+    <string name="magic_link_complete_login_loading_message">正在登入</string>
+    <string name="magic_link_error_too_many_requests_enter_password_message">透過電子郵件登入失敗，請輸入你的密碼。</string>
+    <string name="magic_link_error_too_many_requests_message">你已提出太多要求。 請稍後再試一次。</string>
+    <string name="magic_link_request_error_message">要求神奇連結時出現錯誤</string>
+    <string name="magic_link_request_login_loading_message">正在要求登入連結</string>
+    <string name="magic_link_general_error">發生問題， 請接著再試一次。</string>
+    <string name="login_with_password">使用密碼登入</string>
+    <string name="login_screen_title">登入</string>
+    <string name="magic_link_login">透過電子郵件登入</string>
+    <string name="magic_link_request_login_dialog">若帳號存在，我們已將登入連結透過電子郵件傳送至「%1$s」。</string>
+    <string name="magic_link_request_login_dialog_title">請檢查電子郵件信箱</string>
     <string name="sustainer_app_icon">Sustainer 應用程式圖示</string>
     <string name="simperium_too_many_attempts">登入嘗試次數過多。 請稍後再試一次。</string>
     <string name="simperium_change_password">變更密碼</string>
@@ -23,7 +41,7 @@ Language: zh_TW
     <string name="remove">移除</string>
     <string name="collaborators">協作者</string>
     <string name="remove_collaborator">移除共同作業者</string>
-    <string name="loading_collaborators">載入中…</string>
+    <string name="loading_collaborators">載入中...</string>
     <string name="add_email_collaborator_message">新增電子郵件地址，將此筆記與他人共用。這樣雙方都能變更筆記內容。 新增共同作業者時，他們將收到電子郵件通知。</string>
     <string name="add_collaborator">新增共同作業者</string>
     <string name="note_shared">共用筆記</string>
@@ -66,11 +84,11 @@ Language: zh_TW
     <string name="toast_email_sent">電子郵件已傳送</string>
     <string name="fullscreen_verify_email_button_secondary">重新傳送電子郵件</string>
     <string name="fullscreen_verify_email_title">驗證你的電子郵件</string>
-    <string name="fullscreen_verify_email_subtitle">我們已傳送一封驗證電子郵件到 &lt;b&gt;%1$s&lt;/b&gt;。 請檢查你的收件匣並依照指示操作。</string>
+    <string name="fullscreen_verify_email_subtitle">我們已傳送一封驗證電子郵件到 &lt;b>%1$s&lt;/b>。 請檢查你的收件匣並依照指示操作。</string>
     <string name="fullscreen_review_account_button_secondary">變更電子郵件</string>
     <string name="fullscreen_review_account_button_primary">確認</string>
     <string name="fullscreen_review_account_title">檢閱你的帳號</string>
-    <string name="fullscreen_review_account_subtitle">你已使用電子郵件地址 &lt;b&gt;%1$s&lt;/b&gt; 註冊 Simplenote。&lt;br&gt;&lt;br&gt;如果你不再擁有存取此電子郵件地址的權限，對帳號安全性的改善項目可能導致帳號遺失。</string>
+    <string name="fullscreen_review_account_subtitle">你已使用電子郵件地址 &lt;b>%1$s&lt;/b> 註冊 Simplenote。&lt;br>&lt;br>如果你不再擁有存取此電子郵件地址的權限，對帳號安全性的改善項目可能導致帳號遺失。</string>
     <string name="description_warning">警告</string>
     <string name="description_mail">郵件</string>
     <string name="description_close">關閉</string>


### PR DESCRIPTION
### Fix

This PR updates the following language translations.

- [ ] Arabic
- [ ] Chinese (China)
- [ ] Chinese (Taiwan)
- [ ] Dutch
- [ ] French (France)
- [ ] Greman
- [ ] Hebrew
- [ ] Indonesian
- [ ] Italian
- [ ] Japanese
- [ ] Korean
- [ ] Portugese (Brazil)
- [ ] Russian
- [ ] Spanish (Spain)
- [ ] Swedish
- [ ] Turkish

### Test

- [ ] Build the app in english and ensure the magic link flow works and language is fine,
- [ ] Build the app and change the language to one of the updated locales. Ensure magic links is showing the non english messages.

### Review

Please note I copy over the xml directly from glotpress. Some unrelated strings changed. From what I can tell it from periods. I think it should be fine. But let me know if there are concerns.

### Release
N/A
