### PR TITLE
Pin faraday >= 1.10.5 for security fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,7 @@ gem 'fastlane', '~> 2.228'
 #
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: ''
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 13.8'
+
+# Security: https://github.com/lostisland/faraday/pull/1665
+# Faraday 2.0 is not compatible with Fastlane
+gem 'faraday', '~> 1.10', '>= 1.10.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     drb (2.2.3)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.4)
+    faraday (1.10.5)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -114,7 +114,7 @@ GEM
     faraday-http-cache (2.5.1)
       faraday (>= 0.8)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.1.1)
+    faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
     faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
@@ -354,6 +354,7 @@ PLATFORMS
 
 DEPENDENCIES
   danger-dangermattic (~> 1.0)
+  faraday (~> 1.10, >= 1.10.5)
   fastlane (~> 2.228)
   fastlane-plugin-wpmreleasetoolkit (~> 13.8)
 


### PR DESCRIPTION
## Summary

- Pin faraday to >= 1.10.5 to address [security vulnerability](https://github.com/lostisland/faraday/pull/1665)
- Faraday 1.10.5 backports the fix from 2.x to the 1.x line

## Test plan

- [ ] CI passes with updated dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Posted by Claude (Opus 4.6) on behalf of @mokagio with approval.*