### PR TITLE
Fix crash when opening settings after upgrading from previous version and having old theme selected

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/PreferencesFragment.java
@@ -215,9 +215,6 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements Use
             }
 
             private void updateTheme(Activity activity, int index) {
-                CharSequence[] entries = themePreference.getEntries();
-                themePreference.setSummary(entries[index]);
-
                 AnalyticsTracker.track(
                         AnalyticsTracker.Stat.SETTINGS_THEME_UPDATED,
                         AnalyticsTracker.CATEGORY_USER,

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/SafeThemeListPreference.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/SafeThemeListPreference.kt
@@ -1,0 +1,42 @@
+package com.automattic.simplenote.utils
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.preference.ListPreference
+
+/**
+ * Custom ListPreference that handles invalid index values to prevent ArrayIndexOutOfBoundsException.
+ * This preference safely handles cases where the stored value doesn't match any of the available entries.
+ */
+class SafeThemeListPreference @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = androidx.preference.R.attr.preferenceStyle,
+    defStyleRes: Int = 0
+) : ListPreference(context, attrs, defStyleAttr, defStyleRes) {
+
+    override fun getSummary(): CharSequence? {
+        val value = getValue()
+        val entries = getEntries()
+        
+        if (entries == null || entries.isEmpty()) {
+            return super.getSummary()
+        }
+        
+        val index = findIndexOfValue(value)
+        
+        // If index is invalid (out of bounds or -1), fallback to default value
+        return if (index >= 0 && index < entries.size) {
+            entries[index]
+        } else {
+            // Get the default value (2 = theme_system) and return its entry
+            val defaultIndex = findIndexOfValue("2")
+            if (defaultIndex >= 0 && defaultIndex < entries.size) {
+                entries[defaultIndex]
+            } else {
+                // Ultimate fallback - return the first entry
+                entries[0]
+            }
+        }
+    }
+}

--- a/Simplenote/src/main/res/xml/preferences.xml
+++ b/Simplenote/src/main/res/xml/preferences.xml
@@ -41,15 +41,14 @@
         android:key="pref_key_appearance_preferences"
         android:title="@string/appearance">
 
-        <ListPreference
+        <com.automattic.simplenote.utils.SafeThemeListPreference
             android:key="pref_key_theme"
             android:defaultValue="2"
             android:entries="@array/array_theme_names"
             android:entryValues="@array/array_theme_values"
-            android:summary="%s"
             android:title="@string/theme"
             tools:summary="@string/theme_system">
-        </ListPreference>
+        </com.automattic.simplenote.utils.SafeThemeListPreference>
 
         <Preference
             android:key="pref_key_style"


### PR DESCRIPTION
Closes https://github.com/Automattic/simplenote-android/issues/1772

### Fix

**What was happening**
ListPreference crashes on resume because a deprecated theme value stored in SharedPreferences is an invalid index for the newly shortened resource array.

User selects 'Auto' theme (value 2) before it was deprecated.
The user's preference is stored in SharedPreferences. In an older version, the theme options included 'Auto' which corresponded to a value that is now invalid or points to a different entry.

The 'Auto' theme was removed in commit c43d0ad. The array_theme_values for API 29+ now only contains 3 items (0, 1, 2), but the user's stored value might be 3 (System) or 2 (Auto, which is now System).
<!-- Simplenote/src/main/res/values-v29/arrays.xml (Current State) -->
<string-array name="array_theme_values">
    <item>0</item> <!-- Light -->
    <item>1</item> <!-- Dark -->
    <item>2</item> <!-- System -->
</string-array>

**Fix:**
Added a workaround to comply with existing saved preference where the options array included more values than the new array has in newer versions, so this ListPreference extension checks for bounds to prevent IOBException and defaults to the system value


### Test
1. download the previous version of Simplenote and install it on your phone 2.34 https://github.com/Automattic/simplenote-android/releases/tag/2.34
2. login with an account with data
3. go to settings and select Theme "System" (fourth option)
4. exit settings
5. now create a release build on this branch and update the app on the same device:
go to Build -> Generate Signed App Bundle or APK, choose APK, then populate the fields with the secret store data in gradle.properties, or ping me for to DM you a signed APK.
6. observe you can go to settings and it doesn't crash


In the following video I show you all 3 updates:
1. old version 2.34 working, saving to use the fourth theme option.
2. then installing 2.36 and attempting to go to settings -> observe it crashes
3. then installing the fix (built a signed release version locally), opening settings and it works.

https://github.com/user-attachments/assets/404810e4-812c-429d-8ca7-98322c438a2f





### Review
<!--
***(Required)*** Add instructions for reviewers.  For example:
Only one developer and one designer are required to review these changes, but anyone can perform the review.
-->

### Release
<!--
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.txt` was updated in d3adb3ef with:
> Added markdown support
-->
<!--
If the changes should not be included in release notes, add a statement to this section. For example:
These changes do not require release notes.
-->
