### PR TITLE
Update outdated GitHub Actions

### DIFF
--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   dangermattic:
     if: ${{ (github.event.pull_request.draft == false) }}
-    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1.1.2
+    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1
     with:
       org-slug: "automattic"
       pipeline-slug: "simplenote-android"

--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -11,13 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: Setup Gradle to generate and submit dependency graphs
-        uses: gradle/gradle-build-action@v2
-        with:
-          dependency-graph: generate-and-submit
-      - name: Generate the dependency graph which will be submitted post-job
-        run: ./gradlew :Simplenote:dependencies :Wear:dependencies
+        uses: gradle/actions/dependency-submission@v4

--- a/.github/workflows/validate-issues.yml
+++ b/.github/workflows/validate-issues.yml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   check-labels-on-issues:
-    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@v1.0.0
+    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@v1
     with:
       label-format-list: '[
-        "^\[.+\]",
+        "^\\[.+\\]",
         "^[[:alnum:]]"
       ]'
       label-error-message: '🚫 Please add a type label (e.g. **[Type] Enhancement**) and a feature label (e.g. **Stats**) to this issue.'


### PR DESCRIPTION
Fixes AINFRA-2297

## Summary
- Replace deprecated `gradle/gradle-build-action@v2` with `gradle/actions/dependency-submission@v4`
- Upgrade `actions/setup-java` from v3 to v4
- Update dangermattic reusable workflows to `@v1`
- Fix label regex escaping in validate-issues workflow

## Test plan
- [ ] Verify dependency submission workflow runs successfully on next push to trunk
- [ ] Verify Danger workflow runs on next PR
- [ ] Verify issue label validation workflow works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)