### PR TITLE
[Tooling] Automate GitHub release publishing for beta builds

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -260,8 +260,9 @@ platform :android do
       repository: GITHUB_REPO,
       version: version,
       release_notes_file_path: RELEASE_NOTES_PATH,
-      prerelease: beta,
-      release_assets: apk_path
+      release_assets: apk_path,
+      prerelease: beta, # Beta = prerelease, Final = normal Release
+      is_draft: !beta # Beta = publish immediately, Final = Draft (only publish after Google approval)
     )
   end
 end


### PR DESCRIPTION
Reference: pdnsEh-24G-p2

- iOS counterpart PR: https://github.com/Automattic/simplenote-ios/pull/1703
- ReleasesV2 PR: https://github.a8c.com/Automattic/wpcom/pull/176219

### Description
This PR updates the `create_release_on_github` lane to automate the publishing of beta builds:

- Beta releases: Set as `prerelease=true` and `draft=false` to publish immediately as a pre-release
- Final releases: Set as `prerelease=false` and `draft=true` to create as a draft until we get Google approval and can publish it

### Testing Steps

We'll be able to fully verify this works as expected during the next Simplenote Android release cycle.

