### PR TITLE
Fastlane: referencing the right variable

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -88,7 +88,7 @@ platform :android do
     set_branch_protection(repository: GITHUB_REPO, branch: computed_release_branch_name, enforce_admins: false)
 
     freeze_milestone_and_move_assigned_prs_to_next_milestone(
-      milestone_to_freeze: new_version_final,
+      milestone_to_freeze: new_version,
       next_milestone: release_version_next
     )
 


### PR DESCRIPTION
### Fix
I’m looking to prepare a [new build](https://mc.a8c.com/releases-v2/release.php?product=SimplenoteAndroid&version=2.37) for Simplenote Android, but it failed the code freeze step in fastlane since it seems the .rb code is [referencing an undefined variable](https://buildkite.com/automattic/simplenote-android/builds/559#0199f68e-5875-4def-b8ee-14e019f8ecae). I tried fixing it on trunk but I can’t push to trunk since it’s a protected branch.

Preparing a PR and will look for someone to merge - I hope that's the only problem with fastlane!

### Test
N/A

### Review
<!--
***(Required)*** Add instructions for reviewers.  For example:
Only one developer and one designer are required to review these changes, but anyone can perform the review.
-->

### Release
<!--
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.txt` was updated in d3adb3ef with:
> Added markdown support
-->
<!--
If the changes should not be included in release notes, add a statement to this section. For example:
These changes do not require release notes.
-->
