### PR TITLE
[Analysis] Update `Aligned16KB` Lint Check Severity to Error

### DIFF
--- a/Simplenote/lint.xml
+++ b/Simplenote/lint.xml
@@ -3,6 +3,7 @@
     <issue id="MissingTranslation" severity="ignore" />
     <issue id="ExtraTranslation" severity="ignore" />
     <issue id="HardcodedText" severity="error" />
+    <issue id="Aligned16KB" severity="error" />
 
     <issue id="MissingPrefix">
         <ignore regexp="Unexpected namespace prefix &quot;app&quot; found for tag `Image.*`" />


### PR DESCRIPTION
Closes: [AINFRA-1817](https://linear.app/a8c/issue/AINFRA-1817)
Reason: pdt0Fp-4dX-p2 + pdt0Fp-4dX-p2#comment-1740

---

### Fix
<!--
***(Required)*** Add a concise description of what you fixed.  If this is related to an issue, add a link to it.  If applicable, add screenshots, animations, or videos to help illustrate the fix.
-->

Add `Aligned16KB` lint check with error severity to ensure 16KB page alignment compliance is enforced at build time.
                                                                                                                                                                         
FYI: Starting with Android 15 (API 35), devices may use 16KB memory page sizes. Apps with native code or dependencies using native libraries must be 16KB aligned to run on these devices. By elevating this lint check to error severity, we catch alignment issues during the build process rather than at runtime.                                
   

---

### Test
<!--
***(Required)*** List the steps to test the behavior.  For example:
1. Go to...
2. Tap on...
3. See error...
-->

1. Run lint:
    ```
    ./gradlew lintDebug
    ```
2. Verify no `Aligned16KB` errors are reported.
3. (Optional) To verify the lint check catches non-aligned libraries:
    - Temporarily add the [MockK](https://github.com/mockk/mockk) library of version [1.14.2](https://github.com/mockk/mockk/releases/tag/1.14.2) (see patch).
        - FYI: This version includes native libraries compiled before 16KB page alignment was required.
    - Run lint again:
        ```
        ./gradlew lintDebug
        ```
    - Verify lint fails with an `Aligned16KB` error for the [MockK](https://github.com/mockk/mockk) library.

<details>
    <summary>patch</summary>

```diff
Subject: [PATCH] [Analysis] Update `Aligned16KB` Lint Check Severity to Error
---
Index: Simplenote/build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/Simplenote/build.gradle b/Simplenote/build.gradle
--- a/Simplenote/build.gradle	(revision 15bfcaec99076cec736c5c63f938a365fa9f799a)
+++ b/Simplenote/build.gradle	(date 1769526121228)
@@ -101,6 +101,7 @@
     testImplementation "androidx.arch.core:core-testing:2.2.0"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2"
     testImplementation "org.mockito.kotlin:mockito-kotlin:6.0.0"
+    testImplementation "io.mockk:mockk-android:1.14.2"
 
 
     // Support for JsonObjects in unit tests since they are used by BucketObjects
```

</details>

---

### Review
<!--
***(Required)*** Add instructions for reviewers.  For example:
Only one developer and one designer are required to review these changes, but anyone can perform the review.
-->

---

### Release (`N/A`)
<!--
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.txt` was updated in d3adb3ef with:
> Added markdown support
-->
<!--
If the changes should not be included in release notes, add a statement to this section. For example:
These changes do not require release notes.
-->
