### PR TITLE
[Tooling] Replace ActiveSupport's String#parameterize with a pure-Ruby helper

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -261,7 +261,7 @@ platform :android do
   def generate_prototype_build_number
     if ENV['BUILDKITE']
       commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
-      branch = parameterize(ENV['BUILDKITE_BRANCH'])
+      branch = parameterize(ENV.fetch('BUILDKITE_BRANCH', nil))
       pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
 
       pr_num == 'false' ? "#{branch}-#{commit}" : "pr#{pr_num}-#{commit}-#{ENV.fetch('BUILDKITE_JOB_ID', nil)}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -250,17 +250,24 @@ platform :android do
     )
   end
 
+  # Mimics the subset of ActiveSupport's `String#parameterize` we rely on.
+  # release-toolkit dropped its `activesupport` runtime dependency in v14.3.1,
+  # so `String#parameterize` is no longer available here.
+  def parameterize(string)
+    string.downcase.gsub(/[^a-z0-9\-_]+/, '-').squeeze('-').gsub(/\A-|-\z/, '')
+  end
+
   # This function is Buildkite-specific
   def generate_prototype_build_number
     if ENV['BUILDKITE']
       commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
-      branch = ENV['BUILDKITE_BRANCH'].parameterize
+      branch = parameterize(ENV['BUILDKITE_BRANCH'])
       pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
 
       pr_num == 'false' ? "#{branch}-#{commit}" : "pr#{pr_num}-#{commit}-#{ENV.fetch('BUILDKITE_JOB_ID', nil)}"
     else
       repo = Git.open(PROJECT_ROOT_FOLDER)
-      commit = repo.current_branch.parameterize
+      commit = parameterize(repo.current_branch)
       branch = repo.revparse('HEAD')[0, 7]
 
       "#{branch}-#{commit}"


### PR DESCRIPTION
### Fix

`release-toolkit` [v14.3.1](https://github.com/wordpress-mobile/release-toolkit/pull/709) dropped its `activesupport` runtime dependency. `generate_prototype_build_number` in our `Fastfile` still calls `String#parameterize`, which will raise `NoMethodError` as soon as we bump `release-toolkit` to `>= 14.3.1` (currently pinned to `~> 13.8`). Proactive fix so the bump doesn't break Prototype Builds — `wordpress-android` already hit this.

Adds a tiny pure-Ruby `parameterize` helper (downcase, replace runs of non-`[a-z0-9_-]` with `-`, squeeze, strip leading/trailing `-`) and routes the two call sites through it. Output matches ActiveSupport's `String#parameterize` for the branch/commit names involved.

### Test

1. `ruby -c fastlane/Fastfile` passes.
2. Prototype Build CI step still produces the expected build number for typical branch names.

### Review

The helper is a drop-in replacement for the two `.parameterize` call sites; behavior is unchanged for the inputs we pass (git branch / ref names).

### Release

Release notes are not needed (CI/tooling only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)