### PR TITLE
Prioritise release jobs ahead of feature builds

### DIFF
--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -6,6 +6,8 @@
 agents:
     queue: mac-metal
 
+priority: 1
+
 steps:
   - label: Complete Code Freeze
     key: complete_code_freeze

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
+priority: 1
+
 steps:
   - label: Finalize Release
     plugins: [$CI_TOOLKIT_PLUGIN]

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
+priority: 1
+
 steps:
   - label: "New Beta Release"
     plugins: [$CI_TOOLKIT_PLUGIN]

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
+priority: 1
+
 steps:
   - label: Publish Release
     plugins: [$CI_TOOLKIT_PLUGIN]

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -3,6 +3,8 @@
 
 # Variables used in this pipeline are defined in `shared-pipeline-vars`, which is `source`'d before calling `buildkite-agent pipeline upload`
 
+priority: 1
+
 steps:
   - label: Start Code Freeze
     plugins:


### PR DESCRIPTION
Adds `priority: 1` to the release pipelines so release jobs jump the queue ahead of feature builds, and the release train stalls less.

Closes [AINFRA-3046](https://linear.app/a8c/issue/AINFRA-3046).

<details>
<summary>AI-generated details.</summary>

## Description

The Releases V2 tasks run on the same pipeline and queue as every PR build, so a release manager waits behind queued feature work. The release build files already had `priority`; `release-pipelines/*` never did.

Set pipeline-wide rather than per step so that steps added later inherit it.

Part of [AINFRA-3038](https://linear.app/a8c/issue/AINFRA-3038); audit in [AINFRA-3032](https://linear.app/a8c/issue/AINFRA-3032).

## Testing instructions

CI here does not exercise these files — the upload step only uploads `pipeline.yml`. Locally, all 5 parse and every step resolves to priority `1`.

Real confirmation is the next release: the job should show **Priority** `1` in Buildkite, against `0` for a PR build.

</details>
