### PR TITLE
Add Apply Window Insets Listener to Floating Action Button on Collaborators and Edit Tags Screens

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/CollaboratorsActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/CollaboratorsActivity.kt
@@ -13,8 +13,8 @@ import androidx.appcompat.widget.Toolbar
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.automattic.simplenote.databinding.ActivityCollaboratorsBinding
 import com.automattic.simplenote.utils.CollaboratorsAdapter
-import com.automattic.simplenote.utils.CollaboratorsAdapter.*
 import com.automattic.simplenote.utils.CollaboratorsAdapter.CollaboratorDataItem.*
+import com.automattic.simplenote.utils.DisplayUtils
 import com.automattic.simplenote.utils.IntentUtils
 import com.automattic.simplenote.utils.SystemBarUtils
 import com.automattic.simplenote.utils.toast
@@ -48,7 +48,7 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
             setObservers()
 
             viewModel.loadCollaborators(noteId)
-            
+
             // Setup edge-to-edge display with proper WindowInsets handling
             // Use auto-theming to properly handle status bar appearance based on theme
             val toolbar = findViewById<Toolbar>(R.id.toolbar)
@@ -90,6 +90,9 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
         collaboratorsList.setEmptyView(empty.root)
 
         buttonAddCollaborator.setOnClickListener { viewModel.clickAddCollaborator() }
+        buttonAddCollaborator.setOnApplyWindowInsetsListener { view, insets ->
+            DisplayUtils.applyWindowInsetsForFloatingActionButton(insets, resources, view)
+        }
 
         empty.image.setImageResource(R.drawable.ic_collaborate_24dp)
         empty.title.text = getString(R.string.no_collaborators)

--- a/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/TagsActivity.kt
@@ -37,7 +37,7 @@ class TagsActivity : ThemedAppCompatActivity() {
         binding.setObservers()
 
         viewModel.start()
-        
+
         // Setup edge-to-edge display with proper WindowInsets handling
         // Use auto-theming to properly handle status bar appearance based on theme
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
@@ -72,6 +72,9 @@ class TagsActivity : ThemedAppCompatActivity() {
         buttonAdd.setOnLongClickListener {
             viewModel.longClickAddTag()
             true
+        }
+        buttonAdd.setOnApplyWindowInsetsListener { view, insets ->
+            DisplayUtils.applyWindowInsetsForFloatingActionButton(insets, resources, view)
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/DisplayUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/DisplayUtils.java
@@ -3,12 +3,17 @@ package com.automattic.simplenote.utils;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.graphics.Point;
+import android.os.Build;
 import android.util.TypedValue;
 import android.view.Display;
 import android.view.View;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.RelativeLayout;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -148,5 +153,40 @@ public class DisplayUtils {
         if (inputMethodManager != null) {
             inputMethodManager.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT);
         }
+    }
+
+    /**
+     * Apply window insets for a {@link FloatingActionButton} in a {@link RelativeLayout} to the given {@link View}.
+     *
+     * @param insets     {@link WindowInsets} to apply to {@link View}.
+     * @param resources  {@link Resources} to get dimension value from.
+     * @param view       {@link View} to apply {@link WindowInsets} to.
+     *
+     * @return           {@link WindowInsets} supplied from a listener.
+     */
+    public static WindowInsets applyWindowInsetsForFloatingActionButton(WindowInsets insets, Resources resources, View view) {
+        int bottom;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            bottom = insets.getInsets(WindowInsets.Type.systemBars()).bottom;
+        } else {
+            bottom = insets.getSystemWindowInsetBottom();
+        }
+
+        int button = (int) resources.getDimension(R.dimen.button_floating);
+        int margin = (int) resources.getDimension(R.dimen.margin_default);
+
+        RelativeLayout.LayoutParams buttonLayoutParams = new RelativeLayout.LayoutParams(
+            RelativeLayout.LayoutParams.WRAP_CONTENT,
+            RelativeLayout.LayoutParams.WRAP_CONTENT
+        );
+        buttonLayoutParams.setMargins(margin, 0, margin, bottom + margin);
+        buttonLayoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+        buttonLayoutParams.addRule(RelativeLayout.ALIGN_PARENT_END);
+        buttonLayoutParams.height = button;
+        buttonLayoutParams.width = button;
+        view.setLayoutParams(buttonLayoutParams);
+
+        return insets;
     }
 }


