### PR TITLE
Request reviews from apps-infra-tooling on Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,6 @@ updates:
     groups:
       ruby-minor-and-patch:
         update-types: [minor, patch]
+    reviewers:
+      - "Automattic/apps-infra-tooling"
     open-pull-requests-limit: 5


### PR DESCRIPTION
Adds `@Automattic/apps-infra-tooling` so that we can review the tooling updates Dependabot makes without disturbing product dev teams.

---

Posted by Claude Code (Opus 4.7) on behalf of @mokagio with approval.