### PR TITLE
Extract create backmerge PR methods in helper files

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,6 +63,7 @@ VERSION_FILE = Fastlane::Wpmreleasetoolkit::Versioning::AndroidVersionFile.new(v
 import 'lanes/build.rb'
 import 'lanes/localization.rb'
 import 'lanes/release.rb'
+import 'lib/release_helpers.rb'
 
 platform :android do
   ENV['PROJECT_ROOT_FOLDER'] = "#{File.dirname(File.expand_path(__dir__))}/"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,6 +63,7 @@ VERSION_FILE = Fastlane::Wpmreleasetoolkit::Versioning::AndroidVersionFile.new(v
 import 'lanes/build.rb'
 import 'lanes/localization.rb'
 import 'lanes/release.rb'
+# This helper is only used in the release lanes but it needs to be imported here in order to access Fastlane-specific API and our methods like release_version_current
 import 'lib/release_helpers.rb'
 
 platform :android do

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -2,6 +2,8 @@
 
 # Lanes related to the Release Process (Code Freeze, Betas, Final Build, App Store Submission…)
 
+require_relative '../lib/release_helpers'
+
 platform :android do
   desc 'Creates a new release branch from the current default branch'
   lane :start_code_freeze do |skip_prechecks: false, skip_confirm: false|
@@ -310,45 +312,6 @@ def report_milestone_error(error_title:)
   UI.error(error_message)
 
   buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci
-end
-
-def create_backmerge_pr!
-  pr_urls = create_backmerge_prs!
-
-  return pr_urls unless pr_urls.length > 1
-
-  backmerge_error_message = UI.user_error! <<~ERROR
-    Unexpectedly opened more than one backmerge pull request. URLs:
-    #{pr_urls.map { |url| "- #{url}" }.join("\n")}
-  ERROR
-  buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: backmerge_error_message) if is_ci
-  UI.user_error!(backmerge_error_message)
-end
-
-# Notice the plural in the name.
-# The action this method calls may create multiple backmerge PRs, depending on how many release branches with version greater than the source are in the remote.
-def create_backmerge_prs!
-  version = release_version_current
-
-  create_release_backmerge_pull_request(
-    repository: GITHUB_REPO,
-    source_branch: release_branch_name(release_version: version),
-    labels: ['Releases'],
-    milestone_title: release_version_next
-  )
-rescue StandardError => e
-  error_message = <<-MESSAGE
-    Error creating backmerge pull request(s):
-
-    #{e.message}
-
-    If this is not the first time you are running the release task, the backmerge PR(s) for the version `#{version}` might have already been previously created.
-    Please close any pre-existing backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
-  MESSAGE
-
-  buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: error_message) if is_ci
-
-  UI.user_error!(error_message)
 end
 
 def trigger_buildkite_release_build(branch:, beta:)

--- a/fastlane/lib/release_helpers.rb
+++ b/fastlane/lib/release_helpers.rb
@@ -1,40 +1,53 @@
 # frozen_string_literal: true
 
-def create_backmerge_pr!
-  pr_urls = create_backmerge_prs!
-
-  return pr_urls unless pr_urls.length > 1
-
-  backmerge_error_message = UI.user_error! <<~ERROR
-    Unexpectedly opened more than one backmerge pull request. URLs:
-    #{pr_urls.map { |url| "- #{url}" }.join("\n")}
-  ERROR
-  buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: backmerge_error_message) if is_ci
-  UI.user_error!(backmerge_error_message)
-end
-
 # Notice the plural in the name.
 # The action this method calls may create multiple backmerge PRs, depending on how many release branches with version greater than the source are in the remote.
-def create_backmerge_prs!
-  version = release_version_current
+def create_backmerge_prs!(
+  version: release_version_current,
+  source_branch: release_branch_name(release_version: version),
+  labels: ['Releases'],
+  milestone_title: release_version_next
+)
+  begin
+    pr_urls = create_release_backmerge_pull_request(
+      repository: GITHUB_REPO,
+      source_branch: source_branch,
+      labels: labels,
+      milestone_title: milestone_title
+    )
+  rescue StandardError => e
+    error_message = <<~MESSAGE
+      Error creating backmerge pull request(s):
 
