### PR TITLE
Add Toast to Add Collaborator Floating Action Button Long Click

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/CollaboratorsActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/CollaboratorsActivity.kt
@@ -3,6 +3,7 @@ package com.automattic.simplenote
 import android.content.Intent
 import android.os.Bundle
 import android.text.SpannableString
+import android.view.HapticFeedbackConstants
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
@@ -93,6 +94,10 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
         buttonAddCollaborator.setOnApplyWindowInsetsListener { view, insets ->
             DisplayUtils.applyWindowInsetsForFloatingActionButton(insets, resources, view)
         }
+        buttonAddCollaborator.setOnLongClickListener {
+            viewModel.longClickAddCollaborator()
+            true
+        }
 
         empty.image.setImageResource(R.drawable.ic_collaborate_24dp)
         empty.title.text = getString(R.string.no_collaborators)
@@ -128,10 +133,18 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
         viewModel.event.observe(this@CollaboratorsActivity, { event ->
             when (event) {
                 is Event.AddCollaboratorEvent -> showAddCollaboratorFragment(event)
+                is Event.LongAddCollaboratorEvent -> showLongAddToast()
                 is Event.RemoveCollaboratorEvent -> showRemoveCollaboratorDialog(event)
                 Event.CloseCollaboratorsEvent -> finish()
             }
         })
+    }
+
+    private fun ActivityCollaboratorsBinding.showLongAddToast() {
+        if (buttonAddCollaborator.isHapticFeedbackEnabled) {
+            buttonAddCollaborator.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+        }
+        toast(R.string.add_collaborator)
     }
 
     private fun ActivityCollaboratorsBinding.handleCollaboratorsList(collaborators: List<String>) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModel.kt
@@ -62,6 +62,10 @@ class CollaboratorsViewModel @Inject constructor(
         _event.value = Event.AddCollaboratorEvent(noteId)
     }
 
+    fun longClickAddCollaborator() {
+        _event.postValue(Event.LongAddCollaboratorEvent)
+    }
+
     fun clickRemoveCollaborator(collaborator: String) {
         _event.value = Event.RemoveCollaboratorEvent(collaborator)
     }
@@ -102,6 +106,7 @@ class CollaboratorsViewModel @Inject constructor(
     sealed class Event {
         data class AddCollaboratorEvent(val noteId: String) : Event()
         object CloseCollaboratorsEvent : Event()
+        object LongAddCollaboratorEvent : Event()
         data class RemoveCollaboratorEvent(val collaborator: String) : Event()
     }
 }

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModelTest.kt
@@ -128,6 +128,13 @@ class CollaboratorsViewModelTest {
     }
 
     @Test
+    fun longClickAddCollaboratorShouldTriggerLongAddCollaboratorEVent() {
+        viewModel.longClickAddCollaborator()
+
+        assertEquals(viewModel.event.value, Event.LongAddCollaboratorEvent)
+    }
+
+    @Test
     fun clickRemoveCollaboratorShouldTriggerEventAddCollaborator() {
         val collaborator = "test@emil.com"
         viewModel.clickRemoveCollaborator(collaborator)


### PR DESCRIPTION
### Fix
Add a toast message to the ***Add Collaborator*** floating action button long click on the ***Collaborators*** screen.  The behavior and test mimic the existing ***Add Tag*** floating action button long click on the ***Edit Tags*** screen. 
 See the videos below for illustration.

<details>
    <summary>
        <h3>Videos</h3>
    </summary>
    <table>
        <tr>
            <th>Before</th>
            <th>After</th>
        </tr>
        <tr>
            <td><video src="https://github.com/user-attachments/assets/663e1235-cd5f-4bd7-a825-2c08f0e541a2" /></td>
            <td><video src="https://github.com/user-attachments/assets/d23d196b-fc1d-4759-9534-c86c931ef1c0" /></td>
        </tr>
    </table>
</details>

Relates: #1752

### Test
1. Tap any note in list.
2. Tap ellipsis/overflow button in top app bar.
3. Tap ***Collaborators*** item in menu.
4. Long-press ***Add Collaborator*** floating action button.
5. Notice ***Add Collaborator*** toast.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.