### PR TITLE
[Tooling] Use ReleasesV2 version as the source of truth during Code Freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -260,14 +260,17 @@ def release_version_next
   VERSION_FORMATTER.release_version(release_version_next)
 end
 
-# Compute the version to be used by the code freeze step in the release process.
+# Returns the initial beta version for a code freeze (e.g., "1.2-rc-1" for release version "1.2")
+# Increments the build number from 0 to 1 to create the first release candidate
 #
-# It first increments the minor number, which also resets the build number to 0.
-# It then bumps the build number so the -rc-1 can be appended to the code freeze version.
 def release_version_for_code_freeze(version_name: nil)
+  # Use provided version or read the current version from version.properties
   version_name ||= VERSION_FILE.read_version_name
+  # Parse the version string (e.g., "1.2") into an AppVersion object
   version = VERSION_FORMATTER.parse(version_name)
+  # Increment the build number to 1 to get the first beta version
   beta_version_first = VERSION_CALCULATOR.next_build_number(version: version)
+  # Format as beta version (e.g., "1.2-rc-1")
   VERSION_FORMATTER.beta_version(beta_version_first)
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -264,10 +264,10 @@ end
 #
 # It first increments the minor number, which also resets the build number to 0.
 # It then bumps the build number so the -rc-1 can be appended to the code freeze version.
-def release_version_for_code_freeze
-  current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_version_name)
-  next_version = VERSION_CALCULATOR.next_release_version(version: current_version)
-  beta_version_first = VERSION_CALCULATOR.next_build_number(version: next_version)
+def release_version_for_code_freeze(version_name: nil)
+  version_name ||= VERSION_FILE.read_version_name
+  version = VERSION_FORMATTER.parse(version_name)
+  beta_version_first = VERSION_CALCULATOR.next_build_number(version: version)
   VERSION_FORMATTER.beta_version(beta_version_first)
 end
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -23,15 +23,17 @@ platform :android do
     new_version = version || computed_version
     computed_release_branch_name = release_branch_name(release_version: new_version)
 
-    # Warn if provided version differs from computed version
+    # Fail if provided version differs from computed version
     if version && version != computed_version
-      warning_message = <<~WARNING
-        ⚠️ Version mismatch: The explicitly-provided version was '#{version}' while new computed version would have been '#{computed_version}'.
-        If this is unexpected, you might want to investigate the discrepency.
-        Continuing with the explicitly-provided verison '#{version}'.
-      WARNING
-      UI.important(warning_message)
-      buildkite_annotate(style: 'warning', context: 'start-code-freeze-version-mismatch', message: warning_message) if is_ci
+      error_message = <<~ERROR
+        ❌ Version mismatch detected!
+
+        The explicitly-provided version from the release tool is '#{version}' but the computed version from the codebase is '#{computed_version}'.
+
+        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
+      ERROR
+      buildkite_annotate(style: 'error', context: 'start-code-freeze-version-mismatch', message: error_message) if is_ci
+      UI.user_error!(error_message)
     end
 
     message = <<~MESSAGE

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -15,32 +15,20 @@ platform :android do
 
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    new_version_with_beta = release_version_for_code_freeze
-    computed_version = release_version_next
+    # If a new version is passed, use it as source of truth from now on
+    new_version = version || release_version_next
+    computed_release_branch_name = release_branch_name(release_version: new_version)
+    new_version_with_beta = release_version_for_code_freeze(version_name: new_version)
     new_build_code = build_code_next
 
-    # Use provided version from release tool, or fall back to computed version
-    new_version = version || computed_version
-    computed_release_branch_name = release_branch_name(release_version: new_version)
-
-    # Fail if provided version differs from computed version
-    if version && version != computed_version
-      error_message = <<~ERROR
-        ❌ Version mismatch detected!
-
-        The explicitly-provided version from the release tool is '#{version}' but the computed version from the codebase is '#{computed_version}'.
-
-        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
-      ERROR
-      buildkite_annotate(style: 'error', context: 'start-code-freeze-version-mismatch', message: error_message) if is_ci
-      UI.user_error!(error_message)
-    end
-
     message = <<~MESSAGE
+
       Code Freeze:
       - New release branch from #{DEFAULT_BRANCH}: #{computed_release_branch_name}
+
       - Current release version and build code: #{release_version_current} (#{build_code_current}).
       - New beta version and build code: #{new_version_with_beta} (#{new_build_code}).
+
     MESSAGE
     UI.important(message)
 
@@ -48,6 +36,8 @@ platform :android do
       UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.")
       next
     end
+
+    ensure_branch_does_not_exist!(computed_release_branch_name)
 
     UI.message 'Creating release branch...'
     Fastlane::Helper::GitHelper.create_branch(computed_release_branch_name)
@@ -101,7 +91,7 @@ platform :android do
 
       Next steps:
 
-      - Checkout `#{release_branch_name}` branch locally
+      - Checkout `#{computed_release_branch_name}` branch locally
       - Update the simperium dependency to a stable version if needed
       - Update the release notes that were extracted from RELEASE-NOTES.txt if appropriate
       - Finalize the code freeze
@@ -391,4 +381,15 @@ def delete_remote_git_branch!(branch_name, remote: 'origin')
   remove_branch_protection(repository: GITHUB_REPO, branch: branch_name)
 
   Git.open(Dir.pwd).push(remote, branch_name, delete: true)
+end
+
+def ensure_branch_does_not_exist!(branch_name)
+  return unless Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: branch_name)
+
+  error_message = "The branch `#{branch_name}` already exists. Please check first if there is an existing Pull Request that needs to be merged or closed first, " \
+                  'or delete the branch to then run again the release task.'
+
+  buildkite_annotate(style: 'error', context: 'error-checking-branch', message: error_message) if is_ci
+
+  UI.user_error!(error_message)
 end


### PR DESCRIPTION
See AINFRA-1478

## Description

This PR enhances the version handling added in the previous iteration to assume the version received by the code freeze lane as the source of truth, ignoring potential mismatches between the ReleasesV2 version and the project's computed version.

## Testing

You can make sure the calculated release branch, current version and the next version are correctly shown in the "Continue" prompt. Just **remember to answer `N` when asked to continue**, to cancel the actual code freeze.

To avoid unexpected results, comment out the lines doing `ensure_git_status_clean` and `Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)` at the beginning of the lane.

You can run the `start_code_freeze` lane, with and without the version parameters:
- Run `bundle exec fastlane start_code_freeze` 
- Run `bundle exec fastlane start_code_freeze version:30.6`

This will be fully tested in the next release cycle during code freeze.