### PR TITLE
[Tooling] Update GitHub Actions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,8 @@ agents:
 steps:
   - label: ":gradle: Gradle Wrapper Validation"
     command: validate_gradle_wrapper
-    plugins: [$CI_TOOLKIT_PLUGIN]
+    agents:
+      queue: linter
     notify:
       - github_commit_status:
           context: Gradle Wrapper Validation

--- a/.buildkite/release-build.yml
+++ b/.buildkite/release-build.yml
@@ -7,10 +7,13 @@ agents:
   queue: android
 
 steps:
+  # NOTE: once this pipeline is called inline from another pipeline via ReleasesV2,
+  # we may need to use another agent to checkout the release branch before the Gradle Wrapper Validation
   - label: ":gradle: Gradle Wrapper Validation"
     command: validate_gradle_wrapper
     priority: 1
-    plugins: [$CI_TOOLKIT_PLUGIN]
+    agents:
+      queue: linter
 
   - wait
 

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v4

--- a/tools/extract_release_notes.rb
+++ b/tools/extract_release_notes.rb
@@ -62,7 +62,7 @@ end
 case mode
 when :strip_pr_links
   formatted_lines = release_lines
-                    .map { |l| l.gsub(/ \[.*\]$/, '') }
+    .map { |l| l.gsub(/ \[.*\]$/, '') }
 when :keep_pr_links
   # The PR "links" are not canonical markdown links. That's not a problem on
   # GitHub where they be automatically parsed into links to the corresponding
@@ -72,7 +72,7 @@ when :keep_pr_links
   # It's probably best to update the convention in writing the release notes
   # but in the meantime let's compensate with more automation.
   formatted_lines = release_lines
-                    .map { |l| replace_pr_link_with_markdown_link(l) }
+    .map { |l| replace_pr_link_with_markdown_link(l) }
 end
 
 # It would be good to either add overriding of the file where the parsed


### PR DESCRIPTION
Reference: p7H4VZ-59z-p2

Simplenote Android doesn't use one of the GitHub Actions about to have its older versions deprecated as `actions/upload-artifact`, `actions/download-artifact` or `actions/cache`, but I used this opportunity to upgrade the Action `gradle/actions/wrapper-validation` and to move the Buildkite Gradle Wrapper Validation to the Linter queue.