### PR TITLE
Unlock all styles now that Sustainer is discontinued

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.39
 -----
+* Unlocked all styles, including the pure-black AMOLED style, for everyone now that Simplenote Sustainer is discontinued [#1771](https://github.com/Automattic/simplenote-android/issues/1771) [#1661](https://github.com/Automattic/simplenote-android/issues/1661)
 
 2.38
 -----

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/PrefUtils.java
@@ -168,7 +168,7 @@ public class PrefUtils {
     }
 
     public static boolean isPremium(Context context) {
-        return getPrefs(context).getBoolean(PREF_PREMIUM, false);
+        return getPrefs(context).getBoolean(PREF_PREMIUM, true);
     }
 
     public static void setIsPremium(Context context, boolean isPremium) {

--- a/Simplenote/src/main/res/xml/preferences.xml
+++ b/Simplenote/src/main/res/xml/preferences.xml
@@ -54,7 +54,7 @@
             android:key="pref_key_style"
             android:summary="%s"
             android:title="@string/style"
-            app:isPreferenceVisible="false"
+            app:isPreferenceVisible="true"
             tools:summary="@string/style_classic">
         </Preference>
 


### PR DESCRIPTION
### Fix
Simplenote Sustainer has been discontinued, and `pref_key_premium` is never written anywhere in the codebase's history, so `isPremium()` was always `false` — leaving every style except **Default** permanently locked and the Style row hidden in Settings, even though a pure-black AMOLED style (**Black**) already exists.

Per review feedback, this is the minimal change:
- `PrefUtils.isPremium` now defaults to `true` (no device ever stored a value, so this unlocks everyone).
- The `pref_key_style` row in `preferences.xml` is visible again (`app:isPreferenceVisible="true"`).

Fixes #1771
Fixes #1661

### Test
1. Go to **Settings** — the **Style** row is visible under Appearance.
2. Open it and verify no styles show a lock icon and each can be selected.
3. Select **Black** and enable dark mode — backgrounds are pure black (AMOLED).
4. Add the note widget and note list widget in dark mode with the Black style selected — widgets use the black layouts.

### Review
Anyone can review. Note: with `isPremium()` defaulting to true, the (still hidden) membership row would show "premium" if ever un-hidden.

### Release
`RELEASE-NOTES.txt` was updated in 6e28103c with:
> Unlocked all styles, including the pure-black AMOLED style, for everyone now that Simplenote Sustainer is discontinued