### PR TITLE
[Deps] Update `automattic-tracks` to 6.0.4

### DIFF
--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -144,9 +144,9 @@ dependencies {
     implementation 'net.openid:appauth:0.7.0'
 
     // Dagger Hilt dependencies
-    implementation 'com.google.dagger:hilt-android:2.38.1'
-    annotationProcessor 'com.google.dagger:hilt-compiler:2.38.1'
-    kapt 'com.google.dagger:hilt-compiler:2.38.1'
+    implementation "com.google.dagger:hilt-android:$google_dagger"
+    annotationProcessor "com.google.dagger:hilt-compiler:$google_dagger"
+    kapt "com.google.dagger:hilt-compiler:$google_dagger"
 
     wearApp project(':Wear')
     implementation project(':PasscodeLock')

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -73,7 +73,7 @@ android {
 
 buildscript {
     dependencies {
-        classpath 'io.sentry:sentry-android-gradle-plugin:3.5.0'
+        classpath "io.sentry:sentry-android-gradle-plugin:$sentryVersion"
     }
 
     repositories {

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -112,10 +112,8 @@ dependencies {
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
     // Automattic and WordPress dependencies
     implementation 'com.automattic:simperium:v1.3.1'
-    implementation('com.github.Automattic:Automattic-Tracks-Android:2.1.0') {
-        // Tracks lib is referring to an unavailable build of okhttp
-        exclude group: 'com.squareup.okhttp3'
-    }
+    implementation "com.automattic:Automattic-Tracks-Android:$automatticTracksVersion"
+    implementation "com.automattic.tracks:crashlogging:$automatticTracksVersion"
 
     // Kotlin's coroutines
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
@@ -159,6 +157,7 @@ repositories {
         url "https://a8c-libs.s3.amazonaws.com/android"
         content {
             includeGroup "com.automattic"
+            includeGroup "com.automattic.tracks"
         }
     }
     maven { url "https://maven.google.com" }

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     testImplementation 'org.json:json:20210307'
 
     // Fastlane screengrab for screenshots automation
-    androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
+    androidTestImplementation "tools.fastlane:screengrab:$screengrabVersion"
     // Automattic and WordPress dependencies
     implementation 'com.automattic:simperium:v1.3.1'
     implementation "com.automattic:Automattic-Tracks-Android:$automatticTracksVersion"

--- a/Simplenote/build.gradle
+++ b/Simplenote/build.gradle
@@ -131,10 +131,10 @@ dependencies {
     // Support for ViewModels and LiveData
     implementation "androidx.activity:activity-ktx:1.3.1"
     implementation "androidx.fragment:fragment-ktx:1.3.6"
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.1'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidxLifecycleVersion"
     // Support for androidx Fragments
-    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$androidxLifecycleVersion"
 
     // Google Play Services
     implementation 'com.google.android.gms:play-services-wearable:17.0.0'

--- a/Simplenote/src/main/java/com/automattic/simplenote/AddTagActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/AddTagActivity.kt
@@ -98,6 +98,7 @@ class AddTagActivity : AppCompatActivity() {
                     DisplayUtils.hideKeyboard(tagInput)
                     showDialogError()
                 }
+                else -> {} // Do nothing
             }
         })
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/Simplenote.java
@@ -99,6 +99,7 @@ public class Simplenote extends Application implements HeartbeatListener {
 
     public void onCreate() {
         super.onCreate();
+        crashLogging.initialize();
 
         SimplenoteAppLock appLock = new SimplenoteAppLock(this);
         AppLockManager.getInstance().setCurrentAppLock(appLock);

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/MagicLinkConfirmationFragment.kt
@@ -70,6 +70,7 @@ class MagicLinkConfirmationFragment : Fragment() {
                         parentFragmentManager.popBackStack()
                     }
                 }
+                else -> {} // Do nothing
             }
         }
         return view

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/OkHttpMagicLinkRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/magiclink/OkHttpMagicLinkRepository.kt
@@ -20,7 +20,7 @@ class OkHttpMagicLinkRepository @Inject constructor(private val simpleHttp: Simp
             "account/complete-login",
             mapOf(Pair("username", username), Pair("auth_code", authCode))
         ).use { response ->
-            val body = response.body()?.string()
+            val body = response.body?.string()
             if (response.isSuccessful) {
                 val json = JSONObject(body ?: "")
                 val syncToken = json.getString("sync_token")
@@ -33,7 +33,7 @@ class OkHttpMagicLinkRepository @Inject constructor(private val simpleHttp: Simp
                 MagicLinkAuthError.REQUEST_NOT_FOUND -> R.string.magic_link_complete_login_expired_code_error_message
                 MagicLinkAuthError.UNKNOWN_ERROR -> R.string.magic_link_general_error
             }
-            return MagicLinkResponseResult.MagicLinkError(response.code(), authError, errorStringRes)
+            return MagicLinkResponseResult.MagicLinkError(response.code, authError, errorStringRes)
         }
     }
 
@@ -63,9 +63,9 @@ class OkHttpMagicLinkRepository @Inject constructor(private val simpleHttp: Simp
             mapOf(Pair("username", username), Pair("request_source", "android"))
         ).use { response ->
             if (response.isSuccessful) {
-                return MagicLinkResponseResult.MagicLinkRequestSuccess(response.code())
+                return MagicLinkResponseResult.MagicLinkRequestSuccess(response.code)
             } else {
-                return MagicLinkResponseResult.MagicLinkError(response.code())
+                return MagicLinkResponseResult.MagicLinkError(response.code)
             }
         }
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/networking/SimpleHttp.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/networking/SimpleHttp.kt
@@ -1,7 +1,7 @@
 package com.automattic.simplenote.networking
 
 import okhttp3.HttpUrl
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
@@ -13,7 +13,7 @@ import javax.inject.Inject
 private const val HTTP_SCHEME = "https"
 private const val BASE_URL = "app.simplenote.com"
 open class SimpleHttp @Inject constructor(val client: OkHttpClient) {
-    private val jsonMediaType = MediaType.parse("application/json; charset=utf-8")
+    private val jsonMediaType = "application/json; charset=utf-8".toMediaTypeOrNull()
 
     private fun buildUrl(path: String): HttpUrl = HttpUrl.Builder()
         .scheme(HTTP_SCHEME)

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumCollaboratorsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumCollaboratorsRepository.kt
@@ -69,17 +69,17 @@ class SimperiumCollaboratorsRepository @Inject constructor(
     override suspend fun collaboratorsChanged(noteId: String): Flow<Boolean> = callbackFlow {
         val callbackOnSaveObject = Bucket.OnSaveObjectListener<Note> { _, note ->
             if (note.simperiumKey == noteId) {
-                offer(true)
+                trySend(true).isSuccess
             }
         }
         val callbackOnDeleteObject = Bucket.OnDeleteObjectListener<Note> { _, note ->
             if (note.simperiumKey == noteId) {
-                offer(true)
+                trySend(true).isSuccess
             }
         }
         val callbackOnNetworkChange = Bucket.OnNetworkChangeListener<Note> { _, _, updatedNoteId ->
             if (updatedNoteId != null && noteId == updatedNoteId) {
-                offer(true)
+                trySend(true).isSuccess
             }
         }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/repositories/SimperiumTagsRepository.kt
@@ -12,7 +12,6 @@ import com.simperium.client.Bucket
 import com.simperium.client.BucketObjectNameInvalid
 import com.simperium.client.Query
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -82,9 +81,9 @@ class SimperiumTagsRepository @Inject constructor(
     }
 
     override suspend fun tagsChanged(): Flow<Boolean> = callbackFlow {
-        val callbackOnSaveObject = Bucket.OnSaveObjectListener<Tag> { _, _ -> offer(true) }
-        val callbackOnDeleteObject = Bucket.OnDeleteObjectListener<Tag> { _, _ -> offer(true) }
-        val callbackOnNetworkChange = Bucket.OnNetworkChangeListener<Tag> { _, _, _ -> offer(true) }
+        val callbackOnSaveObject = Bucket.OnSaveObjectListener<Tag> { _, _ -> trySend(true).isSuccess }
+        val callbackOnDeleteObject = Bucket.OnDeleteObjectListener<Tag> { _, _ -> trySend(true).isSuccess }
+        val callbackOnNetworkChange = Bucket.OnNetworkChangeListener<Tag> { _, _, _ -> trySend(true).isSuccess }
 
         tagsBucket.addOnSaveObjectListener(callbackOnSaveObject)
         tagsBucket.addOnDeleteObjectListener(callbackOnDeleteObject)

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/crashlogging/CrashLoggingModule.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/crashlogging/CrashLoggingModule.kt
@@ -1,6 +1,6 @@
 package com.automattic.simplenote.utils.crashlogging
 
-import android.content.Context
+import android.app.Application
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingProvider
@@ -10,8 +10,9 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import javax.inject.Singleton
 
 @Module
@@ -20,8 +21,15 @@ abstract class CrashLoggingModule {
     companion object {
         @Provides
         @Singleton
-        fun provideCrashLogging(@ApplicationContext context: Context, crashLoggingDataProvider: CrashLoggingDataProvider): CrashLogging {
-            return CrashLoggingProvider.createInstance(context, crashLoggingDataProvider)
+        fun provideCrashLogging(
+            application: Application,
+            crashLoggingDataProvider: CrashLoggingDataProvider
+        ): CrashLogging {
+            return CrashLoggingProvider.createInstance(
+                application,
+                crashLoggingDataProvider,
+                CoroutineScope(Dispatchers.Default)
+            )
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/crashlogging/SimplenoteCrashLoggingDataProvider.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/crashlogging/SimplenoteCrashLoggingDataProvider.kt
@@ -22,7 +22,7 @@ class SimplenoteCrashLoggingDataProvider @Inject constructor(
 ) : CrashLoggingDataProvider {
 
     override val buildType = BuildConfig.BUILD_TYPE
-    override val enableCrashLoggingLogs = BuildConfig.DEBUG
+    override val enableCrashLoggingLogs = false
     override val sentryDSN: String = BuildConfig.SENTRY_DSN
 
     override val locale: Locale?

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/crashlogging/SimplenoteCrashLoggingDataProvider.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/crashlogging/SimplenoteCrashLoggingDataProvider.kt
@@ -31,7 +31,7 @@ class SimplenoteCrashLoggingDataProvider @Inject constructor(
     override val releaseName: ReleaseName = if (BuildConfig.DEBUG) {
         ReleaseName.SetByApplication(DEBUG_RELEASE_NAME)
     } else {
-        ReleaseName.SetByApplication(BuildConfig.VERSION_NAME)
+        ReleaseName.SetByTracksLibrary
     }
 
     override val user: Flow<CrashLoggingUser?> = MutableStateFlow(app.simperium?.user?.toCrashLoggingUser())

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/crashlogging/SimplenoteCrashLoggingDataProvider.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/crashlogging/SimplenoteCrashLoggingDataProvider.kt
@@ -4,14 +4,20 @@ import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingUser
 import com.automattic.android.tracks.crashlogging.EventLevel
 import com.automattic.android.tracks.crashlogging.ExtraKnownKey
+import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
+import com.automattic.android.tracks.crashlogging.ReleaseName
 import com.automattic.simplenote.BuildConfig
 import com.automattic.simplenote.Simplenote
 import com.automattic.simplenote.utils.locale.LocaleProvider
+import com.simperium.client.User
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import java.util.Locale
 import javax.inject.Inject
 
 class SimplenoteCrashLoggingDataProvider @Inject constructor(
-    private val app: Simplenote,
+    app: Simplenote,
     private val localeProvider: LocaleProvider,
 ) : CrashLoggingDataProvider {
 
@@ -22,15 +28,18 @@ class SimplenoteCrashLoggingDataProvider @Inject constructor(
     override val locale: Locale?
         get() = localeProvider.provideLocale()
 
-    override val releaseName = if (BuildConfig.DEBUG) {
-        DEBUG_RELEASE_NAME
+    override val releaseName: ReleaseName = if (BuildConfig.DEBUG) {
+        ReleaseName.SetByApplication(DEBUG_RELEASE_NAME)
     } else {
-        BuildConfig.VERSION_NAME
+        ReleaseName.SetByApplication(BuildConfig.VERSION_NAME)
     }
 
-    override fun applicationContextProvider(): Map<String, String> {
-        return emptyMap()
-    }
+    override val user: Flow<CrashLoggingUser?> = MutableStateFlow(app.simperium?.user?.toCrashLoggingUser())
+
+    override val applicationContextProvider: Flow<Map<String, String>> = emptyFlow()
+
+    override val performanceMonitoringConfig: PerformanceMonitoringConfig
+        get() = PerformanceMonitoringConfig.Disabled
 
     override fun crashLoggingEnabled(): Boolean {
         return Simplenote.analyticsIsEnabled()
@@ -51,10 +60,12 @@ class SimplenoteCrashLoggingDataProvider @Inject constructor(
         return false
     }
 
-    override fun userProvider(): CrashLoggingUser {
+    private fun User.toCrashLoggingUser(): CrashLoggingUser? {
+        if (userId.isNullOrEmpty()) return null
+
         return CrashLoggingUser(
-            userID = app.simperium.user.userId.orEmpty(),
-            email = app.simperium.user.email.orEmpty(),
+            userID = userId,
+            email = email.orEmpty(),
             username = ""
         )
     }

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/crashlogging/SimplenoteCrashLoggingDataProvider.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/crashlogging/SimplenoteCrashLoggingDataProvider.kt
@@ -1,5 +1,6 @@
 package com.automattic.simplenote.utils.crashlogging
 
+import android.util.Log
 import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingUser
 import com.automattic.android.tracks.crashlogging.EventLevel
@@ -11,13 +12,14 @@ import com.automattic.simplenote.Simplenote
 import com.automattic.simplenote.utils.locale.LocaleProvider
 import com.simperium.client.User
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import java.util.Locale
 import javax.inject.Inject
 
 class SimplenoteCrashLoggingDataProvider @Inject constructor(
-    app: Simplenote,
+    private val app: Simplenote,
     private val localeProvider: LocaleProvider,
 ) : CrashLoggingDataProvider {
 
@@ -34,7 +36,8 @@ class SimplenoteCrashLoggingDataProvider @Inject constructor(
         ReleaseName.SetByTracksLibrary
     }
 
-    override val user: Flow<CrashLoggingUser?> = MutableStateFlow(app.simperium?.user?.toCrashLoggingUser())
+    override val user: Flow<CrashLoggingUser?>
+        get() = provideUser()
 
     override val applicationContextProvider: Flow<Map<String, String>> = emptyFlow()
 
@@ -60,6 +63,14 @@ class SimplenoteCrashLoggingDataProvider @Inject constructor(
         return false
     }
 
+    private fun provideUser(): Flow<CrashLoggingUser?> =
+        flow {
+            emit(app.simperium?.user?.toCrashLoggingUser())
+        }.catch { e ->
+            Log.e(TAG, "Exception getting the user", e)
+            emit(null)
+        }
+
     private fun User.toCrashLoggingUser(): CrashLoggingUser? {
         if (userId.isNullOrEmpty()) return null
 
@@ -71,6 +82,7 @@ class SimplenoteCrashLoggingDataProvider @Inject constructor(
     }
 
     companion object {
-        const val DEBUG_RELEASE_NAME = "debug"
+        private const val DEBUG_RELEASE_NAME = "debug"
+        private val TAG: String = SimplenoteCrashLoggingDataProvider::class.java.getSimpleName()
     }
 }

--- a/Simplenote/src/main/res/values-v31/styles.xml
+++ b/Simplenote/src/main/res/values-v31/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+
+    <style name="Theme.Simplestyle.Splash" parent="Theme.Simplestyle"/>
+
+</resources>

--- a/Simplenote/src/test/java/com/automattic/simplenote/CoroutineTestRule.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/CoroutineTestRule.kt
@@ -1,0 +1,22 @@
+package com.automattic.simplenote
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class CoroutineTestRule(val testDispatcher: TestDispatcher) : TestWatcher() {
+    override fun starting(description: Description) {
+        super.starting(description)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+}

--- a/Simplenote/src/test/java/com/automattic/simplenote/repositories/SimperiumCollaboratorsRepositoryTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/repositories/SimperiumCollaboratorsRepositoryTest.kt
@@ -1,12 +1,13 @@
 package com.automattic.simplenote.repositories
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.automattic.simplenote.CoroutineTestRule
 import com.automattic.simplenote.models.Note
 import com.simperium.client.Bucket
 import com.simperium.client.BucketObjectMissingException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -19,11 +20,16 @@ import org.mockito.kotlin.whenever
 class SimperiumCollaboratorsRepositoryTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutinesTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
 
     private val mockBucket: Bucket<*> = mock(Bucket::class.java)
     private val notesBucket = mock(Bucket::class.java) as Bucket<Note>
 
-    private val collaboratorsRepository = SimperiumCollaboratorsRepository(notesBucket, TestCoroutineDispatcher())
+    private val collaboratorsRepository = SimperiumCollaboratorsRepository(
+        notesBucket,
+        coroutinesTestRule.testDispatcher
+    )
 
     private val noteId = "key1"
     private val note = Note(noteId).apply {
@@ -66,7 +72,7 @@ class SimperiumCollaboratorsRepositoryTest {
     }
 
     @Test
-    fun getCollaboratorsShouldReturnJustEmails() = runBlockingTest {
+    fun getCollaboratorsShouldReturnJustEmails() = runTest {
         val expected = CollaboratorsActionResult.CollaboratorsList(listOf("test@emil.com", "name@example.co.jp"))
         val result = collaboratorsRepository.getCollaborators(noteId)
 
@@ -74,7 +80,7 @@ class SimperiumCollaboratorsRepositoryTest {
     }
 
     @Test
-    fun getCollaboratorsWhenNoteInTrashShouldReturnError() = runBlockingTest {
+    fun getCollaboratorsWhenNoteInTrashShouldReturnError() = runTest {
         note.isDeleted = true
 
         val result = collaboratorsRepository.getCollaborators(noteId)
@@ -84,7 +90,7 @@ class SimperiumCollaboratorsRepositoryTest {
     }
 
     @Test
-    fun getCollaboratorsWhenNoteIsDeletedShouldReturnError() = runBlockingTest {
+    fun getCollaboratorsWhenNoteIsDeletedShouldReturnError() = runTest {
         whenever(notesBucket.get(any())).thenThrow(BucketObjectMissingException())
 
         val result = collaboratorsRepository.getCollaborators(noteId)
@@ -94,7 +100,7 @@ class SimperiumCollaboratorsRepositoryTest {
     }
 
     @Test
-    fun addCollaboratorShouldAddATagToNote() = runBlockingTest {
+    fun addCollaboratorShouldAddATagToNote() = runTest {
         val collaborator = "test1@email.com"
 
         val result = collaboratorsRepository.addCollaborator(noteId, collaborator)
@@ -105,7 +111,7 @@ class SimperiumCollaboratorsRepositoryTest {
     }
 
     @Test
-    fun addCollaboratorWhenNoteInTrashShouldReturnError() = runBlockingTest {
+    fun addCollaboratorWhenNoteInTrashShouldReturnError() = runTest {
         note.isDeleted = true
         val collaborator = "test1@email.com"
 
@@ -116,7 +122,7 @@ class SimperiumCollaboratorsRepositoryTest {
     }
 
     @Test
-    fun addCollaboratorWhenNoteIsDeletedShouldReturnError() = runBlockingTest {
+    fun addCollaboratorWhenNoteIsDeletedShouldReturnError() = runTest {
         whenever(notesBucket.get(any())).thenThrow(BucketObjectMissingException())
         val collaborator = "test1@email.com"
 
@@ -127,7 +133,7 @@ class SimperiumCollaboratorsRepositoryTest {
     }
 
     @Test
-    fun removeCollaboratorShouldAddATagToNote() = runBlockingTest {
+    fun removeCollaboratorShouldAddATagToNote() = runTest {
         val collaborator = "name@example.co.jp"
 
         val result = collaboratorsRepository.removeCollaborator(noteId, collaborator)
@@ -138,7 +144,7 @@ class SimperiumCollaboratorsRepositoryTest {
     }
 
     @Test
-    fun removeCollaboratorWhenNoteInTrashShouldReturnError() = runBlockingTest {
+    fun removeCollaboratorWhenNoteInTrashShouldReturnError() = runTest {
         note.isDeleted = true
         val collaborator = "test1@email.com"
 
@@ -149,7 +155,7 @@ class SimperiumCollaboratorsRepositoryTest {
     }
 
     @Test
-    fun removeCollaboratorWhenNoteIsDeletedShouldReturnError() = runBlockingTest {
+    fun removeCollaboratorWhenNoteIsDeletedShouldReturnError() = runTest {
         whenever(notesBucket.get(any())).thenThrow(BucketObjectMissingException())
         val collaborator = "test1@email.com"
 

--- a/Simplenote/src/test/java/com/automattic/simplenote/usecases/GetTagsUseCaseTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/usecases/GetTagsUseCaseTest.kt
@@ -1,19 +1,18 @@
 package com.automattic.simplenote.usecases
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.automattic.simplenote.CoroutineTestRule
 import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.models.TagItem
-import com.automattic.simplenote.repositories.CollaboratorsRepository
 import com.automattic.simplenote.repositories.SimperiumCollaboratorsRepository
 import com.automattic.simplenote.repositories.TagsRepository
 import com.simperium.client.Bucket
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
@@ -23,11 +22,17 @@ import org.mockito.kotlin.stub
 
 @ExperimentalCoroutinesApi
 class GetTagsUseCaseTest {
-    @get:Rule val rule = InstantTaskExecutorRule()
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutinesTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
 
     private val notesBucket = mock(Bucket::class.java) as Bucket<Note>
     private val tagsRepository: TagsRepository = mock(TagsRepository::class.java)
-    private val collaboratorsRepository = SimperiumCollaboratorsRepository(notesBucket, TestCoroutineDispatcher())
+    private val collaboratorsRepository = SimperiumCollaboratorsRepository(
+        notesBucket,
+        coroutinesTestRule.testDispatcher
+    )
     private val getTagsUseCase: GetTagsUseCase = GetTagsUseCase(tagsRepository, collaboratorsRepository)
     private val tagItems = listOf(
         TagItem(Tag("tag1"), 0),
@@ -46,7 +51,7 @@ class GetTagsUseCaseTest {
     }
 
     @Test
-    fun allTagsShouldFilterCollaborators() = runBlockingTest {
+    fun allTagsShouldFilterCollaborators() = runTest {
         tagsRepository.stub { onBlocking { allTags() }.doReturn(tagItems) }
 
 
@@ -59,7 +64,7 @@ class GetTagsUseCaseTest {
     }
 
     @Test
-    fun searchTagsShouldFilterCollaborators() = runBlockingTest {
+    fun searchTagsShouldFilterCollaborators() = runTest {
         val searchTagItems = listOf(
             TagItem(Tag("tag1"), 0),
             TagItem(Tag("tag2"), 2),

--- a/Simplenote/src/test/java/com/automattic/simplenote/usecases/ValidateTagUseCaseTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/usecases/ValidateTagUseCaseTest.kt
@@ -1,13 +1,15 @@
 package com.automattic.simplenote.usecases
 
+import com.automattic.simplenote.CoroutineTestRule
 import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.repositories.SimperiumCollaboratorsRepository
 import com.automattic.simplenote.repositories.TagsRepository
 import com.automattic.simplenote.usecases.ValidateTagUseCase.TagValidationResult
 import com.simperium.client.Bucket
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Assert.assertEquals
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.any
@@ -15,9 +17,14 @@ import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 class ValidateTagUseCaseTest {
+    @get:Rule
+    val coroutinesTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
     private val notesBucket = Mockito.mock(Bucket::class.java) as Bucket<Note>
     private val tagsRepository: TagsRepository = Mockito.mock(TagsRepository::class.java)
-    private val collaboratorsRepository = SimperiumCollaboratorsRepository(notesBucket, TestCoroutineDispatcher())
+    private val collaboratorsRepository = SimperiumCollaboratorsRepository(
+        notesBucket,
+        coroutinesTestRule.testDispatcher
+    )
     private val validateTagUseCase = ValidateTagUseCase(tagsRepository, collaboratorsRepository)
 
     @Test

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/AddCollaboratorViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/AddCollaboratorViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.automattic.simplenote.viewmodels
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.automattic.simplenote.CoroutineTestRule
 import com.automattic.simplenote.authentication.SessionManager
 import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.repositories.SimperiumCollaboratorsRepository
@@ -9,8 +10,8 @@ import com.simperium.client.Bucket
 import com.simperium.client.BucketObjectMissingException
 import com.simperium.client.User
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -23,9 +24,14 @@ import org.mockito.kotlin.whenever
 class AddCollaboratorViewModelTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutinesTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
 
     private val notesBucket = Mockito.mock(Bucket::class.java) as Bucket<Note>
-    private val collaboratorsRepository = SimperiumCollaboratorsRepository(notesBucket, TestCoroutineDispatcher())
+    private val collaboratorsRepository = SimperiumCollaboratorsRepository(
+        notesBucket,
+        coroutinesTestRule.testDispatcher
+    )
     private val simperium = Mockito.mock(Simperium::class.java)
     private val viewModel = AddCollaboratorViewModel(collaboratorsRepository, SessionManager(simperium))
 
@@ -47,21 +53,21 @@ class AddCollaboratorViewModelTest {
     }
 
     @Test
-    fun addValidCollaboratorShouldTriggerAddedEvent() = runBlockingTest {
+    fun addValidCollaboratorShouldTriggerAddedEvent() = runTest {
         viewModel.addCollaborator(noteId,"test@emil.com")
 
         assertEquals(AddCollaboratorViewModel.Event.CollaboratorAdded, viewModel.event.value)
     }
 
     @Test
-    fun addInvalidCollaboratorShouldTriggerInvalidEvent() = runBlockingTest {
+    fun addInvalidCollaboratorShouldTriggerInvalidEvent() = runTest {
         viewModel.addCollaborator(noteId, "test@emil")
 
         assertEquals(AddCollaboratorViewModel.Event.InvalidCollaborator, viewModel.event.value)
     }
 
     @Test
-    fun addValidCollaboratorToNoteInTrashShouldTriggerNoteInTrash() = runBlockingTest {
+    fun addValidCollaboratorToNoteInTrashShouldTriggerNoteInTrash() = runTest {
         note.isDeleted = true
 
         viewModel.addCollaborator(noteId, "test@emil.com")
@@ -70,7 +76,7 @@ class AddCollaboratorViewModelTest {
     }
 
     @Test
-    fun addValidCollaboratorToNoteDeletedShouldTriggerNoteDeleted() = runBlockingTest {
+    fun addValidCollaboratorToNoteDeletedShouldTriggerNoteDeleted() = runTest {
         whenever(notesBucket.get(any())).thenThrow(BucketObjectMissingException())
 
         viewModel.addCollaborator(noteId, "test@emil.com")
@@ -79,7 +85,7 @@ class AddCollaboratorViewModelTest {
     }
 
     @Test
-    fun addSameAccountShouldTriggerCollaboratorCurrentUser() = runBlockingTest {
+    fun addSameAccountShouldTriggerCollaboratorCurrentUser() = runTest {
         viewModel.addCollaborator(noteId, "test@test.com")
 
         assertEquals(AddCollaboratorViewModel.Event.CollaboratorCurrentUser, viewModel.event.value)

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/AddTagViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/AddTagViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.automattic.simplenote.viewmodels
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.automattic.simplenote.CoroutineTestRule
 import com.automattic.simplenote.R
 import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.repositories.SimperiumCollaboratorsRepository
@@ -9,7 +10,7 @@ import com.automattic.simplenote.usecases.ValidateTagUseCase
 import com.automattic.simplenote.utils.getLocalRandomStringOfLen
 import com.simperium.client.Bucket
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Rule
@@ -19,11 +20,17 @@ import org.mockito.Mockito.mock
 
 @ExperimentalCoroutinesApi
 class AddTagViewModelTest {
-    @get:Rule val rule = InstantTaskExecutorRule()
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutinesTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
 
     private val fakeTagsRepository = mock(TagsRepository::class.java)
     private val notesBucket = mock(Bucket::class.java) as Bucket<Note>
-    private val collaboratorsRepository = SimperiumCollaboratorsRepository(notesBucket, TestCoroutineDispatcher())
+    private val collaboratorsRepository = SimperiumCollaboratorsRepository(
+        notesBucket,
+        coroutinesTestRule.testDispatcher
+    )
     private val validateTagUseCase = ValidateTagUseCase(fakeTagsRepository, collaboratorsRepository)
     private val viewModel = AddTagViewModel(fakeTagsRepository, validateTagUseCase)
 

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModelTest.kt
@@ -1,13 +1,15 @@
 package com.automattic.simplenote.viewmodels
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.automattic.simplenote.CoroutineTestRule
 import com.automattic.simplenote.repositories.CollaboratorsActionResult
 import com.automattic.simplenote.repositories.CollaboratorsRepository
 import com.automattic.simplenote.viewmodels.CollaboratorsViewModel.Event
 import com.automattic.simplenote.viewmodels.CollaboratorsViewModel.UiState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -19,21 +21,22 @@ import org.mockito.kotlin.whenever
 class CollaboratorsViewModelTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutinesTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
 
     private val mockCollaboratorsRepository = mock(CollaboratorsRepository::class.java)
     private val viewModel = CollaboratorsViewModel(mockCollaboratorsRepository)
 
     private val noteId = "key1"
 
-
     @Before
-    fun setup() = runBlockingTest {
+    fun setup() = runTest {
         whenever(mockCollaboratorsRepository.getCollaborators(noteId))
             .thenReturn(CollaboratorsActionResult.CollaboratorsList(listOf("test@emil.com", "name@example.co.jp")))
     }
 
     @Test
-    fun loadCollaboratorsShouldUpdateUiStateWithList() = runBlockingTest {
+    fun loadCollaboratorsShouldUpdateUiStateWithList() = runTest {
         viewModel.loadCollaborators(noteId)
 
         val expectedCollaborators = UiState.CollaboratorsList(listOf("test@emil.com", "name@example.co.jp"))
@@ -41,7 +44,7 @@ class CollaboratorsViewModelTest {
     }
 
     @Test
-    fun loadEmptyCollaboratorsShouldUpdateUiStateWithEmpty() = runBlockingTest {
+    fun loadEmptyCollaboratorsShouldUpdateUiStateWithEmpty() = runTest {
         whenever(mockCollaboratorsRepository.getCollaborators(noteId))
             .thenReturn(CollaboratorsActionResult.CollaboratorsList(emptyList()))
 
@@ -51,7 +54,7 @@ class CollaboratorsViewModelTest {
     }
 
     @Test
-    fun loadCollaboratorsForNoteInTrashShouldUpdateUiStateNoteInTrash() = runBlockingTest {
+    fun loadCollaboratorsForNoteInTrashShouldUpdateUiStateNoteInTrash() = runTest {
         whenever(mockCollaboratorsRepository.getCollaborators(noteId))
             .thenReturn(CollaboratorsActionResult.NoteInTrash)
 
@@ -61,7 +64,7 @@ class CollaboratorsViewModelTest {
     }
 
     @Test
-    fun loadCollaboratorsForNoteInTrashShouldUpdateUiStateNoteDeleted() = runBlockingTest {
+    fun loadCollaboratorsForNoteInTrashShouldUpdateUiStateNoteDeleted() = runTest {
         whenever(mockCollaboratorsRepository.getCollaborators(noteId))
             .thenReturn(CollaboratorsActionResult.NoteDeleted)
 
@@ -71,7 +74,7 @@ class CollaboratorsViewModelTest {
     }
 
     @Test
-    fun removeCollaboratorShouldReturnListEmails() = runBlockingTest {
+    fun removeCollaboratorShouldReturnListEmails() = runTest {
         viewModel.loadCollaborators(noteId)
         whenever(mockCollaboratorsRepository.removeCollaborator(noteId, "test@emil.com"))
             .thenReturn(CollaboratorsActionResult.CollaboratorsList(listOf("name@example.co.jp")))
@@ -83,7 +86,7 @@ class CollaboratorsViewModelTest {
     }
 
     @Test
-    fun removeLastCollaboratorShouldReturnEmpty() = runBlockingTest {
+    fun removeLastCollaboratorShouldReturnEmpty() = runTest {
         viewModel.loadCollaborators(noteId)
         whenever(mockCollaboratorsRepository.removeCollaborator(noteId, "test@emil.com"))
             .thenReturn(CollaboratorsActionResult.CollaboratorsList(emptyList()))
@@ -94,7 +97,7 @@ class CollaboratorsViewModelTest {
     }
 
     @Test
-    fun removeCollaboratorForNoteInTrashShouldTriggerEvent() = runBlockingTest {
+    fun removeCollaboratorForNoteInTrashShouldTriggerEvent() = runTest {
         viewModel.loadCollaborators(noteId)
         whenever(mockCollaboratorsRepository.removeCollaborator(noteId, "test@emil.com"))
             .thenReturn(CollaboratorsActionResult.NoteInTrash)
@@ -105,7 +108,7 @@ class CollaboratorsViewModelTest {
     }
 
     @Test
-    fun removeCollaboratorForNoteDeletedShouldTriggerEvent() = runBlockingTest {
+    fun removeCollaboratorForNoteDeletedShouldTriggerEvent() = runTest {
         viewModel.loadCollaborators(noteId)
         whenever(mockCollaboratorsRepository.removeCollaborator(noteId, "test@emil.com"))
             .thenReturn(CollaboratorsActionResult.NoteDeleted)
@@ -140,7 +143,7 @@ class CollaboratorsViewModelTest {
     }
 
     @Test
-    fun collaboratorAddedAfterStoppedListeningChangesShouldNotUpdateUiState() = runBlockingTest {
+    fun collaboratorAddedAfterStoppedListeningChangesShouldNotUpdateUiState() = runTest {
         viewModel.loadCollaborators(noteId)
         viewModel.startListeningChanges()
         viewModel.stopListeningChanges()
@@ -154,7 +157,7 @@ class CollaboratorsViewModelTest {
     }
 
     @Test
-    fun collaboratorAddedShouldUpdateUiState() = runBlockingTest {
+    fun collaboratorAddedShouldUpdateUiState() = runTest {
         viewModel.loadCollaborators(noteId)
         whenever(mockCollaboratorsRepository.collaboratorsChanged(noteId)).thenReturn(flow { emit(true) })
         val expectedList = listOf("test@emil.com", "name@example.co.jp", "test2@email.com")

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/CompleteMagicLinkViewModelTest.kt
@@ -1,16 +1,16 @@
 package com.automattic.simplenote.viewmodels
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.automattic.simplenote.CoroutineTestRule
 import com.automattic.simplenote.repositories.MagicLinkRepository
 import com.automattic.simplenote.repositories.MagicLinkResponseResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.Mockito
 
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Rule
 
 const val AUTH_KEY_TEST = "auth_key_test"
@@ -18,30 +18,28 @@ const val AUTH_CODE_TEST = "auth_code_test"
 
 @ExperimentalCoroutinesApi
 class CompleteMagicLinkViewModelTest {
-
     @get:Rule
     val instantExecutorRule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutinesTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
 
     private val repository: MagicLinkRepository = Mockito.mock(MagicLinkRepository::class.java)
-
-    @Before
-    fun setup() {
-
-    }
+    private val viewModel = CompleteMagicLinkViewModel(
+        repository,
+        coroutinesTestRule.testDispatcher
+    )
 
     @Test
-    fun instantiateViewModel() = runBlockingTest {
-        val viewModel = CompleteMagicLinkViewModel(repository, TestCoroutineDispatcher())
+    fun instantiateViewModel() = runTest {
         assertEquals(MagicLinkUiState.Waiting, viewModel.magicLinkUiState.value)
     }
 
     @Test
-    fun firingPostRequestShouldLeadToSuccess() = runBlockingTest {
+    fun firingPostRequestShouldLeadToSuccess() = runTest {
         Mockito.`when`(
             repository.completeLogin(AUTH_KEY_TEST, AUTH_CODE_TEST)
         ).thenReturn(MagicLinkResponseResult.MagicLinkCompleteSuccess(AUTH_KEY_TEST, AUTH_CODE_TEST))
 
-        val viewModel = CompleteMagicLinkViewModel(repository, TestCoroutineDispatcher())
         val states = mutableListOf<MagicLinkUiState>()
         viewModel.magicLinkUiState.observeForever {
             states.add(it)
@@ -54,12 +52,11 @@ class CompleteMagicLinkViewModelTest {
     }
 
     @Test
-    fun firingPostRequestShouldLeadToError() = runBlockingTest {
+    fun firingPostRequestShouldLeadToError() = runTest {
         Mockito.`when`(
             repository.completeLogin(AUTH_KEY_TEST, AUTH_CODE_TEST)
         ).thenReturn(MagicLinkResponseResult.MagicLinkError(code = 400))
 
-        val viewModel = CompleteMagicLinkViewModel(repository, TestCoroutineDispatcher())
         val states = mutableListOf<MagicLinkUiState>()
         viewModel.magicLinkUiState.observeForever {
             states.add(it)

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/NoteEditorViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/NoteEditorViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.automattic.simplenote.viewmodels
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.automattic.simplenote.CoroutineTestRule
 import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.repositories.SimperiumCollaboratorsRepository
 import com.automattic.simplenote.repositories.TagsRepository
@@ -9,10 +10,9 @@ import com.automattic.simplenote.usecases.ValidateTagUseCase
 import com.automattic.simplenote.viewmodels.NoteEditorViewModel.NoteEditorEvent
 import com.simperium.client.Bucket
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
@@ -23,10 +23,15 @@ import org.mockito.kotlin.whenever
 class NoteEditorViewModelTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutinesTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
 
     private val tagsRepository: TagsRepository = mock(TagsRepository::class.java)
     private val notesBucket = mock(Bucket::class.java) as Bucket<Note>
-    private val collaboratorsRepository = SimperiumCollaboratorsRepository(notesBucket, TestCoroutineDispatcher())
+    private val collaboratorsRepository = SimperiumCollaboratorsRepository(
+        notesBucket,
+        coroutinesTestRule.testDispatcher
+    )
     private val getTagsUseCase = GetTagsUseCase(tagsRepository, collaboratorsRepository)
     private val validateTagUseCase = ValidateTagUseCase(tagsRepository, collaboratorsRepository)
     private val viewModel = NoteEditorViewModel(getTagsUseCase, validateTagUseCase)

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/RequestMagicLinkViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/RequestMagicLinkViewModelTest.kt
@@ -1,11 +1,12 @@
 package com.automattic.simplenote.viewmodels
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.automattic.simplenote.CoroutineTestRule
 import com.automattic.simplenote.repositories.MagicLinkRepository
 import com.automattic.simplenote.repositories.MagicLinkResponseResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.Mockito
 
@@ -18,22 +19,26 @@ const val email = "test@email.com"
 class RequestMagicLinkViewModelTest {
     @get:Rule
     val instantExecutorRule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutinesTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
 
     private val repository: MagicLinkRepository = Mockito.mock(MagicLinkRepository::class.java)
+    private val viewModel = RequestMagicLinkViewModel(
+        repository,
+        coroutinesTestRule.testDispatcher
+    )
 
     @Test
-    fun instantiateViewModel() = runBlockingTest {
-        val viewModel = RequestMagicLinkViewModel(repository, TestCoroutineDispatcher())
+    fun instantiateViewModel() = runTest {
         assertEquals(MagicLinkRequestUiState.Waiting, viewModel.magicLinkRequestUiState.value)
     }
 
     @Test
-    fun firingPostRequestShouldLeadToSuccess() = runBlockingTest {
+    fun firingPostRequestShouldLeadToSuccess() = runTest {
         Mockito.`when`(
             repository.requestLogin(email)
         ).thenReturn(MagicLinkResponseResult.MagicLinkRequestSuccess(code = 200))
 
-        val viewModel = RequestMagicLinkViewModel(repository, TestCoroutineDispatcher())
         val states = mutableListOf<MagicLinkRequestUiState>()
         viewModel.magicLinkRequestUiState.observeForever {
             states.add(it)
@@ -45,12 +50,11 @@ class RequestMagicLinkViewModelTest {
     }
 
     @Test
-    fun firingPostRequestShouldLeadToError() = runBlockingTest {
+    fun firingPostRequestShouldLeadToError() = runTest {
         Mockito.`when`(
             repository.requestLogin(email)
         ).thenReturn(MagicLinkResponseResult.MagicLinkError(code = 400))
 
-        val viewModel = RequestMagicLinkViewModel(repository, TestCoroutineDispatcher())
         val states = mutableListOf<MagicLinkRequestUiState>()
         viewModel.magicLinkRequestUiState.observeForever {
             states.add(it)

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagDialogViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.automattic.simplenote.viewmodels
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.automattic.simplenote.CoroutineTestRule
 import com.automattic.simplenote.R
 import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.models.Tag
@@ -10,7 +11,7 @@ import com.automattic.simplenote.usecases.ValidateTagUseCase
 import com.automattic.simplenote.utils.getLocalRandomStringOfLen
 import com.simperium.client.Bucket
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -20,11 +21,17 @@ import org.mockito.Mockito.mock
 
 @ExperimentalCoroutinesApi
 class TagDialogViewModelTest {
-    @get:Rule val rule = InstantTaskExecutorRule()
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutinesTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
 
     private val fakeTagsRepository = mock(TagsRepository::class.java)
     private val notesBucket = mock(Bucket::class.java) as Bucket<Note>
-    private val collaboratorsRepository = SimperiumCollaboratorsRepository(notesBucket, TestCoroutineDispatcher())
+    private val collaboratorsRepository = SimperiumCollaboratorsRepository(
+        notesBucket,
+        coroutinesTestRule.testDispatcher
+    )
     private val validateTagUseCase = ValidateTagUseCase(fakeTagsRepository, collaboratorsRepository)
     private val viewModel = TagDialogViewModel(fakeTagsRepository, validateTagUseCase)
     private val tagName = "tag1"

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.automattic.simplenote.viewmodels
 
 import android.view.View
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.automattic.simplenote.CoroutineTestRule
 import com.automattic.simplenote.models.Note
 import com.automattic.simplenote.models.Tag
 import com.automattic.simplenote.models.TagItem
@@ -13,11 +14,10 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
@@ -29,11 +29,17 @@ import org.mockito.kotlin.stub
 
 @ExperimentalCoroutinesApi
 class TagsViewModelTest {
-    @get:Rule val rule = InstantTaskExecutorRule()
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+    @get:Rule
+    val coroutinesTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
 
     private val tagsBucket = mock(Bucket::class.java) as Bucket<Tag>
     private val notesBucket = mock(Bucket::class.java) as Bucket<Note>
-    private val collaboratorsRepository = SimperiumCollaboratorsRepository(notesBucket, TestCoroutineDispatcher())
+    private val collaboratorsRepository = SimperiumCollaboratorsRepository(
+        notesBucket,
+        coroutinesTestRule.testDispatcher
+    )
     private val fakeTagsRepository = mock(TagsRepository::class.java)
     private val getTagsUseCase: GetTagsUseCase = GetTagsUseCase(fakeTagsRepository, collaboratorsRepository)
     private val viewModel = TagsViewModel(fakeTagsRepository, getTagsUseCase)
@@ -59,7 +65,7 @@ class TagsViewModelTest {
     )
 
     @Test
-    fun startShouldSetupUiState() = runBlockingTest {
+    fun startShouldSetupUiState() = runTest {
         fakeTagsRepository.stub {
             onBlocking { allTags() }.doReturn(tagItems)
         }
@@ -75,7 +81,7 @@ class TagsViewModelTest {
     }
 
     @Test
-    fun whenTagsChangedWithANewTagUiStateShouldUpdate() = runBlockingTest {
+    fun whenTagsChangedWithANewTagUiStateShouldUpdate() = runTest {
         val variableTagItems = tagItems.toMutableList()
         fakeTagsRepository.stub {
             onBlocking { allTags() }.doReturn(tagItems)
@@ -107,7 +113,7 @@ class TagsViewModelTest {
     }
 
     @Test
-    fun whenPauseIsCalledAllChangedToTagsAreNotListened() = runBlockingTest {
+    fun whenPauseIsCalledAllChangedToTagsAreNotListened() = runTest {
         val variableTagItems = expectedTagItems.toMutableList()
         fakeTagsRepository.stub {
             onBlocking { allTags() }.doReturn(tagItems)
@@ -159,7 +165,7 @@ class TagsViewModelTest {
     }
 
     @Test
-    fun closeSearchShouldCleanQuery() = runBlockingTest {
+    fun closeSearchShouldCleanQuery() = runTest {
         fakeTagsRepository.stub {
             onBlocking { allTags() }.doReturn(tagItems)
         }
@@ -175,7 +181,7 @@ class TagsViewModelTest {
     }
 
     @Test
-    fun searchShouldFilterTags() = runBlockingTest {
+    fun searchShouldFilterTags() = runTest {
         fakeTagsRepository.stub {
             onBlocking { allTags() }.doReturn(tagItems)
         }
@@ -198,7 +204,7 @@ class TagsViewModelTest {
     }
 
     @Test
-    fun afterAddingATagUpdateOnResultShouldUpdateUiState() = runBlockingTest {
+    fun afterAddingATagUpdateOnResultShouldUpdateUiState() = runTest {
         val mutableTagItems = expectedTagItems.toMutableList()
         fakeTagsRepository.stub {
             onBlocking { allTags() }.doReturn(mutableTagItems)
@@ -236,7 +242,7 @@ class TagsViewModelTest {
     }
 
     @Test
-    fun clickDeleteTagOfTagWithoutNotesShouldDeleteTagDirectly() = runBlockingTest {
+    fun clickDeleteTagOfTagWithoutNotesShouldDeleteTagDirectly() = runTest {
         fakeTagsRepository.stub {
             onBlocking { deleteTag(any()) }.doReturn(Unit)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -66,4 +66,5 @@ def gitVersion() {
 
 ext {
     automatticTracksVersion = '6.0.4'
+    androidxLifecycleVersion = '2.5.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ def gitVersion() {
 }
 
 ext {
+    sentryVersion = '5.8.0'
+
     automatticTracksVersion = '6.0.4'
     androidxLifecycleVersion = '2.5.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = '1.9.25'
+    ext.google_dagger = '2.52'
 
     repositories {
         maven {
@@ -17,7 +18,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.40.1'
+        classpath "com.google.dagger:hilt-android-gradle-plugin:$google_dagger"
         classpath 'com.automattic.android:configure:0.6.1'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.9.25'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,6 @@ ext {
 
     automatticTracksVersion = '6.0.4'
     androidxLifecycleVersion = '2.5.1'
+
+    screengrabVersion = '2.1.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -63,3 +63,6 @@ def gitVersion() {
     (gitDescribe() =~ /^v/).replaceFirst('')
 }
 
+ext {
+    automatticTracksVersion = '6.0.4'
+}


### PR DESCRIPTION
Closes: [AINFRA-918](https://linear.app/a8c/issue/AINFRA-918/snandroid)

---

### Description
<!--
***(Required)*** Add a concise description of what you fixed.  If this is related to an issue, add a link to it.  If applicable, add screenshots, animations, or videos to help illustrate the fix.
-->

This PR updates `automattic-tracks` to [6.0.4](https://github.com/Automattic/Automattic-Tracks-Android/releases/tag/6.0.4).

FYI: This update makes this library fully 16 KB page size compatible ([context](https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html)).

PS: Also see:

- Kotlin [1.9.25](https://github.com/JetBrains/kotlin/releases/tag/v1.9.25): f14db5acf4b679a0de4addf22b894b7870bb70dd
- Dagger [2.52](https://github.com/google/dagger/releases/tag/dagger-2.52): dbfb1a464401ece197df1e79b2c4e8be87b016fe
- AndroidX Lifecycle [2.5.1](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.5.1): 7b61292c3f98255fdec3ddc48dd4f02c3db83ba7
- Error Resolution: 6a364d280a08f3f6eeb4542c662ce7b390ca9eb0 + 27992a68bd078e7f1a397e0af027a2a9ce9d85ec + 57e3f58f5472959de3324f85159fbe7fa3eb0446 + 22ef40710a909499ca71f819b44ec3b81f2e17c0
- Theme Fix: 41ea3e10bdada04b31861707327d4074bbe22afb
- Coroutine Tests: c477a63e6e13cc81213f461e7c78e65de71ecdd2 + 42d907a4de1180880c6cb9a101c3dfc38a1c5251

---

### Test
<!--
***(Required)*** List the steps to test the behavior.  For example:
1. Go to...
2. Tap on...
3. See error...
-->

#### Tracks & Events

1. Using the patch below, add tracking logs to the app.

<details>
    <summary>patch</summary>

```diff
Index: Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTrackerNosara.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTrackerNosara.java b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTrackerNosara.java
--- a/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTrackerNosara.java	(revision 41ea3e10bdada04b31861707327d4074bbe22afb)
+++ b/Simplenote/src/main/java/com/automattic/simplenote/analytics/AnalyticsTrackerNosara.java	(date 1753449557344)
@@ -3,6 +3,7 @@
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.text.TextUtils;
+import android.util.Log;
 
 import androidx.preference.PreferenceManager;
 
@@ -95,8 +96,11 @@
         if (properties != null) {
             JSONObject propertiesJson = new JSONObject(properties);
             mNosaraClient.track(EVENTS_PREFIX + eventName, propertiesJson, user, userType);
+            String jsonString = propertiesJson.toString();
+            Log.i("AnalyticsTrackerNosara", "\uD83D\uDD35 Tracked: " + eventName + ", Properties: " + jsonString);
         } else {
             mNosaraClient.track(EVENTS_PREFIX + eventName, user, userType);
+            Log.i("AnalyticsTrackerNosara", "\uD83D\uDD35 Tracked: " + eventName);
         }
     }
 
@@ -128,4 +132,4 @@
 
         mNosaraClient.flush();
     }
-}
\ No newline at end of file
+}
```
</details>

2. Navigate to `Setting` -> `Privacy` section and make sure to enable `Share analytics`.
3. Open `Logcat` and filter for `🔵 Tracked: ` to make sure that all specific app actions are tracked (ie. switching tabs).

#### Sentry & Crashes

1. Navigate to `Setting` -> `Privacy` section and make sure to enable `Share analytics`.
2. Using the patch below, make the app crash. You could navigate to `Settings` -> `About` section and then click `Crash The App`.

<details>
    <summary>patch</summary>

```diff
Subject: [PATCH] Fix: Add an default simplestyle splash them point to simplestyle  

FYI: This change is done because after all the updates, the app started 
showing a blue overlay with an icon on every screen. With this fix and 
for Android 12 devices and above (API 31) we are no longer dependending 
on this custom splash screen theme, but rather let the system default to
whichever is the default implementation of splashscreen, without us 
adding any additional configuration on top of it and thus defaulting the
main application theme to 'Theme.Simplestyle' for Android 12 devices and
above.
---
Index: Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java	(revision 41ea3e10bdada04b31861707327d4074bbe22afb)
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java	(date 1753449660581)
@@ -169,6 +169,17 @@
             }
         });
 
+        findPreference("pref_key_crash_the_app").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                try {
+                    throw new Exception("Developer caused a crash!");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+
         findPreference("pref_key_about").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
Index: Simplenote/src/main/res/xml/preferences.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/Simplenote/src/main/res/xml/preferences.xml b/Simplenote/src/main/res/xml/preferences.xml
--- a/Simplenote/src/main/res/xml/preferences.xml	(revision 41ea3e10bdada04b31861707327d4074bbe22afb)
+++ b/Simplenote/src/main/res/xml/preferences.xml	(date 1753449660581)
@@ -190,6 +190,12 @@
             android:title="@string/website">
         </Preference>
 
+        <Preference
+            android:key="pref_key_crash_the_app"
+            android:persistent="false"
+            android:title="Crash the App">
+        </Preference>
+
     </PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>
```

</details>

3. Open [Sentry](https://a8c.sentry.io) and navigate to `Issues`. Find `simplenote-android` and check the latest `debug` exceptions. You could search for `Developer caused a crash!` and check the latest crash, making sure that the crash is reported.

#### Smoke Test

Just because this update also includes multiple other core updates (`Kotlin`, `Dagger` and `AndroidX Lifecycle`), please smoke test the app fully and verify everything is working as expected.

---

### Review
<!--
***(Required)*** Add instructions for reviewers.  For example:
Only one developer and one designer are required to review these changes, but anyone can perform the review.
-->

FYI: Updating [automattic-tracks to 6.0.4](https://github.com/Automattic/simplenote-android/pull/1731/commits/e7afdf5949ae8a6cf413c980e50704ebe0b8e666) wasn't enough by itself to make Sentry fully 16 KB page size compatible. Updating [sentry plugin to 5.8.0](https://github.com/Automattic/simplenote-android/pull/1731/commits/c9159f17f81f20d595b49276ba212fa2d202866b) as well did the trick.

PS: I noticed this while working on [AINFRA-994](https://linear.app/a8c/issue/AINFRA-994), after I manually updated `Gradle to 8.13.4` and `AGP to 8.11.1`, then run `lintDebug`, only to notice Sentry still in the [Aligned16KB](https://googlesamples.github.io/android-custom-lint-rules/checks/Aligned16KB.md.html) list.

---

### Release
<!--
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.txt` was updated in d3adb3ef with:
> Added markdown support
-->
<!--
If the changes should not be included in release notes, add a statement to this section. For example:
These changes do not require release notes.
-->

`TODO` (I am actually not sure what to do here, maybe this instruction is now legacy)