### PR TITLE
[Tooling] Use Release Version from ReleasesV2 in Code Freeze

### DIFF
--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -17,7 +17,7 @@ steps:
       install_gems
 
       echo '--- :shipit: Start code freeze'
-      bundle exec fastlane start_code_freeze skip_confirm:true
+      bundle exec fastlane start_code_freeze version:"${RELEASE_VERSION}" skip_confirm:true
     retry:
       manual:
         # If failed, we prefer retrying via ReleaseV2 rather than Buildkite.

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -5,7 +5,8 @@
 platform :android do
   # Creates a new release branch from the current default branch
   #
-  # @param [String] version (optional) The version number for the release from the release tool. If not provided, uses the calculated version.
+  # @param [String] version (optional) The version to use for the new release version to code freeze for.
+  #                 Typically auto-provided by ReleasesV2. If nil, computes the new version based on current one.
   # @param [Boolean] skip_prechecks (default: false) If set, will skip prechecks
   # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt
   #
@@ -15,16 +16,20 @@ platform :android do
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
     new_version_with_beta = release_version_for_code_freeze
-    calculated_version = release_version_next
+    computed_version = release_version_next
     new_build_code = build_code_next
 
-    # Use provided version from release tool, or fall back to calculated version
-    release_version = version || calculated_version
-    computed_release_branch_name = release_branch_name(release_version: release_version)
+    # Use provided version from release tool, or fall back to computed version
+    new_version = version || computed_version
+    computed_release_branch_name = release_branch_name(release_version: new_version)
 
-    # Warn if provided version differs from calculated version
-    if version && version != calculated_version
-      warning_message = "⚠️ Version mismatch: Release tool version is '#{version}' but calculated version is '#{calculated_version}'. Using '#{version}' from release tool."
+    # Warn if provided version differs from computed version
+    if version && version != computed_version
+      warning_message = <<~WARNING
+        ⚠️ Version mismatch: The explicitly-provided version was '#{version}' while new computed version would have been '#{computed_version}'.
+        If this is unexpected, you might want to investigate the discrepency.
+        Continuing with the explicitly-provided verison '#{version}'.
+      WARNING
       UI.important(warning_message)
       buildkite_annotate(style: 'warning', context: 'start-code-freeze-version-mismatch', message: warning_message) if is_ci
     end
@@ -52,8 +57,6 @@ platform :android do
       version_code: new_build_code
     )
     commit_version_bump
-
-    new_version = release_version_current
     UI.success("Done! New beta version: #{new_version}. New build code: #{build_code_current}.")
 
     extract_release_notes_for_version(

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -10,15 +10,19 @@ platform :android do
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
     new_version_with_beta = release_version_for_code_freeze
-    new_version_final = release_version_next
+    calculated_version = release_version_next
     new_build_code = build_code_next
-    computed_release_branch_name = release_branch_name(release_version: new_version_final)
 
-    # Validate provided version matches the calculated version
-    if version && version != new_version_final
-      UI.user_error!("Version mismatch: Provided version '#{version}' does not match calculated version '#{new_version_final}'. Please check the release scenario version matches the project version.")
+    # Use provided version from release tool, or fall back to calculated version
+    release_version = version || calculated_version
+    computed_release_branch_name = release_branch_name(release_version: release_version)
+
+    # Warn if provided version differs from calculated version
+    if version && version != calculated_version
+      warning_message = "⚠️ Version mismatch: Release tool version is '#{version}' but calculated version is '#{calculated_version}'. Using '#{version}' from release tool."
+      UI.important(warning_message)
+      buildkite_annotate(style: 'warning', context: 'start-code-freeze-version-mismatch', message: warning_message) if is_ci
     end
-    UI.success("✓ Version validation passed: Version (#{version || new_version_final}) matches calculated version") if version
 
     message = <<~MESSAGE
       Code Freeze:

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -3,7 +3,12 @@
 # Lanes related to the Release Process (Code Freeze, Betas, Final Build, App Store Submission…)
 
 platform :android do
-  desc 'Creates a new release branch from the current default branch'
+  # Creates a new release branch from the current default branch
+  #
+  # @param [String] version (optional) The version number for the release from the release tool. If not provided, uses the calculated version.
+  # @param [Boolean] skip_prechecks (default: false) If set, will skip prechecks
+  # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt
+  #
   lane :start_code_freeze do |version: nil, skip_prechecks: false, skip_confirm: false|
     ensure_git_status_clean unless skip_prechecks || is_ci
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -4,7 +4,7 @@
 
 platform :android do
   desc 'Creates a new release branch from the current default branch'
-  lane :start_code_freeze do |skip_prechecks: false, skip_confirm: false|
+  lane :start_code_freeze do |version: nil, skip_prechecks: false, skip_confirm: false|
     ensure_git_status_clean unless skip_prechecks || is_ci
 
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
@@ -13,6 +13,12 @@ platform :android do
     new_version_final = release_version_next
     new_build_code = build_code_next
     computed_release_branch_name = release_branch_name(release_version: new_version_final)
+
+    # Validate provided version matches the calculated version
+    if version && version != new_version_final
+      UI.user_error!("Version mismatch: Provided version '#{version}' does not match calculated version '#{new_version_final}'. Please check the release scenario version matches the project version.")
+    end
+    UI.success("✓ Version validation passed: Version (#{version || new_version_final}) matches calculated version") if version
 
     message = <<~MESSAGE
       Code Freeze:


### PR DESCRIPTION
Closes [AINFRA-1381: SNAndroid: Validate that release version sent by ReleasesV2 matches the project](https://linear.app/a8c/issue/AINFRA-1381/snandroid-validate-that-release-version-sent-by-releasesv2-matches-the)

## Description

This PR updates the code freeze process to use the release version provided by ReleasesV2 as the source of truth.

The code freeze Buildkite pipeline now passes the `RELEASE_VERSION` environment variable to the `start_code_freeze` Fastlane lane.
If there's a mismatch between the passed version and the project calculated version, a warning is displayed to help identify configuration discrepancies, but the ReleasesV2 version is always used.

## Testing

The code freeze lane has several side effects like potentially changing the version in the main branch, creating a release branch, updating release notes, etc, making it hard to easily test it. We can run a couple of tests locally commenting out parts of the lane, but they'll only test a minor part of the lane.
The changes will then be fully tested in the next release cycle during code freeze.