### PR TITLE
CI: standardize Danger step label to :danger:

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,7 +22,7 @@ steps:
       - github_commit_status:
           context: Build and Test
 
-  - label: ":radioactive_sign: Danger - PR Check"
+  - label: ":danger: Danger - PR Check"
     command: danger
     key: danger
     if: "build.pull_request.id != null"


### PR DESCRIPTION
Normalizes the Buildkite icon token for the Danger PR check step from `:radioactive_sign:` to `:danger:`, matching the convention already used across a8c iOS/Android repos (e.g. WordPress-iOS, WordPress-Android). Pure cosmetic change to pipeline metadata; no behavior change.

Part of the Orchard `danger-label` campaign standardizing this label across the organization.