### PR DESCRIPTION
### Fix
After the changes up to https://github.com/Automattic/simplenote-android/pull/1737/commits/be33637886eb6af5726f5095a0eeece7398da1fb in https://github.com/Automattic/simplenote-android/pull/1737, the floating action button on the ***Collaborators*** and ***Edit Tags*** screens overlaps the system navigation bar.  The `setOnApplyWindowInsetsListener` method described in the [official documentation to ***Display Content Edge-to-Edge in Views*** under the ***Handle Overlaps Using Insets*** section](https://developer.android.com/develop/ui/views/layout/edge-to-edge#handle-overlaps) was used after lines [81/92 in `CollaboratorsActivity.kt`](https://github.com/Automattic/simplenote-android/pull/1737/files#diff-a5f944b903f4125792b2433bb0d3abedd5fd797f83a6db75d1c6c432e12b83d5R92) and [64/75 in `TagsActivity.kt`](https://github.com/Automattic/simplenote-android/pull/1737/files#diff-5274de772e3bab5722501f4be7fdd246906f93c0a1a3cc1f2697e6cc1b324a74L64) in https://github.com/Automattic/simplenote-android/pull/1737 to fix the issue.  See the screenshots below for illustration.

<details>
<summary>
<h3>Screenshots</h3>
</summary>
<details>
<summary>
<h4>Collaborators</h4>
</summary>
<table>
    <tr>
        <th width="50%">
            Before
        </th>
        <th width="50%">
            After
        </th>
    </tr>
    <tr>
        <td>
            <img alt="1737_update_android_15_collaborators_before" src="https://github.com/user-attachments/assets/a946d5e2-bd45-4d56-b2ec-7a33ef2eb916" />
        </td>
        <td>
            <img alt="1737_update_android_15_collaborators_after" src="https://github.com/user-attachments/assets/ecf74c0a-f536-40c5-9000-a727c1ee16ab" />
        </td>
    </tr>
</table>
</details>
<details>
<summary>
<h4>Edit Tags</h4>
</summary>
<table>
    <tr>
        <th width="50%">
            Before
        </th>
        <th width="50%">
            After
        </th>
    </tr>
    <tr>
        <td>
            <img alt="1737_update_android_15_tags_before" src="https://github.com/user-attachments/assets/5b152494-bb54-4a01-a0e0-a4f1c550baa1" />
        </td>
        <td>
            <img alt="1737_update_android_15_tags_after" src="https://github.com/user-attachments/assets/78ab9019-c5cc-4c1e-8350-f468030d956f" />
        </td>
    </tr>
</table>
</details>
</details>

### Test

Follow the steps below to test the ***Add Collaborator*** and ***Add Tag*** floating action buttons on the ***Collaborators*** and ***Edit Tags*** screens respectively.

#### Collaborators

1. Tap any note in list with at least one collaborator.
2. Tap ellipsis/overflow button in top app bar.
3. Tap ***Collaborators*** item in menu.
4. Notice ***Add Collaborator*** floating action button does not overlap system navigation bar.
5. Tap back arrow in top app bar.
6. Tap back arrow in top app bar.
7. Tap any note in list with no collaborators.
8. Tap ellipsis/overflow button in top app bar.
9. Tap ***Collaborators*** item in menu.
10. Notice ***Add Collaborator*** floating action button does not overlap system navigation bar.

#### Edit Tags

1. Open navigation drawer.
2. Tap ***Edit*** button in ***Tags*** section.
3. Notice ***Add Tag*** floating action button does not overlap system navigation bar.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.