### PR TITLE
Remove Kotlin Sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ captures/
 
 # Gradle
 .gradle/
+.kotlin/
 sentry.properties
 Simplenote/gradle.properties
 


### PR DESCRIPTION
### Fix
Remove `.kotlin/sessions/kotlin-compiler-3964806556153479090.salive` file and add `.kotlin/` to `.gitignore`.

### Test
1. Check root directory.
2. Notice no `.kotlin` directory.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.