### PR TITLE
[Tooling] Improve `new_hotfix_release` lane to work when there's no release tag

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -82,9 +82,18 @@ platform :android do
     previous_version = VERSION_FORMATTER.release_version(
       VERSION_CALCULATOR.previous_patch_version(version: VERSION_FORMATTER.parse(new_version))
     )
+    previous_release_branch = release_branch_name(release_version: previous_version)
 
     UI.user_error!("The version `#{new_version}` tag already exists!") if git_tag_exists(tag: new_version)
-    UI.user_error!("Version #{previous_version} is not tagged! A hotfix branch cannot be created.") unless git_tag_exists(tag: previous_version)
+
+    # Determine the base for the hotfix branch: either a tag or a release branch
+    base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
+                            previous_version
+                          elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
+                            previous_release_branch
+                          else
+                            UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")
+                          end
 
     message = <<~MESSAGE
       Hotfix release:
@@ -94,14 +103,14 @@ platform :android do
       - Current build code: #{build_code_current}
       - New build code: #{version_code_new}
 
-      Branching from tag: #{previous_version}
+      Branching from #{base_ref_for_hotfix}
     MESSAGE
     UI.important(message)
 
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
-    UI.message('Creating hotfix branch...')
-    Fastlane::Helper::GitHelper.create_branch(release_branch_name(release_version: new_version), from: previous_version)
+    UI.message("Creating hotfix branch from #{base_ref_for_hotfix}...")
+    Fastlane::Helper::GitHelper.create_branch(release_branch_name(release_version: new_version), from: base_ref_for_hotfix)
     UI.success("Done! New hotfix branch is: #{git_branch}")
 
     UI.message('Bumping hotfix version and build code...')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -113,6 +113,9 @@ platform :android do
 
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
+    # Fetch the base ref to ensure it's available locally
+    sh('git', 'fetch', 'origin', base_ref_for_hotfix)
+
     UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch(release_branch_name(release_version: new_version), from: base_ref_for_hotfix)
     UI.success("Done! New hotfix branch is: '#{git_branch}'")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -116,8 +116,11 @@ platform :android do
     # Fetch the base ref to ensure it's available locally
     sh('git', 'fetch', 'origin', base_ref_for_hotfix)
 
+    hotfix_branch = release_branch_name(release_version: new_version)
+    ensure_branch_does_not_exist!(hotfix_branch)
+
     UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
-    Fastlane::Helper::GitHelper.create_branch(release_branch_name(release_version: new_version), from: base_ref_for_hotfix)
+    Fastlane::Helper::GitHelper.create_branch(hotfix_branch, from: base_ref_for_hotfix)
     UI.success("Done! New hotfix branch is: '#{git_branch}'")
 
     UI.message('Bumping hotfix version and build code...')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -90,6 +90,7 @@ platform :android do
     base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
                             previous_version
                           elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
+                            UI.message("ℹ️  Tag #{previous_version} not found. Using release branch #{previous_release_branch} as the base for hotfix instead.")
                             previous_release_branch
                           else
                             UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,21 +79,24 @@ platform :android do
     new_version = version_name
     version_code_new = version_code
 
+    # Validate that this is a hotfix version (must have a patch component > 0)
+    parsed_version = VERSION_FORMATTER.parse(new_version)
+    UI.user_error!("Invalid hotfix version '#{new_version}'. Must include a patch number.") unless parsed_version.patch.to_i.positive?
     previous_version = VERSION_FORMATTER.release_version(
-      VERSION_CALCULATOR.previous_patch_version(version: VERSION_FORMATTER.parse(new_version))
+      VERSION_CALCULATOR.previous_patch_version(version: parsed_version)
     )
     previous_release_branch = release_branch_name(release_version: previous_version)
 
-    UI.user_error!("The version `#{new_version}` tag already exists!") if git_tag_exists(tag: new_version)
+    UI.user_error!("Version '#{new_version}' already exists on the remote! Abort!") if git_tag_exists(tag: new_version, remote: true)
 
     # Determine the base for the hotfix branch: either a tag or a release branch
-    base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
+    base_ref_for_hotfix = if git_tag_exists(tag: previous_version, remote: true)
                             previous_version
                           elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
-                            UI.message("ℹ️  Tag #{previous_version} not found. Using release branch #{previous_release_branch} as the base for hotfix instead.")
+                            UI.message("ℹ️  Tag '#{previous_version}' not found on the remote. Using release branch '#{previous_release_branch}' as the base for hotfix instead.")
                             previous_release_branch
                           else
-                            UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")
+                            UI.user_error!("Neither tag '#{previous_version}' nor branch '#{previous_release_branch}' exists on the remote! A hotfix branch cannot be created.")
                           end
 
     message = <<~MESSAGE
@@ -110,9 +113,9 @@ platform :android do
 
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
-    UI.message("Creating hotfix branch from #{base_ref_for_hotfix}...")
+    UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch(release_branch_name(release_version: new_version), from: base_ref_for_hotfix)
-    UI.success("Done! New hotfix branch is: #{git_branch}")
+    UI.success("Done! New hotfix branch is: '#{git_branch}'")
 
     UI.message('Bumping hotfix version and build code...')
     VERSION_FILE.write_version(
@@ -121,7 +124,7 @@ platform :android do
     )
     commit_version_bump
     # Print computed version and build to let user double-check outcome in logs
-    UI.success("Done! New release version: #{release_version_current}. New build code: #{build_code_current}.")
+    UI.success("Done! New release version: '#{release_version_current}'. New build code: '#{build_code_current}'.")
 
     UI.important('Pushing new hotfix branch to remote...')
     push_to_git_remote(tags: false)


### PR DESCRIPTION
Related to AINFRA-1518

## Description

This PR aims to add more robustness and require less manual intervention to the hotfix creation lane `new_hotfix_release`.

We have observed that sometimes it is possible that the release has been finalized but a release tag isn't present yet for some reason (likely due to the fact that the release hasn't been published yet), so release managers will get an error and require manual intervention.

This PR changes the code so that it, if not release tag is present, we start the hotfix branch based on the corresponding release branch.

## Testing instructions

These are some test scenarios that can be simulated:
1. There is a release tag that can be used to create the hotfix branch
2. There's no tag, but there's still a release branch that can be used to create the hotfix branch
3. There's no tag or branch (error)
4. The provided version doesn't have a patch component like `30.6` instead of `30.6.1` (error)

To test it, you can create test branches / tags (⚠️ delete them later or, even better, use [this technique](https://github.com/bloom/DayOne-Apple/pull/27670#issuecomment-3553138802) of pointing your working copy’s `origin` remote to a local bare repo instead ⚠️ ) and run `bundle exec fastlane new_hotfix_release skip_confirm:false version_name:$VERSION version_code:$CODE` and then answer `no` after the prompt so that the lane execution stops and check the printed values.

For example:
1. Create and push release branch `release/30.6` (which doesn't exist and has no corresponding tag for that version)
2. Run `bundle exec fastlane new_hotfix_release skip_confirm:false version_name:30.6.1 version_code:9999`
3. It should use the `release/30.6` branch instead of trying to use a tag. It should print:
```
ℹ️  Tag '30.6' not found on the remote. Using release branch 'release/30.6' as the base for hotfix instead.
Hotfix release:
- Current release version: 2.37
- New hotfix version: 30.6.1

- Current build code: 184
- New build code: 9999

Branching from release/30.6

Do you want to continue? (y/n)

```
