### PR TITLE
Trigger release build instead of running it in `finalize_release`

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -192,7 +192,7 @@ platform :android do
 
     push_to_git_remote(tags: false)
 
-    build_and_upload_release(create_release: true)
+    trigger_release_build(branch_to_build: release_branch_name)
 
     create_backmerge_prs!
 


### PR DESCRIPTION
Two reasons:

1. In it's current status if fails because of `tumblr-metal` constraints. See https://buildkite.com/automattic/simplenote-android/builds/433#0192c195-15a6-49dd-be04-e14b04eea312
2. There is a difference from simply running the lane that builds the release build and running the full CI pipeline. The latter is what we need.

---

Will merge without waiting for CI because none of the code changed here runs in the standard CI. We'll validate it once in the release branch by running a new release finalization attempt.