### PR TITLE
[Tooling] Run Danger on Buildkite Linter Agent

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,6 +24,16 @@ steps:
     command: ./gradlew --stacktrace testRelease
     plugins: *common_plugins
 
+  - label: "☢️ Danger - PR Check"
+    command: danger
+    key: danger
+    if: "build.pull_request.id != null"
+    retry:
+      manual:
+        permit_on_passed: true
+    agents:
+      queue: "linter"
+
   - label: "🔬 Lint"
     command: ./gradlew --stacktrace lintRelease
     plugins: *common_plugins

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -1,13 +1,17 @@
-name: ☢️ Danger
+name: ☢️ Trigger Danger On Buildkite
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize, edited, labeled, unlabeled, milestoned, demilestoned]
+    types: [labeled, unlabeled, milestoned, demilestoned, ready_for_review]
 
 jobs:
   dangermattic:
-    # runs on draft PRs only for opened / synchronize events
-    if: ${{ (github.event.pull_request.draft == false) || (github.event.pull_request.draft == true && contains(fromJSON('["opened", "synchronize"]'), github.event.action)) }}
-    uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@v1.0.0
+    if: ${{ (github.event.pull_request.draft == false) }}
+    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1.1.2
+    with:
+      org-slug: "automattic"
+      pipeline-slug: "simplenote-android"
+      retry-step-key: "danger"
+      build-commit-sha: "${{ github.event.pull_request.head.sha }}"
     secrets:
-      github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}
+      buildkite-api-token: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
     options (2.3.2)
     optparse (0.5.0)
     os (1.1.4)
-    parallel (1.26.2)
+    parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
@@ -274,7 +274,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.3.5)
+    rexml (3.3.6)
       strscan
     rouge (2.0.7)
     rubocop (1.65.1)
@@ -288,7 +288,7 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.0)
+    rubocop-ast (1.32.1)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)


### PR DESCRIPTION
Setting up Danger to run on Buildkite in the Linter queue, using GHA only to trigger the run on Buildkite on PR events such as on label / milestone updates.