### PR TITLE
[Tooling] Remove explicit bot name from `use-bot-for-git` call

### DIFF
--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -12,7 +12,7 @@ steps:
     plugins: [$CI_TOOLKIT_PLUGIN]
     command: |
       echo '--- :robot_face: Use bot for Git operations'
-      source use-bot-for-git wpmobilebot
+      source use-bot-for-git
 
       echo '--- :git: Checkout release branch'
       .buildkite/commands/checkout-release-branch.sh

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -6,7 +6,7 @@ steps:
     plugins: [$CI_TOOLKIT_PLUGIN]
     command: |
       echo '--- :robot_face: Use bot for git operations'
-      source use-bot-for-git wpmobilebot
+      source use-bot-for-git
 
       echo '--- :git: Checkout Release Branch'
       .buildkite/commands/checkout-release-branch.sh

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -6,7 +6,7 @@ steps:
     plugins: [$CI_TOOLKIT_PLUGIN]
     command: |
       echo '--- :robot_face: Use bot for Git operations'
-      source use-bot-for-git wpmobilebot
+      source use-bot-for-git
 
       echo '--- :git: Checkout release branch'
       .buildkite/commands/checkout-release-branch.sh

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -6,7 +6,7 @@ steps:
     plugins: [$CI_TOOLKIT_PLUGIN]
     command: |
       echo '--- :robot_face: Use bot for git operations'
-      source use-bot-for-git wpmobilebot
+      source use-bot-for-git
 
       echo '--- :git: Checkout Release Branch'
       .buildkite/commands/checkout-release-branch.sh

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -11,7 +11,7 @@ steps:
         queue: tumblr-metal
     command: |
       echo '--- :robot_face: Use bot for Git operations'
-      source use-bot-for-git wpmobilebot
+      source use-bot-for-git
 
       echo '--- :ruby: Setup Ruby Tools'
       install_gems


### PR DESCRIPTION
I've added this repo directly to the CI machine (and we'll remove the parameter completely from `use-bot-for-git`), so this parameter isn't necessary.