### PR TITLE
[Lib] Update simperium-android to fix ssl cert bug.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 2.33
 -----
 * Added support for logging in with magic links for a passwordless experience.
+* Fix bug where devices with Android 6 and 7 were unable to login.
 
 2.32
 -----

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
-    implementation 'com.automattic:simperium:250-6690beb1dd6a31d06426dd56b19a3f41359d1ee5'
+    implementation 'com.automattic:simperium:v1.3.1'
     implementation('com.github.Automattic:Automattic-Tracks-Android:2.1.0') {
         // Tracks lib is referring to an unavailable build of okhttp
         exclude group: 'com.squareup.okhttp3'

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     // Fastlane screengrab for screenshots automation
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
-    implementation 'com.automattic:simperium:v1.3.0'
+    implementation 'com.automattic:simperium:250-6690beb1dd6a31d06426dd56b19a3f41359d1ee5'
     implementation('com.github.Automattic:Automattic-Tracks-Android:2.1.0') {
         // Tracks lib is referring to an unavailable build of okhttp
         exclude group: 'com.squareup.okhttp3'


### PR DESCRIPTION
### Fix

This PR updates simperium to fix an Android 6 & 7 ssl certificate bug.

### Test

**Android 6**

 - [ ] Ensure you can log in with an Android 6 device/emulator
 - [ ] Ensure your notes sync when editing notes.
 - [ ] Ensure when editing your notes on a different devices the Android 6 device is getting those updates.

**Android 7**

 - [ ] Ensure you can log in with an Android 7 device/emulator
 - [ ] Ensure your notes sync when editing notes.
 - [ ] Ensure when editing your notes on a different devices the Android 7 device is getting those updates.

### Release

TBD.