### PR TITLE
Improves the back button behaviour during manual login

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 2.38
 -----
-
+* Fixed back button navigation during manual login to return to the login screen instead of the home screen [#1751](https://github.com/Automattic/simplenote-android/issues/1751)
 
 2.37
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/NewCredentialsActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/NewCredentialsActivity.kt
@@ -93,8 +93,6 @@ open class NewCredentialsActivity : ThemedAppCompatActivity() {
 
     override fun onBackPressed() {
         super.onBackPressed()
-        this.startActivity(Intent(this, SimplenoteAuthenticationActivity::class.java))
-        finish()
     }
 
     @SuppressLint("RestrictedApi")

--- a/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/authentication/SignInFragment.kt
@@ -44,6 +44,12 @@ class SignInFragment: MagicLinkableFragment() {
 
     private var authService: AuthorizationService? = null
 
+    private var manualLoginLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            activity?.finish()
+        }
+    }
+
     private var resultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
 
         val data = result.data
@@ -118,7 +124,7 @@ class SignInFragment: MagicLinkableFragment() {
         }
         manualLoginTextView.setOnClickListener {
             val email = getEmailEditText()
-            showLoginWithPassword(activity, email?.text?.toString())
+            launchManualLogin(email?.text?.toString())
         }
         return view
     }
@@ -133,7 +139,7 @@ class SignInFragment: MagicLinkableFragment() {
                     hideDialogProgress()
                     if (state.code == 429) {
                         val email = getEmailEditText()
-                        showLoginWithPassword(activity, email?.text?.toString())
+                        launchManualLogin(email?.text?.toString())
                     }
                     Toast.makeText(context, getString(state.messageRes), Toast.LENGTH_LONG).show()
                 }
@@ -166,9 +172,20 @@ class SignInFragment: MagicLinkableFragment() {
         }
     }
 
+    private fun launchManualLogin(username: String?) {
+        val intent = Intent(requireActivity(), NewCredentialsActivity::class.java)
+        intent.putExtra("EXTRA_IS_LOGIN", true)
+        if (!username.isNullOrBlank()) {
+            intent.putExtra(Intent.EXTRA_EMAIL, username)
+            intent.putExtra(NewCredentialsActivity.PREF_HIDE_EMAIL_FIELD, true)
+        }
+        manualLoginLauncher.launch(intent)
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         resultLauncher.unregister()
+        manualLoginLauncher.unregister()
         authService?.dispose()
     }
 


### PR DESCRIPTION
Fixes the way the back button works on the password login page

### Fix

Fixes the way the back button works on the password login page

Addresses https://github.com/Automattic/simplenote-android/issues/1751


<table>
<tr>
<td width="50%">Before</td>
<td width="50%">After</td>
</tr>
<tr>
<td width="50%">

https://github.com/user-attachments/assets/c0226425-4d60-4204-83ab-bb21294aac41

</td>
<td width="50%">

https://github.com/user-attachments/assets/6f05c129-1d12-4a59-9dcc-de229889cc5e

</td>
</tr>
</table>

### Test

1. Log out of the app if already logged in
2. On the app homescreen, press 'Log In'
3. Click then on 'log in manually'
4. Press the back arrow on the top of the screen, or use Android gestures/back navigation button to go back
5. Notice it will now take you back to the log in page, instead of the homepage




### Review

Please verify if the manual login functionality works as expected after actually logging in. I can't test this since I do not have a Simperium staging account to confirm what happens after logging in. 

### Release

> Issue #1751: Back button navigation during manual login


