### PR TITLE
Update release notes source with placeholder copy for 2.34

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,2 +1,1 @@
-
-
+Under the hood improvements


### PR DESCRIPTION
There were no release notes in `RELEASE-NOTES.txt` for 2.34. I added a placeholder text and I think we can live with that.

I'll admin-merge this to move on with the code freeze process.