### PR TITLE
Call method to trigger beta build, not release, from `new_beta_release`

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -149,7 +149,7 @@ platform :android do
 
     push_to_git_remote(tags: false)
 
-    trigger_release_build(branch_to_build: release_branch_name)
+    trigger_beta_build(branch_to_build: release_branch_name)
 
     create_backmerge_prs!
   end


### PR DESCRIPTION
What it says in the title. See how https://buildkite.com/automattic/simplenote-android/builds/422#0192b614-1d78-4a9c-a01c-a6eaae60a741/348-357, the build for `2.35-rc-2` uploaded to the production track, not open testing.