### PR TITLE
History and Share Bottom Sheets Do Appear Manually and Do Not Reappear Automatically After Dismiss

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1303,24 +1303,18 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onSharePublishClicked() {
         publishNote();
-        if (mShareBottomSheet != null) {
-            mShareBottomSheet.dismiss();
-        }
+        dismissBottomSheet(mShareBottomSheet);
     }
 
     @Override
     public void onShareUnpublishClicked() {
         unpublishNote();
-        if (mShareBottomSheet != null) {
-            mShareBottomSheet.dismiss();
-        }
+        dismissBottomSheet(mShareBottomSheet);
     }
 
     @Override
     public void onWordPressPostClicked() {
-        if (mShareBottomSheet != null) {
-            mShareBottomSheet.dismiss();
-        }
+        dismissBottomSheet(mShareBottomSheet);
 
         if (getFragmentManager() == null) {
             return;
@@ -1346,9 +1340,7 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     @Override
     public void onShareDismissed() {
-        if (mShareBottomSheet != null) {
-            mShareBottomSheet.dismiss();
-        }
+        dismissBottomSheet(mShareBottomSheet);
     }
 
     /**
@@ -1358,28 +1350,22 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onHistoryCancelClicked() {
         mContentEditText.setText(mNote.getContent());
-        if (mHistoryBottomSheet != null) {
-            mHistoryBottomSheet.dismiss();
-        }
+        dismissBottomSheet(mHistoryBottomSheet);
     }
 
     @Override
     public void onHistoryRestoreClicked() {
-        if (mHistoryBottomSheet != null) {
-            mHistoryBottomSheet.dismiss();
-        }
+        dismissBottomSheet(mHistoryBottomSheet);
         saveAndSyncNote();
     }
 
     @Override
     public void onHistoryDismissed() {
-        if (mHistoryBottomSheet != null) {
-            if (!mHistoryBottomSheet.didTapOnButton()) {
-                mContentEditText.setText(mNote.getContent());
-            }
-
-            mHistoryBottomSheet.dismiss();
+        if (mHistoryBottomSheet != null && !mHistoryBottomSheet.didTapOnButton()) {
+            mContentEditText.setText(mNote.getContent());
         }
+
+        dismissBottomSheet(mHistoryBottomSheet);
 
         if (mHistoryTimeoutHandler != null) {
             mHistoryTimeoutHandler.removeCallbacks(mHistoryTimeoutRunnable);
@@ -1389,6 +1375,12 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
     @Override
     public void onHistoryUpdateNote(String content) {
         mContentEditText.setText(content);
+    }
+
+    private void dismissBottomSheet(BottomSheetDialogBase bottomSheet) {
+        if (bottomSheet != null) {
+            bottomSheet.dismiss();
+        }
     }
 
     private void saveNote() {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1371,8 +1371,12 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     @Override
     public void onHistoryDismissed() {
-        if (!mHistoryBottomSheet.didTapOnButton()) {
-            mContentEditText.setText(mNote.getContent());
+        if (mHistoryBottomSheet != null) {
+            if (!mHistoryBottomSheet.didTapOnButton()) {
+                mContentEditText.setText(mNote.getContent());
+            }
+
+            mHistoryBottomSheet.dismiss();
         }
 
         if (mHistoryTimeoutHandler != null) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/NoteEditorFragment.java
@@ -1346,7 +1346,9 @@ public class NoteEditorFragment extends Fragment implements Bucket.Listener<Note
 
     @Override
     public void onShareDismissed() {
-
+        if (mShareBottomSheet != null) {
+            mShareBottomSheet.dismiss();
+        }
     }
 
     /**


### PR DESCRIPTION
### Fix
***History*** and ***Share*** bottom sheets do appear when triggered manually and do not reappear automatically after being dismissed.  See the videos below for illustration.

<details>
    <summary>
        <h3>Videos</h3>
    </summary>
    <table>
        <tr>
            <th>
                Sheet
            </th>
            <th>
                Before
            </th>
            <th>
                After
            </th>
        </tr>
        <tr>
            <td>
                History
            </td>
            <td>
                <video src="https://github.com/user-attachments/assets/7a0490a8-8228-477b-a98c-ce7249c521c4" />
            </td>
            <td>
                <video src="https://github.com/user-attachments/assets/031cd638-df44-4ebb-acb9-075b0f0c4396" />
            </td>
        </tr>
        <tr>
            <td>
                Share
            </td>
            <td>
                <video src="https://github.com/user-attachments/assets/c82cc00e-047c-4064-b4df-06db82b9f392" />
            </td>
            <td>
                <video src="https://github.com/user-attachments/assets/7dbd7883-994b-4bff-809b-d8e8c7a8a35a" />
            </td>
        </tr>
    </table>
</details>

Closes: https://github.com/Automattic/simplenote-android/issues/1765

### Test
Follow the steps below with the ***History*** and ***Share*** menu items.

1. Tap any note in list.
2. Tap ellipsis/overflow icon in top app bar.
3. Tap ***History*** or ***Share*** item in menu.
4. Notice ***History*** or ***Share*** sheet is shown.
5. Tap outside ***History*** or ***Share*** sheet.
6. Notice ***History*** or ***Share*** sheet is hidden.
7. Tap ellipsis/overflow icon in top app bar.
8. Tap ***History*** or ***Share*** item in menu.
9. Noice ***History*** or ***Share*** sheet is shown.
10. Tap outside ***History*** or ***Share*** sheet.
11. Notice ***History*** or ***Share*** sheet is hidden.
12. Tap ellipsis/over icon in top app bar.
13. Tap ***Collaborators*** item in menu.
14. Tap back arrow in top app bar.
15. Notice ***History*** or ***Share*** sheet is not shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.