### PR TITLE
Add explicit `openssl` gem to avoid CI failure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,13 @@ gem 'faraday', '~> 1.10', '>= 1.10.5'
 # Drop once `fastlane-plugin-wpmreleasetoolkit` moves to >= 14.4.1, whose
 # gemspec carries this floor transitively.
 gem 'nokogiri', '~> 1.19'
+
+# To avoid errors like:
+#
+# SSL_connect returned=1 errno=0 peeraddr=3.5.132.155:443 state=error: certificate verify failed (unable to get certificate CRL)
+#
+# See:
+#
+# - https://github.com/ruby/openssl/issues/949
+# - https://linear.app/a8c/issue/AINFRA-2538/upgrade-simplenote-release-tooling-to-at-least-address-ruby-ssl-issue
+gem 'openssl', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,7 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     open4 (1.3.4)
+    openssl (4.0.2)
     options (2.3.2)
     optparse (0.8.1)
     os (1.1.4)
@@ -371,6 +372,7 @@ DEPENDENCIES
   fastlane (~> 2.236)
   fastlane-plugin-wpmreleasetoolkit (~> 13.8)
   nokogiri (~> 1.19)
+  openssl (~> 4.0)
 
 BUNDLED WITH
    2.6.8


### PR DESCRIPTION
See https://linear.app/a8c/issue/AINFRA-2538