### PR TITLE
Add Debug Credentials Again

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/NewCredentialsActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/NewCredentialsActivity.kt
@@ -25,6 +25,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
+import com.automattic.simplenote.BuildConfig
 import com.automattic.simplenote.R
 import com.automattic.simplenote.ThemedAppCompatActivity
 import com.automattic.simplenote.utils.AccountNetworkUtils
@@ -110,6 +111,13 @@ open class NewCredentialsActivity : ThemedAppCompatActivity() {
 
         if (this.intent.extras != null && this.intent.hasExtra("EXTRA_IS_LOGIN")) {
             this.isLogin = this.intent.getBooleanExtra("EXTRA_IS_LOGIN", false)
+        }
+
+        if (BuildConfig.DEBUG && isLogin) {
+            inputEmail = findViewById<View>(R.id.input_email) as TextInputLayout
+            inputEmail?.editText?.setText(BuildConfig.LOGIN_EMAIL)
+            inputPassword = findViewById<View>(R.id.input_password) as TextInputLayout
+            inputPassword?.editText?.setText(BuildConfig.LOGIN_PASSWORD)
         }
 
         val toolbar = findViewById<View>(R.id.toolbar) as Toolbar


### PR DESCRIPTION
### Fix
Add populating the values of the `loginEmail` and `loginPassword` items in the `gradle.properties` file in the email and password fields for debug builds.  If the values are set in `gradle.properties`,  they will be inserted into the fields for the login flow.  Otherwise, the fields will be empty.

These same changes were added previously in [***Add Debug Credentials***](https://github.com/Automattic/simplenote-android/pull/966), but they were removed when [`SimplenoteCredentialsActivity.java` was replaced with `NewCredentialsActivity.kt`](https://github.com/Automattic/simplenote-android/pull/1671).

### Test
0. Clear app data.
1. Tap ***Sign Up*** button.
2. Notice ***Email*** field is empty.
3. Tap back arrow in app bar.
4. Tap ***Log In*** button.
5. Tap "We'll email you a code..." button.
6. Notice ***Email*** and ***Password*** fields are populated with `loginEmail`  and `loginPassword` values from `gradle.properties`.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.