### PR TITLE
Change the domain used for prototypes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@ fastlane_require 'dotenv'
 UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Helper.bundler?
 
 USER_ENV_FILE_PATH = File.join(Dir.home, '.simplenoteandroid-env.default')
-PROTOTYPE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
+PROTOTYPE_BUILD_DOMAIN = 'https://cdn.a8c-ci.services'
 
 before_all do
   # TODO: Use EnvManager — https://github.com/wordpress-mobile/release-toolkit/pull/578


### PR DESCRIPTION
This PR swaps out the CloudFront domain to remove the safety warning shown in Chrome.

## Testing

1. Click the Direct Download link for the prototype builds from @wpmobilebot while using Chrome.
2. Expect: The domain for the prototype build to be `cdn.a8c-ci.services` and not `d2twmm2nzpx3bg.cloudfront.net`.
3. Expect: To not get a "Dangerous site" error like the one below after opening the link.

![image](https://github.com/user-attachments/assets/40f65dcb-1ad5-4332-a325-23a012321b12)