### PR TITLE
Pin nokogiri >= 1.19.3 (GHSA-c4rq-3m3g-8wgx)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,8 @@ gem 'fastlane-plugin-wpmreleasetoolkit', '~> 13.8'
 # Security: https://github.com/lostisland/faraday/pull/1665
 # Faraday 2.0 is not compatible with Fastlane
 gem 'faraday', '~> 1.10', '>= 1.10.5'
+
+# Pinned to pull in the fix for GHSA-c4rq-3m3g-8wgx (CSS selector ReDoS).
+# Drop once `fastlane-plugin-wpmreleasetoolkit` moves to >= 14.4.1, whose
+# gemspec carries this floor transitively.
+gem 'nokogiri', '>= 1.19.3'

--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,4 @@ gem 'faraday', '~> 1.10', '>= 1.10.5'
 # Pinned to pull in the fix for GHSA-c4rq-3m3g-8wgx (CSS selector ReDoS).
 # Drop once `fastlane-plugin-wpmreleasetoolkit` moves to >= 14.4.1, whose
 # gemspec carries this floor transitively.
-gem 'nokogiri', '>= 1.19.3'
+gem 'nokogiri', '~> 1.19', '>= 1.19.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,7 +259,7 @@ GEM
     nanaimo (0.4.0)
     nap (1.1.0)
     naturally (2.3.0)
-    nokogiri (1.19.1)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (6.1.1)
@@ -359,6 +359,7 @@ DEPENDENCIES
   faraday (~> 1.10, >= 1.10.5)
   fastlane (~> 2.228)
   fastlane-plugin-wpmreleasetoolkit (~> 13.8)
+  nokogiri (>= 1.19.3)
 
 BUNDLED WITH
    2.6.8


### PR DESCRIPTION
## Summary

Adds an explicit `gem 'nokogiri', '>= 1.19.3'` pin to `Gemfile` to pull in the fix for [GHSA-c4rq-3m3g-8wgx](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-c4rq-3m3g-8wgx) — a high-severity ReDoS in Nokogiri's CSS selector tokenizer (vulnerable `< 1.19.3`).

This repo is on `fastlane-plugin-wpmreleasetoolkit ~> 13.8`, which predates the toolkit's own `nokogiri >= 1.19.3` floor (added in 14.4.1). Pinning explicitly here closes the gap without requiring a release-toolkit major bump.

Generated as part of the [nokogiri 1.19.3 Orchard campaign](https://github.a8c.com/mokagio/swiftlint-adoption-orchard-campaign/tree/main/nokogiri-1.19.3-campaign) covering all release-toolkit consumers.

## Testing

`bundle install`. `Gemfile.lock` resolves `nokogiri` to `1.19.3`.

---

*Posted by Claude Code (Opus 4.7) on behalf of @mokagio with approval.*