### PR TITLE
Fix autocorrect not being applied in the editor on Samsung devices

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.39
 -----
+* Fixed autocorrect not being applied in the editor on Samsung devices [#1840](https://github.com/Automattic/simplenote-android/pull/1840)
 
 2.38
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/widgets/SamsungInputConnection.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/widgets/SamsungInputConnection.kt
@@ -73,6 +73,34 @@ class SamsungInputConnection(
         return baseInputConnection.setComposingText(text, newCursorPosition)
     }
 
+    /**
+     * The protective branch in [commitText] exists only to keep checklist spans ([CheckableSpan]) from being
+     * corrupted when the Samsung keyboard replaces editor content. If the region the keyboard is about to edit
+     * (the composing region, or the current selection if there is none) contains no checklist span, there is
+     * nothing to protect, so we let the keyboard apply its normal autocorrect/suggestion behavior instead of
+     * suppressing it.
+     */
+    private fun editedRegionHasCheckableSpan(): Boolean {
+        val editable = editable
+        var start = getComposingSpanStart(editable)
+        var end = getComposingSpanEnd(editable)
+
+        if (start == -1 || end == -1) {
+            start = Selection.getSelectionStart(editable)
+            end = Selection.getSelectionEnd(editable)
+        }
+
+        if (start < 0) start = 0
+        if (end < 0) end = 0
+        if (end < start) {
+            val tmp = start
+            start = end
+            end = tmp
+        }
+
+        return editable.getSpans(start, end, CheckableSpan::class.java).isNotEmpty()
+    }
+
     override fun commitText(text: CharSequence?, newCursorPosition: Int): Boolean {
         val incomingTextHasSuggestions = text is Spanned &&
                 text.getSpans(0, text.length, SuggestionSpan::class.java).isNotEmpty()
@@ -81,7 +109,11 @@ class SamsungInputConnection(
         // but CheckableSpan spans are finicky, and tend to get messed when content of the editor is replaced.
         // In this method we do everything replaceText method of EditableInputConnection does, apart from actually
         // replacing text. Instead we copy the suggestions from incoming text into editor directly.
-        if (incomingTextHasSuggestions) {
+        //
+        // We only take this path when the edited region actually contains a checklist span; for plain text there
+        // is nothing to protect, so we fall through to the keyboard's normal autocorrect/suggestion handling
+        // instead of swallowing the correction (which previously broke autocorrect on every note).
+        if (incomingTextHasSuggestions && editedRegionHasCheckableSpan()) {
             AppLog.add(
                 AppLog.Type.EDITOR,
                 "Detected spellchecker trying to commit partial text with suggestions"


### PR DESCRIPTION
_Supersedes #1840 — moved from a fork branch to an in-repo branch so Buildkite CI (Build and Test, Lint, Prototype Build) can run._

### Fix

On Samsung devices the note editor installs a custom `SamsungInputConnection` (gated on `manufacturer == samsung && SDK_INT >= 33 && keyboard startsWith com.samsung.android.honeyboard`). Its `commitText()` override swallows **every** spellcheck/autocorrect commit that carries a `SuggestionSpan` — copying the spans onto the existing text instead of letting the keyboard replace it. That workaround was added in early 2023 (ec90ef27, 42ca1bc7) to stop the in-keyboard **Grammarly** component on One UI 5.0 / Android 13 from corrupting checklist (`CheckableSpan`) spans and the cursor.

Video of the issue: 


https://github.com/user-attachments/assets/7ca23f5c-81a8-4d59-b8d3-95daf56e2dc5




The gate has no upper bound, so it still activates on One UI 7/8 (e.g. Galaxy S25, Android 16). There it fires on ordinary prose too, which means **autocorrect-on-space is never applied and typos "stick"** instead of being corrected. Samsung removed the in-keyboard Grammarly plugin in 2024 (One UI 7+ moved spell/grammar to keyboard-agnostic Galaxy AI Writing Assist), so the original trigger no longer exists — but the interception keeps degrading normal typing.

This change scopes the protective path to where it's actually needed: `commitText()` only takes the span-copy branch when the edited region (the composing region, or the selection when there is none) **actually contains a `CheckableSpan`**. Otherwise it forwards to the keyboard's normal commit, restoring standard autocorrect/suggestions. Checklist protection is unchanged where checklists are being edited.

Confirmed on a Galaxy S25 Ultra (SM-S938B, Android 16) via the in-app log (Settings → Send logs): `Detected spellchecker trying to commit partial text with suggestions` fired twice while typing plain prose with **no checkboxes in the note** — i.e. the old code was suppressing autocorrect with nothing to protect.

### Test

Requires a Samsung device on Android 13+ with the Samsung (Honeyboard) keyboard as default. Galaxy S25 / One UI 7-8 reproduces the original bug best.

**Autocorrect now works (the fix):**
1. Open a note **without** any checklist items and tap into the body.
2. Type a misspelling followed by a space, e.g. `teh ` or `recieve `.
3. ✅ It is autocorrected (`the`, `receive`) just like in other apps. (Before this change the typo stayed as typed.)
4. Optional: Settings → Send logs — `Detected spellchecker trying to commit partial text with suggestions` should **not** appear for this plain-text editing.

**Checklist protection still works (no regression):**
1. In a note, insert a checklist and put the cursor on a checklist line.
2. Type a misspelling + space on that line.
3. ✅ The checkbox stays intact (not duplicated, not reverted to `- [ ]` markdown), and the log line **does** appear for that line.
4. Toggle checkboxes and save/reopen the note — content round-trips correctly.

Also worth a quick smoke test on a non-Samsung device (or Samsung + Gboard) to confirm unchanged behavior — those configs never use `SamsungInputConnection`.

### Review

One developer review is sufficient. The change is isolated to `SamsungInputConnection.commitText()` plus a new private helper `editedRegionHasCheckableSpan()`. Key thing to sanity-check: the region used for the `CheckableSpan` lookup (composing region, falling back to selection, clamped/normalized) matches the region the framework would replace. On-device verification on a modern Samsung phone is the real proof, since this is IME-timing-sensitive code that can't be fully covered by unit tests.

### Release

`RELEASE-NOTES.txt` was updated with:
> Fixed autocorrect not being applied in the editor on Samsung devices

(Added to the top `2.38` section to follow the existing convention — feel free to move it to the appropriate in-development version section if 2.38 is already cut.)
