### PR TITLE
[Tooling] Migrate release pipelines to mac-metal queue

### DIFF
--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -4,7 +4,7 @@
 # Variables used in this pipeline are defined in `shared-pipeline-vars`, which is `source`'d before calling `buildkite-agent pipeline upload`
 
 agents:
-    queue: tumblr-metal
+    queue: mac-metal
 
 steps:
   - label: Complete Code Freeze

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -17,7 +17,7 @@ steps:
       echo '--- :shipit: Finalize Release'
       bundle exec fastlane finalize_release skip_confirm:true
     agents:
-        queue: tumblr-metal
+        queue: mac-metal
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -20,7 +20,7 @@ steps:
       echo '--- :shipit: New Beta Release'
       bundle exec fastlane new_beta_release skip_confirm:true
     agents:
-        queue: tumblr-metal
+        queue: mac-metal
     retry:
       manual:
         # If failed, we prefer retrying via Releases V2 rather than Buildkite.

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -17,7 +17,7 @@ steps:
       echo '--- :package: Publish Release'
       bundle exec fastlane publish_release skip_confirm:true
     agents:
-      queue: tumblr-metal
+      queue: mac-metal
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -8,7 +8,7 @@ steps:
     plugins:
       - $CI_TOOLKIT_PLUGIN
     agents:
-        queue: tumblr-metal
+        queue: mac-metal
     command: |
       echo '--- :robot_face: Use bot for Git operations'
       source use-bot-for-git


### PR DESCRIPTION
Fixes AINFRA-1664

Migrate release pipeline jobs from `tumblr-metal` to `mac-metal` queue.