### PR TITLE
Allow admin push on release/ branch

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -67,7 +67,7 @@ platform :android do
       to_branch: computed_release_branch_name
     )
     # But allow admins to bypass restrictions, so that wpmobilebot can push to the release branch directly for beta version bumps
-    set_branch_protection(branch: computed_release_branch_name, enforce_admins: false)
+    set_branch_protection(repository: GITHUB_REPO, branch: computed_release_branch_name, enforce_admins: false)
 
     freeze_milestone_and_move_assigned_prs_to_next_milestone(
       milestone_to_freeze: new_version_final,

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -60,11 +60,14 @@ platform :android do
       set_upstream: is_ci == false # only set upstream when running locally, useless in transient CI builds
     )
 
+    # Copy the branch protection settings from the default branch to the new release branch
     copy_branch_protection(
       repository: GITHUB_REPO,
       from_branch: DEFAULT_BRANCH,
       to_branch: computed_release_branch_name
     )
+    # But allow admins to bypass restrictions, so that wpmobilebot can push to the release branch directly for beta version bumps
+    set_branch_protection(branch: computed_release_branch_name, enforce_admins: false)
 
     freeze_milestone_and_move_assigned_prs_to_next_milestone(
       milestone_to_freeze: new_version_final,


### PR DESCRIPTION
Closes AINFRA-1120

## Why

@mzorz encountered an issue during the last `complete_code_freeze` because the `release/*` branch was already protected by the time `complete-code_freeze` [tried to push some changes to update the release notes for translations](https://github.com/Automattic/simplenote-android/blob/trunk/fastlane/lanes/release.rb#L99-L107).

```
remote: error: GH006: Protected branch update failed for refs/heads/release/2.36.        
remote: 
remote: - Changes must be made through a pull request.        
remote: 
remote: - 2 of 2 required status checks are expected.        
To http://github.com:Automattic/simplenote-android.git|github.com:Automattic/simplenote-android.git
 ! [remote rejected]   release/2.36 -> release/2.36 (protected branch hook declined)
error: failed to push some refs to 'http://github.com:Automattic/simplenote-android.git|github.com:Automattic/simplenote-android.git'
```

In practice, we need the wpmobile-bot to be able to push directly to the `release/` branch not only during `complete_code_freeze` but also during other parts of the release automation, especially during `new_beta_release` that needs to push the version bump of `version.properties` without needing to do a pull request.

## Fix

After having copied the branch protection settings from `trunk` to the newly-created `release/*` branch during `start_code_freeze`, we now make an additional call to `set_branch_protection` that allows admins to bypass those branch protections. Given the bot has admin role, this should resolve the issue.

📝  Note that this is the same approach that we already applied to other repos and `Fastfile` (like in [`pocket-casts-android`](https://github.com/Automattic/pocket-casts-android/blob/main/fastlane/Fastfile#L144-L147) and [`pocket-casts-ios`](https://github.com/Automattic/pocket-casts-ios/blob/trunk/fastlane/Fastfile#L332-L335)), which is where I copied the code comments from.

## Test

We'll only be able to fully test those changes during the next `start_code_freeze`, which will only happen during the next release, as the current release for 2.36 has already started and already run `start_code_freeze` and applied the branch protections.

For the time being, I have manually edited the current branch protection settings of `release/2.36` in GitHub Settings to uncheck the "Do not allow bypassing the above settings" box manually, then retried [the task running the `complete_code_freeze` step from ReleasesV2](https://mc.a8c.com/releases-v2/release.php?product=SimplenoteAndroid&version=2.36#task-12ca3ed8-aae7-438a-aa6e-b0af7055bf28-fragment), which [succeeded](https://buildkite.com/automattic/simplenote-android/builds/525/annotations?sid=0198998c-9c94-440d-b61b-44c0bca9e807) this time (and both triggered [the expected beta build](https://buildkite.com/automattic/simplenote-android/builds/526/steps/canvas) and created [the expected backmerge PR](https://github.com/Automattic/simplenote-android/pull/1757)), confirming that such update of the branch protection settings will solve the issue in future releases too.

<img width="783" height="90" alt="image" src="https://github.com/user-attachments/assets/f5dc0286-0582-4b47-9928-83204880dfc4" />
