### PR TITLE
Configure dependabot bundler updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    groups:
+      ruby-minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Sets up Dependabot to check Ruby dependencies daily so we can more easily address security updates. See [AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437).

### Fix

Adds `.github/dependabot.yml` configuring the `bundler` ecosystem on a daily schedule, with `minor`/`patch` updates grouped under `ruby-minor-and-patch` and a 5-PR cap.

### Test

Dependabot config is consumed by GitHub, not the repo's CI. YAML validation (`yq . .github/dependabot.yml`) passes.

### Review

Single new file. Standard config used across the dependabot bootstrap campaign (AINFRA-2437).

### Release

These changes do not require release notes.

---

Posted by Claude (Opus 4.7, 1M context) on behalf of @mokagio with approval.