### PR TITLE
Add message to allow user to login manually in the enter email screen.

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
@@ -2,14 +2,17 @@ package com.automattic.simplenote.authentication
 
 import android.app.Activity
 import android.content.Intent
+import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
+import android.text.method.LinkMovementMethod
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.EditText
+import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
@@ -101,6 +104,17 @@ class SignInFragment: MagicLinkableFragment() {
                 "wpcc_button_press_signin_activity"
             )
         }
+        val manualLoginTextView = view.findViewById<TextView>(R.id.sign_in_login_manually)
+        val message = getString(R.string.signin_login_with_email_manually);
+        val span = StrUtils.generateClickableSpannableString(LOGIN_MANUALLY_SUBSTRING, message
+        ) {
+            val email = getEmailEditText()
+            showLoginWithPassword(activity, email?.text?.toString())
+        }
+
+        manualLoginTextView.text = span
+        manualLoginTextView.movementMethod = LinkMovementMethod.getInstance()
+        manualLoginTextView.highlightColor = Color.TRANSPARENT
         return view
     }
 
@@ -154,6 +168,8 @@ class SignInFragment: MagicLinkableFragment() {
     }
 
     companion object {
+        const val LOGIN_MANUALLY_SUBSTRING = "log in manually"
+        
         fun showLoginWithPassword(activity: Activity?, username: String?) {
             activity?.let { act ->
                 val intent = Intent(act, NewCredentialsActivity::class.java)

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
+import android.text.Html
 import android.text.method.LinkMovementMethod
 import android.util.Log
 import android.view.LayoutInflater
@@ -15,6 +16,7 @@ import android.widget.EditText
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import com.automattic.simplenote.R
 import com.automattic.simplenote.Simplenote
@@ -105,16 +107,19 @@ class SignInFragment: MagicLinkableFragment() {
             )
         }
         val manualLoginTextView = view.findViewById<TextView>(R.id.sign_in_login_manually)
-        val message = getString(R.string.signin_login_with_email_manually);
-        val span = StrUtils.generateClickableSpannableString(LOGIN_MANUALLY_SUBSTRING, message
-        ) {
+        context?.let {
+            val colorLink = Integer.toHexString(ContextCompat.getColor(it, R.color.text_link) and 16777215)
+            manualLoginTextView.text = Html.fromHtml(
+                String.format(
+                    getString(R.string.signin_login_with_email_manually),
+                    "<span style=\"color:#", colorLink, "\">", "</span>"
+                )
+            )
+        }
+        manualLoginTextView.setOnClickListener {
             val email = getEmailEditText()
             showLoginWithPassword(activity, email?.text?.toString())
         }
-
-        manualLoginTextView.text = span
-        manualLoginTextView.movementMethod = LinkMovementMethod.getInstance()
-        manualLoginTextView.highlightColor = Color.TRANSPARENT
         return view
     }
 
@@ -169,7 +174,7 @@ class SignInFragment: MagicLinkableFragment() {
 
     companion object {
         const val LOGIN_MANUALLY_SUBSTRING = "log in manually"
-        
+
         fun showLoginWithPassword(activity: Activity?, username: String?) {
             activity?.let { act ->
                 val intent = Intent(act, NewCredentialsActivity::class.java)

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/StrUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/StrUtils.java
@@ -7,8 +7,14 @@ package com.automattic.simplenote.utils;
 
 import static androidx.core.util.PatternsCompat.EMAIL_ADDRESS;
 
+import android.text.SpannableString;
 import android.text.Spanned;
+import android.text.TextPaint;
 import android.text.TextUtils;
+import android.text.style.ClickableSpan;
+import android.view.View;
+
+import androidx.annotation.NonNull;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -133,5 +139,27 @@ public class StrUtils {
         }
 
         return HtmlCompat.fromHtml("<strong>" + originalString.toUpperCase() + "</strong>");
+    }
+
+    public static SpannableString generateClickableSpannableString(final String targetString, final String text, final View.OnClickListener onClickListener) {
+        final SpannableString spannableString = new SpannableString(text);
+        final int startIndex = text.indexOf(targetString);
+        if (startIndex == -1) {
+            return spannableString;
+        }
+        final int endIndex = startIndex + targetString.length();
+        spannableString.setSpan(new ClickableSpan() {
+            @Override
+            public void onClick(@NonNull View widget) {
+                onClickListener.onClick(widget);
+            }
+
+            @Override
+            public void updateDrawState(@NonNull TextPaint ds) {
+                super.updateDrawState(ds);
+                ds.setUnderlineText(false);
+            }
+        }, startIndex, endIndex, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        return spannableString;
     }
 }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/StrUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/StrUtils.java
@@ -7,14 +7,8 @@ package com.automattic.simplenote.utils;
 
 import static androidx.core.util.PatternsCompat.EMAIL_ADDRESS;
 
-import android.text.SpannableString;
 import android.text.Spanned;
-import android.text.TextPaint;
 import android.text.TextUtils;
-import android.text.style.ClickableSpan;
-import android.view.View;
-
-import androidx.annotation.NonNull;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -139,27 +133,5 @@ public class StrUtils {
         }
 
         return HtmlCompat.fromHtml("<strong>" + originalString.toUpperCase() + "</strong>");
-    }
-
-    public static SpannableString generateClickableSpannableString(final String targetString, final String text, final View.OnClickListener onClickListener) {
-        final SpannableString spannableString = new SpannableString(text);
-        final int startIndex = text.indexOf(targetString);
-        if (startIndex == -1) {
-            return spannableString;
-        }
-        final int endIndex = startIndex + targetString.length();
-        spannableString.setSpan(new ClickableSpan() {
-            @Override
-            public void onClick(@NonNull View widget) {
-                onClickListener.onClick(widget);
-            }
-
-            @Override
-            public void updateDrawState(@NonNull TextPaint ds) {
-                super.updateDrawState(ds);
-                ds.setUnderlineText(false);
-            }
-        }, startIndex, endIndex, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-        return spannableString;
     }
 }

--- a/Simplenote/src/main/res/layout/fragment_login.xml
+++ b/Simplenote/src/main/res/layout/fragment_login.xml
@@ -45,7 +45,22 @@
         android:textAllCaps="true"
         android:textColor="@android:color/white" />
 
-    <include layout="@layout/authentication_fancy_or" />
+    <TextView
+        android:id="@+id/sign_in_login_manually"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:text="@string/signin_login_with_email_manually"
+        android:layout_below="@id/button"
+        android:textSize="15sp"
+        android:gravity="center_horizontal"
+        android:layout_marginVertical="10dp"/>
+
+    <include layout="@layout/authentication_fancy_or"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/sign_in_login_manually"
+        android:layout_marginVertical="10dp"
+        />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/button_login_with_wordpress"

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -451,4 +451,6 @@
     <string name="magic_link_confirm_code_enter_pass_label">Enter password</string>
     <string name="magic_link_confirm_code_message">We\'ve sent a code to \n%1$s. The code will be valid for a few minutes.</string>
     <string name="login_with_password_message">Enter the password for the account %1$s</string>
+
+    <string name="signin_login_with_email_manually">We\'ll email you a code to log in, or you can log in manually.</string>
 </resources>

--- a/Simplenote/src/main/res/values/strings.xml
+++ b/Simplenote/src/main/res/values/strings.xml
@@ -452,5 +452,5 @@
     <string name="magic_link_confirm_code_message">We\'ve sent a code to \n%1$s. The code will be valid for a few minutes.</string>
     <string name="login_with_password_message">Enter the password for the account %1$s</string>
 
-    <string name="signin_login_with_email_manually">We\'ll email you a code to log in, or you can log in manually.</string>
+    <string name="signin_login_with_email_manually">We\'ll email you a code to log in, or you can %1$s%2$s%3$slog in manually%4$s.</string>
 </resources>


### PR DESCRIPTION
### Fix #1689 

This PR adds a new label on the screen to enter your email for a magic link. That lable will have a link to login manually, meaning with password instead.

### Test

- [ ] On app launch click login.
- [ ] Under the "Log In With Email" button, there is a new label, "We'll email you a code to log in, or you can log in manually".
- [ ] The "log in manually" is hyperlinked.
- [ ] Clicking the hyperlink should take you to login with password screen.

### Release
 N/A