-  create_release_backmerge_pull_request(
-    repository: GITHUB_REPO,
-    source_branch: release_branch_name(release_version: version),
-    labels: ['Releases'],
-    milestone_title: release_version_next
-  )
-rescue StandardError => e
-  error_message = <<-MESSAGE
-    Error creating backmerge pull request(s):
+      #{e.message}
 
-    #{e.message}
+      If this is not the first time you are running the release task, the backmerge PR(s) for the version `#{version}` might have already been previously created.
+      Please close any pre-existing backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
+    MESSAGE
 
-    If this is not the first time you are running the release task, the backmerge PR(s) for the version `#{version}` might have already been previously created.
-    Please close any pre-existing backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
-  MESSAGE
+    buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: error_message) if is_ci
 
-  buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: error_message) if is_ci
+    UI.user_error!(error_message)
+  end
 
-  UI.user_error!(error_message)
+  # It's possible that no backmerge was created when:
+  #
+  # - there are no hotfixes in development and the next release code freeze has not been started
+  # - nothing changes in the current release branch since release finalization
+  #
+  # As a matter of fact, in the context of Simplenote Android, the above is the most likely scenario.
+  style, message = if pr_urls.empty?
+                     ['info', 'No backmerge PR was required.']
+                   else
+                     [
+                       'success', <<~MESSAGE
+                         The following backmerge PR#{pr_urls.length > 1 ? '(s) were' : ' was'} created:
+                         #{pr_urls.map { |url| "- #{url}" }.join("\n")}
+                       MESSAGE
+                     ]
+                   end
+  buildkite_annotate(style: style, context: 'backmerge-prs-outcome', message: message) if is_ci
+  UI.success(message)
+
+  pr_urls
 end

--- a/fastlane/lib/release_helpers.rb
+++ b/fastlane/lib/release_helpers.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+def create_backmerge_pr!
+  pr_urls = create_backmerge_prs!
+
+  return pr_urls unless pr_urls.length > 1
+
+  backmerge_error_message = UI.user_error! <<~ERROR
+    Unexpectedly opened more than one backmerge pull request. URLs:
+    #{pr_urls.map { |url| "- #{url}" }.join("\n")}
+  ERROR
+  buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: backmerge_error_message) if is_ci
+  UI.user_error!(backmerge_error_message)
+end
+
+# Notice the plural in the name.
+# The action this method calls may create multiple backmerge PRs, depending on how many release branches with version greater than the source are in the remote.
+def create_backmerge_prs!
+  version = release_version_current
+
+  create_release_backmerge_pull_request(
+    repository: GITHUB_REPO,
+    source_branch: release_branch_name(release_version: version),
+    labels: ['Releases'],
+    milestone_title: release_version_next
+  )
+rescue StandardError => e
+  error_message = <<-MESSAGE
+    Error creating backmerge pull request(s):
+
+    #{e.message}
+
+    If this is not the first time you are running the release task, the backmerge PR(s) for the version `#{version}` might have already been previously created.
+    Please close any pre-existing backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
+  MESSAGE
+
+  buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: error_message) if is_ci
+
+  UI.user_error!(error_message)
+end


### PR DESCRIPTION
### Fix
What it says in the title. This is a followup to the discussion with @iangmaia here: https://github.com/Automattic/simplenote-android/pull/1695#discussion_r1766314653

### Test
This is tricky to test outside the release cycle. I checked out a test branch, added a lane that calls the method and saw it go through the expected steps, which was enough to verify everything is at least wired in a way that Ruby can interpret.

![image](https://github.com/user-attachments/assets/46353670-0dc9-46a0-b810-80c75eb10274)

<img width="1270" alt="image" src="https://github.com/user-attachments/assets/3dbb38a3-e0b9-4994-bfb1-7993321fce5b">

### Review
Only one infra engineer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

