### PR TITLE
[Buildkite] Test Android Staging on `ami-0ed66347bb94c070a` -> `ami-03794d38ac4991af7`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 ---
 
 agents:
-  queue: android
+  queue: android-staging
 
 steps:
   - label: ":gradle: Gradle Wrapper Validation"


### PR DESCRIPTION
Related: [buildkite-ci#610](https://github.com/Automattic/buildkite-ci/pull/610)

AMI Name: `android-build-image-6.12.0v1.7-rc-1` -> `android-build-image-6.12.0v1.8-rc-1`

---

### Description
<!--
***(Required)*** Add a concise description of what you fixed.  If this is related to an issue, add a link to it.  If applicable, add screenshots, animations, or videos to help illustrate the fix.
-->

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-0ed66347bb94c070a` works as expected.

---

### Test
<!--
***(Required)*** List the steps to test the behavior.  For example:
1. Go to...
2. Tap on...
3. See error...
-->

Check CI and verify everything is working as expected with the `android-staging` agent.

---

### Review
<!--
***(Required)*** Add instructions for reviewers.  For example:
Only one developer and one designer are required to review these changes, but anyone can perform the review.
-->

`N/A`

---

### Release
<!--
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.txt` was updated in d3adb3ef with:
> Added markdown support
-->
<!--
If the changes should not be included in release notes, add a statement to this section. For example:
These changes do not require release notes.
-->

`N/A`